### PR TITLE
Erd Rework

### DIFF
--- a/src/erd.zig
+++ b/src/erd.zig
@@ -21,8 +21,11 @@ owner: ErdOwner,
 subs: comptime_int,
 /// The relative index of the ERD in its data component
 data_component_idx: comptime_int = undefined,
-/// The relative index of the ERD in the aggregate system data
-system_data_idx: comptime_int = undefined,
+/// The relative index of the ERD in the aggregate system data.
+/// This field is sufficient for runtime ERD read/write/subscriptions.
+/// Performance is negatively affected due to constant-time lookups of `owner` and `data_component_idx`
+/// however this allows for enforcing a small code footprint
+system_data_idx: u16 = undefined,
 
 /// ERD identifier, allows for ERDs to be referenced externally
 pub const ErdHandle = u16; // TODO: Evaluate if this should be an inexhaustive enum `ErdHandle = enum { _ };`

--- a/src/ram_data_component.zig
+++ b/src/ram_data_component.zig
@@ -8,58 +8,112 @@ const SystemErds = @import("system_erds.zig");
 
 const RamDataComponent = @This();
 
-const StoreStruct = blk: {
-    var fields: [num_ram_erds]std.builtin.Type.StructField = undefined;
-    for (SystemErds.ram_definitions, 0..) |erd, i| {
-        // Fields have the name of "_number"
-        const fieldName = std.fmt.comptimePrint("_{}", .{erd.data_component_idx});
-        fields[i] = .{
-            .name = fieldName,
-            .type = erd.T,
-            .default_value_ptr = null,
-            .is_comptime = false,
-            // Proper alignment is the default. If you want denser memory
-            // then set alignment to 1.
-            .alignment = 0,
-        };
-    }
-
-    const ram_data_struct = @Type(.{
-        .@"struct" = .{
-            .layout = .auto,
-            .fields = fields[0..],
-            .decls = &[_]std.builtin.Type.Declaration{},
-            .is_tuple = false,
-        },
-    });
-
-    break :blk ram_data_struct;
-};
-
-/// Internal Storage using a comptime defined struct
-storage: StoreStruct = undefined,
+// TODO: Add a flag that reorders fields to efficiently pack this
+// and another that guarantees alignment for faster R/W.
+storage: [store_size()]u8 align(@alignOf(usize)) = undefined,
 
 pub fn init() RamDataComponent {
     var ram_data_component = RamDataComponent{};
-    ram_data_component.storage = std.mem.zeroInit(@TypeOf(ram_data_component.storage), .{});
+    @memset(ram_data_component.storage[0..], 0);
     return ram_data_component;
 }
 
 const num_ram_erds = SystemErds.ram_definitions.len;
+const ram_offsets = blk: {
+    var _ram_offsets: [num_ram_erds]usize = undefined;
+    var cur_offset = 0;
+    for (SystemErds.ram_definitions, 0..) |erd, i| {
+        _ram_offsets[i] = cur_offset;
+        cur_offset += @sizeOf(erd.T);
+    }
+
+    break :blk _ram_offsets;
+};
+const data_size: [num_ram_erds]u16 = blk: {
+    var _data_size: [num_ram_erds]u16 = undefined;
+
+    for (SystemErds.ram_definitions, 0..) |erd, i| {
+        _data_size[i] = @sizeOf(erd.T);
+    }
+
+    break :blk _data_size;
+};
+
+fn store_size() usize {
+    var size: usize = 0;
+    for (SystemErds.ram_definitions) |erd| {
+        size += @sizeOf(erd.T);
+    }
+    return size;
+}
 
 pub fn read(self: RamDataComponent, erd: Erd) erd.T {
-    const fieldName = std.fmt.comptimePrint("_{}", .{erd.data_component_idx});
+    const idx = erd.data_component_idx;
 
-    return @field(self.storage, fieldName);
+    var value: erd.T = undefined;
+    @memcpy(std.mem.asBytes(&value), self.storage[ram_offsets[idx] .. ram_offsets[idx] + @sizeOf(erd.T)]);
+    return value;
+}
+
+pub fn runtime_read(self: RamDataComponent, data_component_idx: u16, data: *anyopaque) void {
+    var data_slice: [*]u8 = @ptrCast(data);
+    const size = data_size[data_component_idx];
+
+    @memcpy(data_slice[0..size], self.storage[ram_offsets[data_component_idx] .. ram_offsets[data_component_idx] + size]);
 }
 
 pub fn write(self: *RamDataComponent, erd: Erd, data: erd.T) bool {
-    const fieldName = std.fmt.comptimePrint("_{}", .{erd.data_component_idx});
+    const idx = erd.data_component_idx;
 
-    const current: erd.T = @field(self.storage, fieldName);
-    // TODO: Watch this closely, it might lead to a fair bit of code bloat
-    const data_changed = !std.meta.eql(current, data);
-    @field(self.storage, fieldName) = data;
+    const data_bytes = std.mem.toBytes(data);
+
+    const data_changed = !std.mem.eql(u8, &data_bytes, self.storage[ram_offsets[idx] .. ram_offsets[idx] + @sizeOf(erd.T)]);
+    self.storage[ram_offsets[idx] .. ram_offsets[idx] + @sizeOf(erd.T)].* = data_bytes;
 
     return data_changed;
 }
