### PR TITLE
Decl literal API for Comptime-known ERD read/write/subscribe/unsubscribe

### DIFF
--- a/src/common/erd_logic.zig
+++ b/src/common/erd_logic.zig
@@ -33,10 +33,10 @@ const ErdLogicOperator = enum {
     _bitwise_xor,
 };
 
-pub fn ErdLogic(operator: ErdLogicOperator, erd1: Erd, erd2: Erd, outputErd: Erd) type {
+pub fn ErdLogic(operator: ErdLogicOperator, erd1: SystemErds.ErdEnum, erd2: SystemErds.ErdEnum, outputErd: SystemErds.ErdEnum) type {
     comptime {
-        std.debug.assert(erd1.T == erd2.T);
-        std.debug.assert(erd2.T == outputErd.T);
+        std.debug.assert(SystemErds.erd_from_enum(erd1).T == SystemErds.erd_from_enum(erd2).T);
+        std.debug.assert(SystemErds.erd_from_enum(erd2).T == SystemErds.erd_from_enum(outputErd).T);
     }
 
     return struct {
@@ -69,28 +69,26 @@ pub fn ErdLogic(operator: ErdLogicOperator, erd1: Erd, erd2: Erd, outputErd: Erd
 
 test "can _bitwise_and" {
     var system_data: SystemData = .init();
+    ErdLogic(._bitwise_and, .erd_unaligned_u16, .erd_cool_u16, .erd_best_u16).init(&system_data);
 
-    // This is a very peculiar interface... if `SystemErds.erd` were removed this could be extremely concise
-    ErdLogic(._bitwise_and, SystemErds.erd.unaligned_u16, SystemErds.erd.cool_u16, SystemErds.erd.best_u16).init(&system_data);
-
-    try std.testing.expectEqual(0, system_data.read(SystemErds.erd.best_u16));
+    try std.testing.expectEqual(0, system_data.read(.erd_best_u16));
     // Can't do anything about this without an extra subscription
     // it's up to the programmer to not write to "output" ERDs:
-    system_data.write(SystemErds.erd.best_u16, 1337);
-    try std.testing.expectEqual(1337, system_data.read(SystemErds.erd.best_u16));
+    system_data.write(.erd_best_u16, 1337);
+    try std.testing.expectEqual(1337, system_data.read(.erd_best_u16));
 
-    system_data.write(SystemErds.erd.unaligned_u16, 0b01010101);
-    system_data.write(SystemErds.erd.cool_u16, 0b10101010);
-    try std.testing.expectEqual(0, system_data.read(SystemErds.erd.best_u16));
+    system_data.write(.erd_unaligned_u16, 0b01010101);
+    system_data.write(.erd_cool_u16, 0b10101010);
+    try std.testing.expectEqual(0, system_data.read(.erd_best_u16));
 
-    system_data.write(SystemErds.erd.unaligned_u16, 0b00001010);
-    try std.testing.expectEqual(0b1010, system_data.read(SystemErds.erd.best_u16));
+    system_data.write(.erd_unaligned_u16, 0b00001010);
+    try std.testing.expectEqual(0b1010, system_data.read(.erd_best_u16));
 
-    system_data.write(SystemErds.erd.unaligned_u16, 0b10100000);
-    try std.testing.expectEqual(0b10100000, system_data.read(SystemErds.erd.best_u16));
+    system_data.write(.erd_unaligned_u16, 0b10100000);
+    try std.testing.expectEqual(0b10100000, system_data.read(.erd_best_u16));
 
-    system_data.write(SystemErds.erd.unaligned_u16, 0xFF);
-    try std.testing.expectEqual(system_data.read(SystemErds.erd.cool_u16), system_data.read(SystemErds.erd.best_u16));
+    system_data.write(.erd_unaligned_u16, 0xFF);
+    try std.testing.expectEqual(system_data.read(.erd_cool_u16), system_data.read(.erd_best_u16));
 }
 
 // TODO: Finish the rest of the tests when there's a way to create testing (locally scoped) ERDs

--- a/src/indirect_data_component.zig
+++ b/src/indirect_data_component.zig
@@ -17,7 +17,8 @@ pub const IndirectErdMapping = struct {
     fn_ptr: *const anyopaque,
 
     /// Compile-time guarantees a valid mapping
-    pub fn map(erd: Erd, func: *const fn (*erd.T) void) IndirectErdMapping {
+    pub fn map(comptime erd_enum: SystemErds.ErdEnum, func: *const fn (*SystemErds.erd_from_enum(erd_enum).T) void) IndirectErdMapping {
+        const erd: Erd = SystemErds.erd_from_enum(erd_enum);
         return .{ .erd = erd, .fn_ptr = func };
     }
 };

--- a/src/system_data.zig
+++ b/src/system_data.zig
@@ -78,8 +78,8 @@ fn plus_one(data: *u16) void {
 }
 
 const indirectErdMapping = [_]IndirectDataComponent.IndirectErdMapping{
-    .map(SystemErds.erd.erd_always_42, always_42),
-    .map(SystemErds.erd.erd_another_erd_plus_one, plus_one),
+    .map(.erd_always_42, always_42),
+    .map(.erd_another_erd_plus_one, plus_one),
 };
 
 pub fn init() SystemData {

--- a/src/tests/erd_json_test.zig
+++ b/src/tests/erd_json_test.zig
@@ -13,42 +13,42 @@ test "Correct ERD JSON Generation" {
         \\    "namespace": "zig-embedded-starter-kit",
         \\    "erds": [
         \\        {
-        \\            "name": "application_version",
+        \\            "name": "erd_application_version",
         \\            "id": "0x0000",
         \\            "type": "u32"
         \\        },
         \\        {
-        \\            "name": "some_bool",
+        \\            "name": "erd_some_bool",
         \\            "id": "0x0001",
         \\            "type": "bool"
         \\        },
         \\        {
-        \\            "name": "unaligned_u16",
+        \\            "name": "erd_unaligned_u16",
         \\            "id": "0x0002",
         \\            "type": "u16"
         \\        },
         \\        {
-        \\            "name": "well_packed",
+        \\            "name": "erd_well_packed",
         \\            "id": "0x0003",
         \\            "type": "system_erds.WellPackedStruct"
         \\        },
         \\        {
-        \\            "name": "padded",
+        \\            "name": "erd_padded",
         \\            "id": "0x0004",
         \\            "type": "system_erds.PaddedStruct"
         \\        },
         \\        {
-        \\            "name": "actually_packed_fr",
+        \\            "name": "erd_actually_packed_fr",
         \\            "id": "0x0005",
         \\            "type": "system_erds.PackedFr"
         \\        },
         \\        {
-        \\            "name": "always_42",
+        \\            "name": "erd_always_42",
         \\            "id": "0x0006",
         \\            "type": "u16"
         \\        },
         \\        {
-        \\            "name": "another_erd_plus_one",
+        \\            "name": "erd_another_erd_plus_one",
         \\            "id": "0x0008",
         \\            "type": "u16"
         \\        }

--- a/src/tests/indirect_data_component_test.zig
+++ b/src/tests/indirect_data_component_test.zig
@@ -3,25 +3,25 @@ const IndirectDataComponent = @import("../indirect_data_component.zig");
 const IndirectErdMapping = IndirectDataComponent.IndirectErdMapping;
 const SystemErds = @import("../system_erds.zig");
 
-fn always_42(data: *u16) void {
+fn erd_always_42(data: *u16) void {
     data.* = 42;
 }
 
 fn plus_one(data: *u16) void {
     var should_be_42: u16 = undefined;
-    always_42(&should_be_42);
+    erd_always_42(&should_be_42);
 
     data.* = should_be_42 + 1;
 }
 
 test "indirect data component read" {
     var indirect_data = IndirectDataComponent.init([_]IndirectErdMapping{
-        IndirectErdMapping.map(SystemErds.erd.always_42, always_42),
-        IndirectErdMapping.map(SystemErds.erd.another_erd_plus_one, plus_one),
+        IndirectErdMapping.map(SystemErds.erd.erd_always_42, erd_always_42),
+        IndirectErdMapping.map(SystemErds.erd.erd_another_erd_plus_one, plus_one),
     });
 
-    try std.testing.expectEqual(42, indirect_data.read(SystemErds.erd.always_42));
-    try std.testing.expectEqual(42 + 1, indirect_data.read(SystemErds.erd.another_erd_plus_one));
+    try std.testing.expectEqual(42, indirect_data.read(SystemErds.erd.erd_always_42));
+    try std.testing.expectEqual(42 + 1, indirect_data.read(SystemErds.erd.erd_another_erd_plus_one));
 }
 
 test "indirect data component write" {
@@ -29,24 +29,24 @@ test "indirect data component write" {
     // TODO: Re-enable this test once you can test for compile error
 
     // var indirect_data = IndirectDataComponent.init([_]IndirectErdMapping{
-    //     .{ .erd = SystemErds.erd.always_42, .fn_ptr = &always_42 },
-    //     .{ .erd = SystemErds.erd.another_erd_plus_one, .fn_ptr = &plus_one },
+    //     .{ .erd = SystemErds.erd.erd_always_42, .fn_ptr = &erd_always_42 },
+    //     .{ .erd = SystemErds.erd.erd_another_erd_plus_one, .fn_ptr = &plus_one },
     // });
 
-    // _ = indirect_data.write(SystemErds.erd.always_42, 41);
+    // _ = indirect_data.write(SystemErds.erd.erd_always_42, 41);
 }
 
 test "indirect data component runtime read" {
     var indirect_data = IndirectDataComponent.init([_]IndirectErdMapping{
-        IndirectErdMapping.map(SystemErds.erd.always_42, always_42),
-        IndirectErdMapping.map(SystemErds.erd.another_erd_plus_one, plus_one),
+        IndirectErdMapping.map(SystemErds.erd.erd_always_42, erd_always_42),
+        IndirectErdMapping.map(SystemErds.erd.erd_another_erd_plus_one, plus_one),
     });
 
     var should_be_42: u16 = undefined;
     var should_be_43: u16 = undefined;
 
-    indirect_data.runtime_read(SystemErds.erd.always_42.data_component_idx, &should_be_42);
-    indirect_data.runtime_read(SystemErds.erd.another_erd_plus_one.data_component_idx, &should_be_43);
+    indirect_data.runtime_read(SystemErds.erd.erd_always_42.data_component_idx, &should_be_42);
+    indirect_data.runtime_read(SystemErds.erd.erd_another_erd_plus_one.data_component_idx, &should_be_43);
 
     try std.testing.expectEqual(42, should_be_42);
     try std.testing.expectEqual(42 + 1, should_be_43);
@@ -57,9 +57,9 @@ test "indirect data component runtime write" {
     // TODO: Re-enable this test once you can test for compile error
 
     // var indirect_data = IndirectDataComponent.init([_]IndirectErdMapping{
-    //     .{ .erd = SystemErds.erd.always_42, .fn_ptr = &always_42 },
-    //     .{ .erd = SystemErds.erd.another_erd_plus_one, .fn_ptr = &plus_one },
+    //     .{ .erd = SystemErds.erd.erd_always_42, .fn_ptr = &erd_always_42 },
+    //     .{ .erd = SystemErds.erd.erd_another_erd_plus_one, .fn_ptr = &plus_one },
     // });
 
-    // _ = indirect_data.runtime_write(SystemErds.erd.always_42.data_component_idx, &41);
+    // _ = indirect_data.runtime_write(SystemErds.erd.erd_always_42.data_component_idx, &41);
 }

--- a/src/tests/indirect_data_component_test.zig
+++ b/src/tests/indirect_data_component_test.zig
@@ -16,8 +16,8 @@ fn plus_one(data: *u16) void {
 
 test "indirect data component read" {
     var indirect_data = IndirectDataComponent.init([_]IndirectErdMapping{
-        IndirectErdMapping.map(SystemErds.erd.erd_always_42, erd_always_42),
-        IndirectErdMapping.map(SystemErds.erd.erd_another_erd_plus_one, plus_one),
+        .map(.erd_always_42, erd_always_42),
+        .map(.erd_another_erd_plus_one, plus_one),
     });
 
     try std.testing.expectEqual(42, indirect_data.read(SystemErds.erd.erd_always_42));
@@ -29,8 +29,8 @@ test "indirect data component write" {
     // TODO: Re-enable this test once you can test for compile error
 
     // var indirect_data = IndirectDataComponent.init([_]IndirectErdMapping{
-    //     .{ .erd = SystemErds.erd.erd_always_42, .fn_ptr = &erd_always_42 },
-    //     .{ .erd = SystemErds.erd.erd_another_erd_plus_one, .fn_ptr = &plus_one },
+    //     .map(.erd_always_42, erd_always_42),
+    //     .map(.erd_another_erd_plus_one, plus_one),
     // });
 
     // _ = indirect_data.write(SystemErds.erd.erd_always_42, 41);
@@ -38,8 +38,8 @@ test "indirect data component write" {
 
 test "indirect data component runtime read" {
     var indirect_data = IndirectDataComponent.init([_]IndirectErdMapping{
-        IndirectErdMapping.map(SystemErds.erd.erd_always_42, erd_always_42),
-        IndirectErdMapping.map(SystemErds.erd.erd_another_erd_plus_one, plus_one),
+        .map(.erd_always_42, erd_always_42),
+        .map(.erd_another_erd_plus_one, plus_one),
     });
 
     var should_be_42: u16 = undefined;
@@ -57,8 +57,8 @@ test "indirect data component runtime write" {
     // TODO: Re-enable this test once you can test for compile error
 
     // var indirect_data = IndirectDataComponent.init([_]IndirectErdMapping{
-    //     .{ .erd = SystemErds.erd.erd_always_42, .fn_ptr = &erd_always_42 },
-    //     .{ .erd = SystemErds.erd.erd_another_erd_plus_one, .fn_ptr = &plus_one },
+    //     .map(.erd_always_42, erd_always_42),
+    //     .map(.erd_another_erd_plus_one, plus_one),
     // });
 
     // _ = indirect_data.runtime_write(SystemErds.erd.erd_always_42.data_component_idx, &41);

--- a/src/tests/ram_data_component_test.zig
+++ b/src/tests/ram_data_component_test.zig
@@ -5,56 +5,56 @@ const SystemErds = @import("../system_erds.zig");
 test "ram data component read and write" {
     var ram_data = RamDataComponent.init();
     // Should zero init
-    try std.testing.expectEqual(0, ram_data.read(SystemErds.erd.application_version));
-    try std.testing.expectEqual(false, ram_data.write(SystemErds.erd.application_version, 0));
+    try std.testing.expectEqual(0, ram_data.read(SystemErds.erd.erd_application_version));
+    try std.testing.expectEqual(false, ram_data.write(SystemErds.erd.erd_application_version, 0));
 
     const new_application_version: u32 = 0x12345678;
-    try std.testing.expectEqual(true, ram_data.write(SystemErds.erd.application_version, new_application_version));
-    try std.testing.expectEqual(new_application_version, ram_data.read(SystemErds.erd.application_version));
+    try std.testing.expectEqual(true, ram_data.write(SystemErds.erd.erd_application_version, new_application_version));
+    try std.testing.expectEqual(new_application_version, ram_data.read(SystemErds.erd.erd_application_version));
 }
 
 test "unaligned read and write" {
     var ram_data = RamDataComponent.init();
-    _ = ram_data.write(SystemErds.erd.unaligned_u16, 0x1234);
-    try std.testing.expectEqual(0x1234, ram_data.read(SystemErds.erd.unaligned_u16));
+    _ = ram_data.write(SystemErds.erd.erd_unaligned_u16, 0x1234);
+    try std.testing.expectEqual(0x1234, ram_data.read(SystemErds.erd.erd_unaligned_u16));
 
-    try std.testing.expectEqual(0, ram_data.read(SystemErds.erd.application_version));
-    try std.testing.expectEqual(false, ram_data.read(SystemErds.erd.some_bool));
+    try std.testing.expectEqual(0, ram_data.read(SystemErds.erd.erd_application_version));
+    try std.testing.expectEqual(false, ram_data.read(SystemErds.erd.erd_some_bool));
 }
 
 test "read and write of type where @bitSizeOf is not multiple of 8" {
     var ram_data = RamDataComponent.init();
-    try std.testing.expectEqual(false, ram_data.read(SystemErds.erd.some_bool));
+    try std.testing.expectEqual(false, ram_data.read(SystemErds.erd.erd_some_bool));
 
-    _ = ram_data.write(SystemErds.erd.some_bool, true);
-    try std.testing.expectEqual(true, ram_data.read(SystemErds.erd.some_bool));
+    _ = ram_data.write(SystemErds.erd.erd_some_bool, true);
+    try std.testing.expectEqual(true, ram_data.read(SystemErds.erd.erd_some_bool));
 }
 
 test "pointers read/write" {
     var ram_data = RamDataComponent.init();
-    try std.testing.expectEqual(null, ram_data.read(SystemErds.erd.pointer_to_something));
+    try std.testing.expectEqual(null, ram_data.read(SystemErds.erd.erd_pointer_to_something));
 
     var temp: u16 = 2;
-    _ = ram_data.write(SystemErds.erd.pointer_to_something, &temp);
-    try std.testing.expectEqual(2, ram_data.read(SystemErds.erd.pointer_to_something).?.*);
+    _ = ram_data.write(SystemErds.erd.erd_pointer_to_something, &temp);
+    try std.testing.expectEqual(2, ram_data.read(SystemErds.erd.erd_pointer_to_something).?.*);
 }
 
 test "structs" {
     var ram_data = RamDataComponent.init();
-    const st = ram_data.read(SystemErds.erd.well_packed);
+    const st = ram_data.read(SystemErds.erd.erd_well_packed);
     try std.testing.expectEqual(@as(@TypeOf(st), .{ .a = 0, .b = 0, .c = 0 }), st);
 
-    const packed_st = ram_data.read(SystemErds.erd.actually_packed_fr);
+    const packed_st = ram_data.read(SystemErds.erd.erd_actually_packed_fr);
     try std.testing.expectEqual(std.mem.zeroes(@TypeOf(packed_st)), packed_st);
 
-    _ = ram_data.write(SystemErds.erd.actually_packed_fr, .{ .a = 1, .b = 0, .c = 0, .d = 0, .e = 1, .f = 0, .g = 1 });
-    const packed_st_with_data = ram_data.read(SystemErds.erd.actually_packed_fr);
+    _ = ram_data.write(SystemErds.erd.erd_actually_packed_fr, .{ .a = 1, .b = 0, .c = 0, .d = 0, .e = 1, .f = 0, .g = 1 });
+    const packed_st_with_data = ram_data.read(SystemErds.erd.erd_actually_packed_fr);
     try std.testing.expectEqual(@TypeOf(packed_st_with_data){ .a = 1, .b = 0, .c = 0, .d = 0, .e = 1, .f = 0, .g = 1 }, packed_st_with_data);
 
-    _ = ram_data.write(SystemErds.erd.padded, .{ .a = 0x12, .b = 0x3456, .c = true, .d = 0x09ABCDEF });
+    _ = ram_data.write(SystemErds.erd.erd_padded, .{ .a = 0x12, .b = 0x3456, .c = true, .d = 0x09ABCDEF });
 
-    const padded = ram_data.read(SystemErds.erd.padded);
-    try std.testing.expectEqual(@TypeOf(padded){ .a = 0x12, .b = 0x3456, .c = true, .d = 0x09ABCDEF }, padded);
+    const erd_padded = ram_data.read(SystemErds.erd.erd_padded);
+    try std.testing.expectEqual(@TypeOf(erd_padded){ .a = 0x12, .b = 0x3456, .c = true, .d = 0x09ABCDEF }, erd_padded);
 }
 
 test "failure upon writing incorrect types" {
@@ -62,16 +62,16 @@ test "failure upon writing incorrect types" {
     // TODO: Enable this test once you can test for compile errors
 
     // var ram_data = RamDataComponent.init();
-    // std.testing.expectError(, ram_data.write(SystemErds.erd.some_bool, 20));
+    // std.testing.expectError(, ram_data.write(SystemErds.erd.erd_some_bool, 20));
 }
 
 test "runtime reads" {
     var ram_data = RamDataComponent.init();
 
-    _ = ram_data.write(SystemErds.erd.some_bool, true);
+    _ = ram_data.write(SystemErds.erd.erd_some_bool, true);
 
     var bool_val: bool = undefined;
-    ram_data.runtime_read(SystemErds.erd.some_bool.data_component_idx, &bool_val);
+    ram_data.runtime_read(SystemErds.erd.erd_some_bool.data_component_idx, &bool_val);
 
     try std.testing.expectEqual(true, bool_val);
 }
@@ -80,15 +80,15 @@ test "runtime writes" {
     var ram_data = RamDataComponent.init();
 
     const very_true = true;
-    var changed = ram_data.runtime_write(SystemErds.erd.some_bool.data_component_idx, &very_true);
+    var changed = ram_data.runtime_write(SystemErds.erd.erd_some_bool.data_component_idx, &very_true);
     try std.testing.expect(changed);
 
-    const bool_val = ram_data.read(SystemErds.erd.some_bool);
+    const bool_val = ram_data.read(SystemErds.erd.erd_some_bool);
     try std.testing.expectEqual(true, bool_val);
 
-    changed = ram_data.write(SystemErds.erd.some_bool, true);
+    changed = ram_data.write(SystemErds.erd.erd_some_bool, true);
     try std.testing.expect(!changed);
 
-    changed = ram_data.write(SystemErds.erd.some_bool, false);
+    changed = ram_data.write(SystemErds.erd.erd_some_bool, false);
     try std.testing.expect(changed);
 }

--- a/src/tests/system_data_test.zig
+++ b/src/tests/system_data_test.zig
@@ -6,59 +6,59 @@ const Subscription = @import("../subscription.zig");
 test "ram data component read and write" {
     var system_data = SystemData.init();
     // Should zero init
-    try std.testing.expectEqual(0, system_data.read(SystemErds.erd.application_version));
+    try std.testing.expectEqual(0, system_data.read(.erd_application_version));
 
     const new_application_version: u32 = 0x12345678;
-    system_data.write(SystemErds.erd.application_version, new_application_version);
-    try std.testing.expectEqual(new_application_version, system_data.read(SystemErds.erd.application_version));
+    system_data.write(.erd_application_version, new_application_version);
+    try std.testing.expectEqual(new_application_version, system_data.read(.erd_application_version));
 }
 
 test "runtime read/write matches data components" {
     var system_data = SystemData.init();
     var ver: u32 = undefined;
-    system_data.runtime_read(SystemErds.erd.application_version.system_data_idx, &ver);
+    system_data.runtime_read(SystemErds.erd.erd_application_version.system_data_idx, &ver);
     try std.testing.expectEqual(0, ver);
 
-    system_data.write(SystemErds.erd.application_version, 1234);
-    system_data.runtime_read(SystemErds.erd.application_version.system_data_idx, &ver);
+    system_data.write(.erd_application_version, 1234);
+    system_data.runtime_read(SystemErds.erd.erd_application_version.system_data_idx, &ver);
     try std.testing.expectEqual(1234, ver);
 
     var should_be_42: u16 = undefined;
-    system_data.runtime_read(SystemErds.erd.always_42.system_data_idx, &should_be_42);
-    system_data.runtime_read(SystemErds.erd.always_42.system_data_idx, &ver);
+    system_data.runtime_read(SystemErds.erd.erd_always_42.system_data_idx, &should_be_42);
+    system_data.runtime_read(SystemErds.erd.erd_always_42.system_data_idx, &ver);
     try std.testing.expectEqual(42, should_be_42);
 }
 
 test "indirect data component read and a note on reads" {
     var system_data = SystemData.init();
-    try std.testing.expectEqual(42, system_data.read(SystemErds.erd.always_42));
+    try std.testing.expectEqual(42, system_data.read(.erd_always_42));
 
     // This does not work:
     // src\system_data.zig:49:31: error: reached unreachable code
     //     .Indirect => comptime unreachable,
-    // system_data.write(SystemErds.erd.always_42, 43);
+    // system_data.write(.erd_always_42, 43);
 }
 
 fn ExampleDo(system_data: *SystemData) !void {
-    try std.testing.expectEqual(42, system_data.read(SystemErds.erd.always_42));
+    try std.testing.expectEqual(42, system_data.read(.erd_always_42));
 
     const new_application_version: u32 = 0x87654321;
-    system_data.write(SystemErds.erd.application_version, new_application_version);
+    system_data.write(.erd_application_version, new_application_version);
 }
 
 test "mutable system_data passing without error" {
     var system_data = SystemData.init();
 
     try ExampleDo(&system_data);
-    try std.testing.expectEqual(0x87654321, system_data.read(SystemErds.erd.application_version));
+    try std.testing.expectEqual(0x87654321, system_data.read(.erd_application_version));
 }
 
 var persisted_system_data: *SystemData = undefined;
 fn ExampleCallbackEffect() !void {
-    try std.testing.expectEqual(42, persisted_system_data.read(SystemErds.erd.always_42));
+    try std.testing.expectEqual(42, persisted_system_data.read(.erd_always_42));
 
     const new_application_version: u32 = 0xCAFEBABE;
-    persisted_system_data.write(SystemErds.erd.application_version, new_application_version);
+    persisted_system_data.write(.erd_application_version, new_application_version);
 }
 
 fn ExampleInit(system_data: *SystemData) void {
@@ -75,92 +75,92 @@ test "retain reference to system_data" {
     ExampleInit(&system_data);
 
     try ExampleCallbackEffect();
-    try std.testing.expectEqual(0xCAFEBABE, system_data.read(SystemErds.erd.application_version));
+    try std.testing.expectEqual(0xCAFEBABE, system_data.read(.erd_application_version));
 }
 
 fn turn_off_some_bool_and_increment_application_version(_: ?*anyopaque, _: *const anyopaque, system_data: *SystemData) void {
-    system_data.write(SystemErds.erd.some_bool, false);
-    system_data.write(SystemErds.erd.application_version, system_data.read(SystemErds.erd.application_version) + 1);
+    system_data.write(.erd_some_bool, false);
+    system_data.write(.erd_application_version, system_data.read(.erd_application_version) + 1);
 }
 
 test "subscription_test" {
     var system_data = SystemData.init();
-    // system_data.subscribe(SystemErds.erd.some_bool, null, null); // This is a compile error!
+    // system_data.subscribe(.erd_some_bool, null, null); // This is a compile error!
 
-    system_data.subscribe(SystemErds.erd.some_bool, null, turn_off_some_bool_and_increment_application_version);
+    system_data.subscribe(.erd_some_bool, null, turn_off_some_bool_and_increment_application_version);
     // Subscriptions can be stored on the stack if it lives through all of its callbacks.
     // defer pattern only makes sense if you stack initialize this. Here it's to show that it's safe to call unsub multiple times
-    defer system_data.unsubscribe(SystemErds.erd.some_bool, turn_off_some_bool_and_increment_application_version);
+    defer system_data.unsubscribe(.erd_some_bool, turn_off_some_bool_and_increment_application_version);
 
-    system_data.write(SystemErds.erd.some_bool, true);
-    try std.testing.expectEqual(false, system_data.read(SystemErds.erd.some_bool));
-    try std.testing.expectEqual(2, system_data.read(SystemErds.erd.application_version));
+    system_data.write(.erd_some_bool, true);
+    try std.testing.expectEqual(false, system_data.read(.erd_some_bool));
+    try std.testing.expectEqual(2, system_data.read(.erd_application_version));
 
-    system_data.unsubscribe(SystemErds.erd.some_bool, turn_off_some_bool_and_increment_application_version);
-    system_data.write(SystemErds.erd.some_bool, true);
-    try std.testing.expectEqual(true, system_data.read(SystemErds.erd.some_bool));
-    try std.testing.expectEqual(2, system_data.read(SystemErds.erd.application_version));
+    system_data.unsubscribe(.erd_some_bool, turn_off_some_bool_and_increment_application_version);
+    system_data.write(.erd_some_bool, true);
+    try std.testing.expectEqual(true, system_data.read(.erd_some_bool));
+    try std.testing.expectEqual(2, system_data.read(.erd_application_version));
 }
 
 fn forward_context(context: ?*anyopaque, _: *const anyopaque, system_data: *SystemData) void {
     const a: *u8 = @ptrCast(context.?);
 
-    system_data.write(SystemErds.erd.unaligned_u16, a.*);
+    system_data.write(.erd_unaligned_u16, a.*);
 }
 
 test "subscription with context" {
     var system_data = SystemData.init();
 
     var a: u8 = 17;
-    system_data.subscribe(SystemErds.erd.some_bool, &a, forward_context);
-    system_data.write(SystemErds.erd.some_bool, true);
+    system_data.subscribe(.erd_some_bool, &a, forward_context);
+    system_data.write(.erd_some_bool, true);
 
-    try std.testing.expectEqual(17, system_data.read(SystemErds.erd.unaligned_u16));
+    try std.testing.expectEqual(17, system_data.read(.erd_unaligned_u16));
 }
 
 fn context_must_match_args(context: ?*anyopaque, args: *const anyopaque, system_data: *SystemData) void {
     const a: *u16 = @alignCast(@ptrCast(context.?));
     const b: *const u16 = @alignCast(@ptrCast(args));
 
-    system_data.write(SystemErds.erd.some_bool, a.* == b.*);
+    system_data.write(.erd_some_bool, a.* == b.*);
 }
 
 test "subscription with args" {
     var system_data = SystemData.init();
 
     var a: u16 = 1;
-    system_data.subscribe(SystemErds.erd.unaligned_u16, &a, context_must_match_args);
-    system_data.write(SystemErds.erd.unaligned_u16, 1);
-    try std.testing.expect(true == system_data.read(SystemErds.erd.some_bool));
+    system_data.subscribe(.erd_unaligned_u16, &a, context_must_match_args);
+    system_data.write(.erd_unaligned_u16, 1);
+    try std.testing.expect(true == system_data.read(.erd_some_bool));
 
-    system_data.write(SystemErds.erd.unaligned_u16, 2);
-    try std.testing.expect(false == system_data.read(SystemErds.erd.some_bool));
+    system_data.write(.erd_unaligned_u16, 2);
+    try std.testing.expect(false == system_data.read(.erd_some_bool));
 
     a = 2;
-    system_data.write(SystemErds.erd.unaligned_u16, 2);
+    system_data.write(.erd_unaligned_u16, 2);
     // Stays false because no publish
-    try std.testing.expect(false == system_data.read(SystemErds.erd.some_bool));
+    try std.testing.expect(false == system_data.read(.erd_some_bool));
 }
 
 fn bump_some_u16(_: ?*anyopaque, _: *const anyopaque, system_data: *SystemData) void {
-    system_data.write(SystemErds.erd.unaligned_u16, system_data.read(SystemErds.erd.unaligned_u16) + 1);
+    system_data.write(.erd_unaligned_u16, system_data.read(.erd_unaligned_u16) + 1);
 }
 
 test "double sub test" {
     var system_data = SystemData.init();
-    system_data.subscribe(SystemErds.erd.some_bool, null, turn_off_some_bool_and_increment_application_version);
-    system_data.subscribe(SystemErds.erd.some_bool, null, bump_some_u16);
+    system_data.subscribe(.erd_some_bool, null, turn_off_some_bool_and_increment_application_version);
+    system_data.subscribe(.erd_some_bool, null, bump_some_u16);
 
-    system_data.write(SystemErds.erd.some_bool, true);
-    try std.testing.expectEqual(false, system_data.read(SystemErds.erd.some_bool));
-    try std.testing.expectEqual(2, system_data.read(SystemErds.erd.application_version));
-    try std.testing.expectEqual(2, system_data.read(SystemErds.erd.unaligned_u16));
+    system_data.write(.erd_some_bool, true);
+    try std.testing.expectEqual(false, system_data.read(.erd_some_bool));
+    try std.testing.expectEqual(2, system_data.read(.erd_application_version));
+    try std.testing.expectEqual(2, system_data.read(.erd_unaligned_u16));
 
-    system_data.unsubscribe(SystemErds.erd.some_bool, turn_off_some_bool_and_increment_application_version);
-    system_data.write(SystemErds.erd.some_bool, true);
-    try std.testing.expectEqual(true, system_data.read(SystemErds.erd.some_bool));
-    try std.testing.expectEqual(2, system_data.read(SystemErds.erd.application_version));
-    try std.testing.expectEqual(3, system_data.read(SystemErds.erd.unaligned_u16));
+    system_data.unsubscribe(.erd_some_bool, turn_off_some_bool_and_increment_application_version);
+    system_data.write(.erd_some_bool, true);
+    try std.testing.expectEqual(true, system_data.read(.erd_some_bool));
+    try std.testing.expectEqual(2, system_data.read(.erd_application_version));
+    try std.testing.expectEqual(3, system_data.read(.erd_unaligned_u16));
 }
 
 fn whatever(_: ?*anyopaque, _: *const anyopaque, _: *SystemData) void {}
@@ -168,11 +168,11 @@ fn whatever(_: ?*anyopaque, _: *const anyopaque, _: *SystemData) void {}
 test "exact subscription enforcement" {
     var system_data = SystemData.init();
 
-    system_data.subscribe(SystemErds.erd.some_bool, null, whatever);
-    system_data.subscribe(SystemErds.erd.some_bool, null, bump_some_u16);
-    system_data.subscribe(SystemErds.erd.some_bool, null, turn_off_some_bool_and_increment_application_version);
-    system_data.subscribe(SystemErds.erd.unaligned_u16, null, whatever);
-    system_data.subscribe(SystemErds.erd.cool_u16, null, whatever);
+    system_data.subscribe(.erd_some_bool, null, whatever);
+    system_data.subscribe(.erd_some_bool, null, bump_some_u16);
+    system_data.subscribe(.erd_some_bool, null, turn_off_some_bool_and_increment_application_version);
+    system_data.subscribe(.erd_unaligned_u16, null, whatever);
+    system_data.subscribe(.erd_cool_u16, null, whatever);
 
     // TODO: Move this test into the Application test file
     // and replace all of the above with `application.init`
@@ -186,27 +186,27 @@ fn scratch_allocating(_: ?*anyopaque, args: *const anyopaque, system_data: *Syst
         item.* = @intCast(i);
     }
 
-    system_data.write(SystemErds.erd.application_version, allocated[allocated.len - 1]);
+    system_data.write(.erd_application_version, allocated[allocated.len - 1]);
 }
 
 test "scratch allocations" {
     var system_data: SystemData = .init();
 
-    system_data.subscribe(SystemErds.erd.unaligned_u16, null, scratch_allocating);
-    system_data.write(SystemErds.erd.unaligned_u16, 7);
-    try std.testing.expectEqual(7, system_data.read(SystemErds.erd.application_version));
+    system_data.subscribe(.erd_unaligned_u16, null, scratch_allocating);
+    system_data.write(.erd_unaligned_u16, 7);
+    try std.testing.expectEqual(7, system_data.read(.erd_application_version));
 
     system_data.scratch_reset();
 
-    system_data.write(SystemErds.erd.unaligned_u16, 5);
-    try std.testing.expectEqual(5, system_data.read(SystemErds.erd.application_version));
+    system_data.write(.erd_unaligned_u16, 5);
+    try std.testing.expectEqual(5, system_data.read(.erd_application_version));
 
-    const more_allocation = system_data.scratch_alloc(u8, system_data.read(SystemErds.erd.application_version));
+    const more_allocation = system_data.scratch_alloc(u8, system_data.read(.erd_application_version));
     try std.testing.expect(system_data.scratch.ownsSlice(more_allocation));
 
     system_data.scratch_reset();
     // NOTE: Notice how this does not fail!
     // One must be very careful since this data is now considered freed, but there's no runtime check on it.
-    system_data.write(SystemErds.erd.application_version, more_allocation[0]);
-    try std.testing.expectEqual(0b10101010, system_data.read(SystemErds.erd.application_version));
+    system_data.write(.erd_application_version, more_allocation[0]);
+    try std.testing.expectEqual(0b10101010, system_data.read(.erd_application_version));
 }


### PR DESCRIPTION
This PR removes the `SystemErds.erd.unaligned_u16` pattern in order to opt for `.erd_unaligned_u16` where an ERD name is used. As a result most APIs are much more concise, offer immediate auto-complete upon typing `.` , and the benefits are compounded in APIs that use multiple ERDs.