+
+pub fn runtime_write(self: *RamDataComponent, data_component_idx: u16, data: *const anyopaque) bool {
+    const idx = data_component_idx;
+
+    var data_slice: [*]const u8 = @ptrCast(data);
+    const size = data_size[data_component_idx];
+
+    const data_changed = !std.mem.eql(u8, data_slice[0..size], self.storage[ram_offsets[idx] .. ram_offsets[idx] + size]);
+
+    @memcpy(self.storage[ram_offsets[idx] .. ram_offsets[idx] + size], data_slice[0..size]);
+
+    return data_changed;
+}
+
+// TODO: This is a neat way of gaining automatic optimized alignment, but MAN
+//       it sucks for actually accessing fields, particularly using runtime info
+//       see if it can eventually be used?
+// const ram_fields: [num_ram_erds]std.builtin.Type.StructField = blk: {
+//     var _fields: [num_ram_erds]std.builtin.Type.StructField = undefined;
+//
+//     for (SystemErds.ram_definitions, 0..) |erd, i| {
+//         // Fields have the name of "_number"
+//         const fieldName = std.fmt.comptimePrint("_{}", .{erd.data_component_idx});
+//         _fields[i] = .{
+//             .name = fieldName,
+//             .type = erd.T,
+//             .default_value_ptr = null,
+//             .is_comptime = false,
+//             // Proper alignment is the default. If you want denser memory
+//             // then set alignment to 1.
+//             .alignment = 0,
+//         };
+//     }
+//
+//     break :blk _fields;
+// };
+//
+// const StoreStruct = @Type(.{
+//     .@"struct" = .{
+//         .layout = .auto,
+//         .fields = ram_fields[0..],
+//         .decls = &[_]std.builtin.Type.Declaration{},
+//         .is_tuple = false,
+//     },
+// });

--- a/src/system_data.zig
+++ b/src/system_data.zig
@@ -66,12 +66,15 @@ const subscription_count = system_erds_collect(u8, "subs");
 const owner_from_idx = system_erds_collect(Erd.ErdOwner, "owner");
 const data_component_idx_from_idx = system_erds_collect(u16, "data_component_idx");
 
-fn always_42() u16 {
-    return 42;
+fn always_42(data: *u16) void {
+    data.* = 42;
 }
 
-fn plus_one() u16 {
-    return always_42() + 1;
+fn plus_one(data: *u16) void {
+    var should_be_42: u16 = undefined;
+    always_42(&should_be_42);
+
+    data.* = should_be_42 + 1;
 }
 
 const indirectErdMapping = [_]IndirectDataComponent.IndirectErdMapping{

--- a/src/system_erds.zig
+++ b/src/system_erds.zig
@@ -8,11 +8,6 @@ const Erd = @import("erd.zig");
 //     runtime_erd,
 // };
 
-// const ErdRequest = union(ErdRequestType) {
-//     comptime_erd: ComptimeErdHandle,
-//     runtime_erd: RuntimeErdHandle,
-// };
-
 // TODO: Depending on the .owner, extra data may be required. For .Indirect this is externalized
 //       as IndirectDataComponent.IndirectErdMapping which requires extra validation
 //       and might pessimize optimization.

--- a/src/tests/indirect_data_component_test.zig
+++ b/src/tests/indirect_data_component_test.zig
@@ -3,12 +3,15 @@ const IndirectDataComponent = @import("../indirect_data_component.zig");
 const IndirectErdMapping = IndirectDataComponent.IndirectErdMapping;
 const SystemErds = @import("../system_erds.zig");
 
-fn always_42() u16 {
-    return 42;
+fn always_42(data: *u16) void {
+    data.* = 42;
 }
 
-fn plus_one() u16 {
-    return always_42() + 1;
+fn plus_one(data: *u16) void {
+    var should_be_42: u16 = undefined;
+    always_42(&should_be_42);
+
+    data.* = should_be_42 + 1;
 }
 
 test "indirect data component read" {
@@ -30,5 +33,33 @@ test "indirect data component write" {
     //     .{ .erd = SystemErds.erd.another_erd_plus_one, .fn_ptr = &plus_one },
     // });
 
-    // indirect_data.write(SystemErds.erd.always_42, 41);
+    // _ = indirect_data.write(SystemErds.erd.always_42, 41);
+}
+
+test "indirect data component runtime read" {
+    var indirect_data = IndirectDataComponent.init([_]IndirectErdMapping{
+        IndirectErdMapping.map(SystemErds.erd.always_42, always_42),
+        IndirectErdMapping.map(SystemErds.erd.another_erd_plus_one, plus_one),
+    });
+
+    var should_be_42: u16 = undefined;
+    var should_be_43: u16 = undefined;
+
+    indirect_data.runtime_read(SystemErds.erd.always_42.data_component_idx, &should_be_42);
+    indirect_data.runtime_read(SystemErds.erd.another_erd_plus_one.data_component_idx, &should_be_43);
+
+    try std.testing.expectEqual(42, should_be_42);
+    try std.testing.expectEqual(42 + 1, should_be_43);
+}
+
+test "indirect data component runtime write" {
+    // return error.SkipZigTest;
+    // TODO: Re-enable this test once you can test for compile error
+
+    // var indirect_data = IndirectDataComponent.init([_]IndirectErdMapping{
+    //     .{ .erd = SystemErds.erd.always_42, .fn_ptr = &always_42 },
+    //     .{ .erd = SystemErds.erd.another_erd_plus_one, .fn_ptr = &plus_one },
+    // });
+
+    // _ = indirect_data.runtime_write(SystemErds.erd.always_42.data_component_idx, &41);
 }

--- a/src/tests/ram_data_component_test.zig
+++ b/src/tests/ram_data_component_test.zig
@@ -64,3 +64,31 @@ test "failure upon writing incorrect types" {
     // var ram_data = RamDataComponent.init();
     // std.testing.expectError(, ram_data.write(SystemErds.erd.some_bool, 20));
 }
+
+test "runtime reads" {
+    var ram_data = RamDataComponent.init();
+
+    _ = ram_data.write(SystemErds.erd.some_bool, true);
+
+    var bool_val: bool = undefined;
+    ram_data.runtime_read(SystemErds.erd.some_bool.data_component_idx, &bool_val);
+
+    try std.testing.expectEqual(true, bool_val);
+}
+
+test "runtime writes" {
+    var ram_data = RamDataComponent.init();
+
+    const very_true = true;
+    var changed = ram_data.runtime_write(SystemErds.erd.some_bool.data_component_idx, &very_true);
+    try std.testing.expect(changed);
+
+    const bool_val = ram_data.read(SystemErds.erd.some_bool);
+    try std.testing.expectEqual(true, bool_val);
+
+    changed = ram_data.write(SystemErds.erd.some_bool, true);
+    try std.testing.expect(!changed);
+
+    changed = ram_data.write(SystemErds.erd.some_bool, false);
+    try std.testing.expect(changed);
+}

--- a/src/tests/system_data_test.zig
+++ b/src/tests/system_data_test.zig
@@ -13,6 +13,22 @@ test "ram data component read and write" {
     try std.testing.expectEqual(new_application_version, system_data.read(SystemErds.erd.application_version));
 }
 
+test "runtime read/write matches data components" {
+    var system_data = SystemData.init();
+    var ver: u32 = undefined;
+    system_data.runtime_read(SystemErds.erd.application_version.system_data_idx, &ver);
+    try std.testing.expectEqual(0, ver);
+
+    system_data.write(SystemErds.erd.application_version, 1234);
+    system_data.runtime_read(SystemErds.erd.application_version.system_data_idx, &ver);
+    try std.testing.expectEqual(1234, ver);
+
+    var should_be_42: u16 = undefined;
+    system_data.runtime_read(SystemErds.erd.always_42.system_data_idx, &should_be_42);
+    system_data.runtime_read(SystemErds.erd.always_42.system_data_idx, &ver);
+    try std.testing.expectEqual(42, should_be_42);
+}
+
 test "indirect data component read and a note on reads" {
     var system_data = SystemData.init();
     try std.testing.expectEqual(42, system_data.read(SystemErds.erd.always_42));


### PR DESCRIPTION
Adds the ERD read/write functions which *only* use runtime information. In contrast to those that use comptime info, runtime info only functions:
- Read/write to data pointers passed as parameters
- Don't return by value
- Aren't as deeply optimized (a comptime function may boil down to a single instruction in some cases)

In order to accommodate these changes, this PR also reverts ram data component to use an array store with pre-computed offsets. The store struct was too magical for runtime reads, namely the required `num => string => struct offset` isn't possible in a way that's not wasteful. Namely, I doubt the ability for the strings to be successfully optimized away to create a `num => struct offset` table. So that method is commented out. Additionally, indirect data component functions now take in a pointer to fill. 