### PR TITLE
Generic SystemErds/SystemData

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,24 @@ zig-out
 *.exe
 *.obj
 *.pdb
+
+# Claude
+.claude
+
+# Claude outputting garbage 0 byte temp files in sandbox (https://github.com/anthropics/claude-code/issues/29316):
+.vscode
+.bash_profile
+.bashrc
+.gitconfig
+.gitmodules
+.idea
+.mcp.json
+.profile
+.ripgreprc
+.zprofile
+.zshrc
+HEAD
+config
+hooks
+objects
+refs

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,6 +46,10 @@ Tests live in `src/tests/` and are aggregated via `src/unit_tests.zig` using com
 
 Managed via `build.zig.zon`. Single dependency: `assert_sometimes`, imported as `"sometimes"` in source. This is a code coverage tool, not a traditional assertion library — it verifies that both the true and false branches of a condition are exercised across test runs. The `test` step disables these checks; `test_coverage` enables them.
 
+## Formatting
+
+After completing any code changes, run `zig fmt src/` to format the entire repo before reporting results.
+
 ## Current Limitations
 
 This repo is early-stage and not yet cleanly usable as a library. Key issues:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,55 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Build & Test Commands
+
+```bash
+zig build                # Build executable
+zig build run            # Run (generates ERD JSON output)
+zig build test           # Run unit tests (sometimes-assertions disabled)
+zig build test_coverage  # Run tests with all assertions enabled
+zig build test_no_run    # Build tests without running
+```
+
+All test steps run across four optimization modes: Debug, ReleaseSafe, ReleaseSmall, ReleaseFast.
+
+## Architecture
+
+This is a **typed publish-subscribe data system** for embedded/real-time Zig applications. It uses comptime-known ERD (Entity-Reference-Descriptor) definitions to achieve zero-cost abstractions over static memory.
+
+### Core Concepts
+
+**ERD (Entity-Reference-Descriptor)** - A named, typed data field with a unique 16-bit handle. Each ERD declares its type, owner, and subscription slot count at comptime. Defined in `src/system_erds.zig`.
+
+**Data Components** own ERDs and provide storage:
+- **RamDataComponent** (`src/ram_data_component.zig`) - Stores values in a packed byte array. Comptime reads/writes compile to direct loads/stores. Fires on-change subscriptions on write.
+- **IndirectDataComponent** (`src/indirect_data_component.zig`) - Read-only computed data via function pointers. No writes allowed (compile error).
+
+**SystemData** (`src/system_data.zig`) - Top-level aggregator that owns both data components and the subscription arrays. Provides the public API: `read`, `write`, `subscribe`, `unsubscribe`, `publish`. Also has `runtime_read`/`runtime_write` for dynamic ERD access via `system_data_idx`.
+
+**Subscriptions** - Fixed-size arrays per ERD (slot count from `.subs` field at comptime). Callbacks receive `(?*anyopaque, *OnChangeArgs, *SystemData)`. Identity is by function pointer; no duplicates per ERD.
+
+### Timer Module
+
+`src/timer.zig` - Lightweight software scheduler using a sorted singly-linked list. Supports periodic and one-shot timers, pause/resume, and uses pointer alignment tricks (LSB stores `is_periodic` flag) for memory efficiency. Designed for tick-based embedded run-to-completion loops.
+
+### Data Generation Framework
+
+`src/data_gen/` - Constraint-based data generation for property-based testing. Separate from the pub-sub core but included in the test suite.
+
+## Testing
+
+Tests live in `src/tests/` and are aggregated via `src/unit_tests.zig` using comptime imports. The `assert_sometimes` dependency provides assertions that can be toggled: disabled in `test` step (for binary size), enabled in `test_coverage` step (full assertion coverage). CI runs both modes on Ubuntu and Windows.
+
+## Dependencies
+
+Managed via `build.zig.zon`. Single dependency: `assert_sometimes`, imported as `"sometimes"` in source. This is a code coverage tool, not a traditional assertion library — it verifies that both the true and false branches of a condition are exercised across test runs. The `test` step disables these checks; `test_coverage` enables them.
+
+## Current Limitations
+
+This repo is early-stage and not yet cleanly usable as a library. Key issues:
+
+- **`system_erds.zig`** defines the ERD table for a specific application. To use this framework in a new project, you'd need to copy and customize this file.
+- **`system_data.zig`** conflates two concerns: the public interface (read/write/subscribe) and the structural wiring of data components. These should eventually be separated so the interface is reusable without dictating component choices.
+- **`src/common/`** contains utilities generic enough to extract into a standalone library, but still has coupling to project-specific types.

--- a/src/app.zig
+++ b/src/app.zig
@@ -35,16 +35,17 @@ fn plus_one(data: *u16) void {
 }
 
 const indirect_mappings = [_]IndirectDataComponent.IndirectErdMapping{
-    IndirectDataComponent.IndirectErdMapping.map(SystemErds.erd.erd_always_42, always_42),
-    IndirectDataComponent.IndirectErdMapping.map(SystemErds.erd.erd_another_erd_plus_one, plus_one),
+    .map(SystemErds.erd.erd_always_42, always_42),
+    .map(SystemErds.erd.erd_another_erd_plus_one, plus_one),
 };
 
-pub fn init() SystemData {
-    var this = SystemData{};
-    this.components.ram = RamDataComponent.init();
-    this.components.indirect = IndirectDataComponent.init(indirect_mappings);
-    this.scratch = .init(&this.scratch_buf);
+pub const Application = struct {
+    system_data: SystemData,
+};
 
-    @memset(&this.subscriptions, .{ .context = null, .callback = null });
-    return this;
+pub fn init() Application {
+    return .{ .system_data = SystemData.init(.{
+        .ram = RamDataComponent.init(),
+        .indirect = IndirectDataComponent.init(indirect_mappings),
+    }) };
 }

--- a/src/app.zig
+++ b/src/app.zig
@@ -2,6 +2,7 @@
 //! This file binds ERD definitions to concrete data component implementations
 //! and provides the fully instantiated SystemData type for this application.
 
+const std = @import("std");
 const SystemErds = @import("system_erds.zig");
 
 pub const RamDataComponent = @import("ram_data_component.zig").RamDataComponent(&SystemErds.ram_definitions);
@@ -10,6 +11,14 @@ pub const IndirectDataComponent = @import("indirect_data_component.zig").Indirec
 pub const Components = struct {
     ram: RamDataComponent,
     indirect: IndirectDataComponent,
+
+    comptime {
+        const Id = SystemErds.ComponentId;
+        if (std.meta.fields(Components)[@intFromEnum(Id.ram)].type != RamDataComponent)
+            @compileError("ComponentId.ram does not match RamDataComponent position in Components");
+        if (std.meta.fields(Components)[@intFromEnum(Id.indirect)].type != IndirectDataComponent)
+            @compileError("ComponentId.indirect does not match IndirectDataComponent position in Components");
+    }
 };
 
 pub const SystemData = @import("system_data.zig").SystemData(SystemErds.ErdDefinitions, SystemErds.ErdEnum, SystemErds.erd, Components);

--- a/src/app.zig
+++ b/src/app.zig
@@ -1,0 +1,41 @@
+//! Application-specific wiring
+//! This file binds ERD definitions to concrete data component implementations
+//! and provides the fully instantiated SystemData type for this application.
+
+const SystemErds = @import("system_erds.zig");
+
+pub const RamDataComponent = @import("ram_data_component.zig").RamDataComponent(&SystemErds.ram_definitions);
+pub const IndirectDataComponent = @import("indirect_data_component.zig").IndirectDataComponent(&SystemErds.indirect_definitions);
+
+pub const Components = struct {
+    ram: RamDataComponent,
+    indirect: IndirectDataComponent,
+};
+
+pub const SystemData = @import("system_data.zig").SystemData(SystemErds.ErdDefinitions, SystemErds.ErdEnum, SystemErds.erd, Components);
+
+fn always_42(data: *u16) void {
+    data.* = 42;
+}
+
+fn plus_one(data: *u16) void {
+    var should_be_42: u16 = undefined;
+    always_42(&should_be_42);
+
+    data.* = should_be_42 + 1;
+}
+
+const indirect_mappings = [_]IndirectDataComponent.IndirectErdMapping{
+    IndirectDataComponent.IndirectErdMapping.map(SystemErds.erd.erd_always_42, always_42),
+    IndirectDataComponent.IndirectErdMapping.map(SystemErds.erd.erd_another_erd_plus_one, plus_one),
+};
+
+pub fn init() SystemData {
+    var this = SystemData{};
+    this.components.ram = RamDataComponent.init();
+    this.components.indirect = IndirectDataComponent.init(indirect_mappings);
+    this.scratch = .init(&this.scratch_buf);
+
+    @memset(&this.subscriptions, .{ .context = null, .callback = null });
+    return this;
+}

--- a/src/common/erd_logic.zig
+++ b/src/common/erd_logic.zig
@@ -6,9 +6,6 @@
 //! there is an O(0) lookup.
 
 const std = @import("std");
-const SystemData = @import("../system_data.zig");
-const SystemErds = @import("../system_erds.zig");
-const Erd = @import("../erd.zig");
 
 const ErdLogicOperator = enum {
     _and,
@@ -26,7 +23,7 @@ const ErdLogicOperator = enum {
 // TODO: Should this really be this generic? It probably leads to a lot of code bloat. I'd much prefer
 // this to use the same machine code for all instances (or at least one set for the unary operators, and one set for binary operators).
 /// Constructs an ErdLogic type
-pub fn ErdLogic(comptime operator: ErdLogicOperator, comptime erds: []const SystemErds.ErdEnum, outputErd: SystemErds.ErdEnum) type {
+pub fn ErdLogic(comptime SystemDataType: type, comptime operator: ErdLogicOperator, comptime erds: []const SystemDataType.ErdEnumType, outputErd: SystemDataType.ErdEnumType) type {
     comptime {
         switch (operator) {
             ._bitwise_not, ._not => std.debug.assert(erds.len == 1), // Unary operators
@@ -34,19 +31,19 @@ pub fn ErdLogic(comptime operator: ErdLogicOperator, comptime erds: []const Syst
         }
 
         if (erds.len > 1) {
-            var window = std.mem.window(SystemErds.ErdEnum, erds, 2, 1);
+            var window = std.mem.window(SystemDataType.ErdEnumType, erds, 2, 1);
             while (window.next()) |erd_pair| {
-                std.debug.assert(SystemErds.erd_from_enum(erd_pair[0]).T == SystemErds.erd_from_enum(erd_pair[1]).T);
+                std.debug.assert(SystemDataType.erd_from_enum_pub(erd_pair[0]).T == SystemDataType.erd_from_enum_pub(erd_pair[1]).T);
             }
         }
 
-        std.debug.assert(SystemErds.erd_from_enum(erds[0]).T == SystemErds.erd_from_enum(outputErd).T);
+        std.debug.assert(SystemDataType.erd_from_enum_pub(erds[0]).T == SystemDataType.erd_from_enum_pub(outputErd).T);
     }
 
     return struct {
         // TODO: Utilize args here to improve the code
         fn on_change(_: ?*anyopaque, _: ?*const anyopaque, publisher: *anyopaque) void {
-            var system_data: *SystemData = @ptrCast(@alignCast(publisher));
+            var system_data: *SystemDataType = @ptrCast(@alignCast(publisher));
 
             if (erds.len == 1) {
                 const value = system_data.read(erds[0]);
@@ -80,7 +77,7 @@ pub fn ErdLogic(comptime operator: ErdLogicOperator, comptime erds: []const Syst
             }
         }
 
-        fn init(system_data: *SystemData) void {
+        fn init(system_data: *SystemDataType) void {
             inline for (erds) |erd| {
                 system_data.subscribe(erd, null, on_change);
             }
@@ -90,39 +87,49 @@ pub fn ErdLogic(comptime operator: ErdLogicOperator, comptime erds: []const Syst
     };
 }
 
+const SystemDataTestDouble = @import("../testing.zig");
+
+const TestSystem = SystemDataTestDouble.create(struct {
+    input_a: SystemDataTestDouble.Erd = SystemDataTestDouble.ramErd(u16, .{ .subs = 1 }),
+    input_b: SystemDataTestDouble.Erd = SystemDataTestDouble.ramErd(u16, .{ .subs = 1 }),
+    output: SystemDataTestDouble.Erd = SystemDataTestDouble.ramErd(u16, .{}),
+});
+const SystemData = TestSystem.SystemData;
+const ErdEnum = SystemData.ErdEnumType;
+
 test "can _bitwise_and" {
-    var system_data: SystemData = .init();
+    var system_data: SystemData = TestSystem.init();
 
-    const input_erds = &[_]SystemErds.ErdEnum{ .erd_unaligned_u16, .erd_cool_u16 };
-    ErdLogic(._bitwise_and, input_erds, .erd_best_u16).init(&system_data);
+    const input_erds = &[_]ErdEnum{ .input_a, .input_b };
+    ErdLogic(SystemData, ._bitwise_and, input_erds, .output).init(&system_data);
 
-    try std.testing.expectEqual(0, system_data.read(.erd_best_u16));
+    try std.testing.expectEqual(0, system_data.read(.output));
     // Can't do anything about this without an extra subscription
     // it's up to the programmer to not write to "output" ERDs:
-    system_data.write(.erd_best_u16, 1337);
-    try std.testing.expectEqual(1337, system_data.read(.erd_best_u16));
+    system_data.write(.output, 1337);
+    try std.testing.expectEqual(1337, system_data.read(.output));
 
-    system_data.write(.erd_unaligned_u16, 0b01010101);
-    system_data.write(.erd_cool_u16, 0b10101010);
-    try std.testing.expectEqual(0, system_data.read(.erd_best_u16));
+    system_data.write(.input_a, 0b01010101);
+    system_data.write(.input_b, 0b10101010);
+    try std.testing.expectEqual(0, system_data.read(.output));
 
-    system_data.write(.erd_unaligned_u16, 0b00001010);
-    try std.testing.expectEqual(0b1010, system_data.read(.erd_best_u16));
+    system_data.write(.input_a, 0b00001010);
+    try std.testing.expectEqual(0b1010, system_data.read(.output));
 
-    system_data.write(.erd_unaligned_u16, 0b10100000);
-    try std.testing.expectEqual(0b10100000, system_data.read(.erd_best_u16));
+    system_data.write(.input_a, 0b10100000);
+    try std.testing.expectEqual(0b10100000, system_data.read(.output));
 
-    system_data.write(.erd_unaligned_u16, 0xFF);
-    try std.testing.expectEqual(system_data.read(.erd_cool_u16), system_data.read(.erd_best_u16));
+    system_data.write(.input_a, 0xFF);
+    try std.testing.expectEqual(system_data.read(.input_b), system_data.read(.output));
 }
 
 test "unary operators work" {
-    var system_data: SystemData = .init();
+    var system_data: SystemData = TestSystem.init();
 
-    ErdLogic(._bitwise_not, &[_]SystemErds.ErdEnum{.erd_cool_u16}, .erd_best_u16).init(&system_data);
+    ErdLogic(SystemData, ._bitwise_not, &[_]ErdEnum{.input_a}, .output).init(&system_data);
 
-    system_data.write(.erd_cool_u16, 0x1F7F);
-    try std.testing.expectEqual(0b1110_0000_1000_0000, system_data.read(.erd_best_u16));
+    system_data.write(.input_a, 0x1F7F);
+    try std.testing.expectEqual(0b1110_0000_1000_0000, system_data.read(.output));
 }
 
 // TODO: Finish the rest of the tests when there's a way to create testing (locally scoped) ERDs

--- a/src/common/erd_logic.zig
+++ b/src/common/erd_logic.zig
@@ -33,11 +33,11 @@ pub fn ErdLogic(comptime SystemDataType: type, comptime operator: ErdLogicOperat
         if (erds.len > 1) {
             var window = std.mem.window(SystemDataType.ErdEnumType, erds, 2, 1);
             while (window.next()) |erd_pair| {
-                std.debug.assert(SystemDataType.erd_from_enum_pub(erd_pair[0]).T == SystemDataType.erd_from_enum_pub(erd_pair[1]).T);
+                std.debug.assert(SystemDataType.erd_from_enum(erd_pair[0]).T == SystemDataType.erd_from_enum(erd_pair[1]).T);
             }
         }
 
-        std.debug.assert(SystemDataType.erd_from_enum_pub(erds[0]).T == SystemDataType.erd_from_enum_pub(outputErd).T);
+        std.debug.assert(SystemDataType.erd_from_enum(erds[0]).T == SystemDataType.erd_from_enum(outputErd).T);
     }
 
     return struct {

--- a/src/common/timer_stats.zig
+++ b/src/common/timer_stats.zig
@@ -10,15 +10,9 @@
 //! `maximum_latency` = 1
 
 const std = @import("std");
-const App = @import("../app.zig");
-const SystemData = App.SystemData;
-const SystemErds = @import("../system_erds.zig");
-const Erd = @import("../erd.zig");
 const timer = @import("../timer.zig");
 const Timer = timer.Timer;
 const TimerModule = timer.TimerModule;
-
-const TimerModuleStats = @This();
 
 pub const StatMeasurement = struct {
     average_throughput_per_tick: u32,
@@ -27,150 +21,163 @@ pub const StatMeasurement = struct {
     maximum_latency: timer.Ticks,
 };
 
-system_data: *SystemData,
-timer_module: *TimerModule,
-throughput_timer: Timer,
-save_measurement_timer: Timer,
-current_throughput: u32,
-highest_latency_this_tick: timer.Ticks,
-enable_erd_idx: u16,
-output_erd_idx: u16,
+pub fn TimerModuleStats(comptime SystemDataType: type) type {
+    return struct {
+        const Self = @This();
 
-fn save_measurement(ctx: ?*anyopaque, _: *TimerModule, _: *Timer) void {
-    const self: *TimerModuleStats = @ptrCast(@alignCast(ctx));
+        system_data: *SystemDataType,
+        timer_module: *TimerModule,
+        throughput_timer: Timer,
+        save_measurement_timer: Timer,
+        current_throughput: u32,
+        highest_latency_this_tick: timer.Ticks,
+        enable_erd_idx: u16,
+        output_erd_idx: u16,
 
-    var current_stats: StatMeasurement = undefined;
-    self.system_data.runtime_read(self.output_erd_idx, &current_stats);
+        fn save_measurement(ctx: ?*anyopaque, _: *TimerModule, _: *Timer) void {
+            const self: *Self = @ptrCast(@alignCast(ctx));
 
-    const updated_stats = StatMeasurement{
-        .average_throughput_per_tick = (current_stats.average_throughput_per_tick + self.current_throughput) / 2, // Effectively an EWMA
-        .maximum_throughput_per_tick = @max(current_stats.maximum_throughput_per_tick, self.current_throughput),
-        .average_latency = (current_stats.average_latency + self.highest_latency_this_tick) / 2, // Effectively an EWMA
-        .maximum_latency = @max(current_stats.maximum_latency, self.highest_latency_this_tick),
+            var current_stats: StatMeasurement = undefined;
+            self.system_data.runtime_read(self.output_erd_idx, &current_stats);
+
+            const updated_stats = StatMeasurement{
+                .average_throughput_per_tick = (current_stats.average_throughput_per_tick + self.current_throughput) / 2, // Effectively an EWMA
+                .maximum_throughput_per_tick = @max(current_stats.maximum_throughput_per_tick, self.current_throughput),
+                .average_latency = (current_stats.average_latency + self.highest_latency_this_tick) / 2, // Effectively an EWMA
+                .maximum_latency = @max(current_stats.maximum_latency, self.highest_latency_this_tick),
+            };
+            self.system_data.runtime_write(self.output_erd_idx, &updated_stats);
+
+            self.current_throughput = 0;
+            self.highest_latency_this_tick = 0;
+        }
+
+        fn measure_throughput(ctx: ?*anyopaque, timer_module: *TimerModule, _: *Timer) void {
+            const self: *Self = @ptrCast(@alignCast(ctx));
+
+            self.current_throughput += 1;
+            const latency = timer_module.ticks_since_last_started(&self.throughput_timer);
+            self.highest_latency_this_tick = @max(latency, self.highest_latency_this_tick);
+        }
+
+        fn on_enable_change(ctx: ?*anyopaque, _args: ?*const anyopaque, publisher: *anyopaque) void {
+            const args: *const SystemDataType.OnChangeArgs = @ptrCast(@alignCast(_args.?));
+            var system_data: *SystemDataType = @ptrCast(@alignCast(publisher));
+            const self: *Self = @ptrCast(@alignCast(ctx));
+            const is_enabled: *const bool = @ptrCast(args.data);
+
+            if (is_enabled.*) {
+                self.current_throughput = 0;
+                self.highest_latency_this_tick = 0;
+
+                const clear_stats = std.mem.zeroes(StatMeasurement);
+                system_data.runtime_write(self.output_erd_idx, &clear_stats);
+
+                self.timer_module.start_periodic(&self.throughput_timer, 0, self, measure_throughput);
+                self.timer_module.start_periodic(&self.save_measurement_timer, 1, self, save_measurement);
+            } else {
+                self.timer_module.stop(&self.throughput_timer);
+                self.timer_module.stop(&self.save_measurement_timer);
+            }
+        }
+
+        // TODO: runtime_subscribe
+        fn inner_init(
+            self: *Self,
+            system_data: *SystemDataType,
+            timer_module: *TimerModule,
+            enable_erd_idx: u16,
+            output_erd_idx: u16,
+        ) void {
+            self.system_data = system_data;
+            self.timer_module = timer_module;
+            self.enable_erd_idx = enable_erd_idx;
+            self.output_erd_idx = output_erd_idx;
+
+            var is_enabled: bool = undefined;
+            system_data.runtime_read(enable_erd_idx, &is_enabled);
+
+            const init_data: SystemDataType.OnChangeArgs = .{ .data = &is_enabled, .system_data_idx = enable_erd_idx };
+            on_enable_change(self, &init_data, system_data);
+        }
+
+        pub fn init(
+            self: *Self,
+            system_data: *SystemDataType,
+            timer_module: *TimerModule,
+            comptime enable_erd: SystemDataType.ErdEnumType,
+            comptime output_erd: SystemDataType.ErdEnumType,
+        ) void {
+            comptime {
+                std.debug.assert(SystemDataType.erd_from_enum(enable_erd).T == bool);
+                std.debug.assert(SystemDataType.erd_from_enum(output_erd).T == StatMeasurement);
+            }
+
+            system_data.subscribe(enable_erd, self, on_enable_change);
+
+            self.inner_init(
+                system_data,
+                timer_module,
+                SystemDataType.erd_from_enum(enable_erd).system_data_idx,
+                SystemDataType.erd_from_enum(output_erd).system_data_idx,
+            );
+        }
     };
-    self.system_data.runtime_write(self.output_erd_idx, &updated_stats);
-
-    self.current_throughput = 0;
-    self.highest_latency_this_tick = 0;
 }
 
-fn measure_throughput(ctx: ?*anyopaque, timer_module: *TimerModule, _: *Timer) void {
-    const self: *TimerModuleStats = @ptrCast(@alignCast(ctx));
+const SystemDataTestDouble = @import("../testing.zig");
 
-    self.current_throughput += 1;
-    const latency = timer_module.ticks_since_last_started(&self.throughput_timer);
-    self.highest_latency_this_tick = @max(latency, self.highest_latency_this_tick);
-}
-
-fn on_enable_change(ctx: ?*anyopaque, _args: ?*const anyopaque, publisher: *anyopaque) void {
-    const args: *const SystemData.OnChangeArgs = @ptrCast(@alignCast(_args.?));
-    var system_data: *SystemData = @ptrCast(@alignCast(publisher));
-    const self: *TimerModuleStats = @ptrCast(@alignCast(ctx));
-    const is_enabled: *const bool = @ptrCast(args.data);
-
-    if (is_enabled.*) {
-        self.current_throughput = 0;
-        self.highest_latency_this_tick = 0;
-
-        const clear_stats = std.mem.zeroes(StatMeasurement);
-        system_data.runtime_write(self.output_erd_idx, &clear_stats);
-
-        self.timer_module.start_periodic(&self.throughput_timer, 0, self, measure_throughput);
-        self.timer_module.start_periodic(&self.save_measurement_timer, 1, self, save_measurement);
-    } else {
-        self.timer_module.stop(&self.throughput_timer);
-        self.timer_module.stop(&self.save_measurement_timer);
-    }
-}
-
-// TODO: runtime_subscribe
-// Inner init is here to make an attempt at forcing call-sites to not inline all of this code.
-// It feels more likely because of the `comptime` arguments.
-fn inner_init(
-    self: *TimerModuleStats,
-    system_data: *SystemData,
-    timer_module: *TimerModule,
-    enable_erd_idx: u16,
-    output_erd_idx: u16,
-) void {
-    self.system_data = system_data;
-    self.timer_module = timer_module;
-    self.enable_erd_idx = enable_erd_idx;
-    self.output_erd_idx = output_erd_idx;
-
-    var is_enabled: bool = undefined;
-    system_data.runtime_read(enable_erd_idx, &is_enabled);
-
-    const init_data: SystemData.OnChangeArgs = .{ .data = &is_enabled, .system_data_idx = enable_erd_idx };
-    on_enable_change(self, &init_data, system_data);
-}
-
-pub fn init(
-    self: *TimerModuleStats,
-    system_data: *SystemData,
-    timer_module: *TimerModule,
-    comptime enable_erd: SystemErds.ErdEnum,
-    comptime output_erd: SystemErds.ErdEnum,
-) void {
-    comptime {
-        std.debug.assert(SystemErds.erd_from_enum(enable_erd).T == bool);
-        std.debug.assert(SystemErds.erd_from_enum(output_erd).T == StatMeasurement);
-    }
-
-    system_data.subscribe(enable_erd, self, on_enable_change);
-
-    self.inner_init(
-        system_data,
-        timer_module,
-        SystemErds.erd_from_enum(enable_erd).system_data_idx,
-        SystemErds.erd_from_enum(output_erd).system_data_idx,
-    );
-}
+const TestSystem = SystemDataTestDouble.create(struct {
+    enable: SystemDataTestDouble.Erd = SystemDataTestDouble.ramErd(bool, .{ .subs = 1 }),
+    stats: SystemDataTestDouble.Erd = SystemDataTestDouble.ramErd(StatMeasurement, .{}),
+});
+const TestSystemData = TestSystem.SystemData;
+const TestTimerModuleStats = TimerModuleStats(TestSystemData);
 
 test "does nothing if disabled" {
-    var system_data: SystemData = App.init();
+    var system_data: TestSystemData = TestSystem.init();
     var timer_module: TimerModule = .{};
-    var instance: TimerModuleStats = undefined;
+    var instance: TestTimerModuleStats = undefined;
 
-    instance.init(&system_data, &timer_module, .erd_some_bool, .erd_timer_stats);
+    instance.init(&system_data, &timer_module, .enable, .stats);
     timer_module.increment_current_time(1);
     try std.testing.expect(!timer_module.run());
 }
 
 test "stats are initialized to zero if enabled" {
-    var system_data: SystemData = App.init();
+    var system_data: TestSystemData = TestSystem.init();
     var timer_module: TimerModule = .{};
-    var instance: TimerModuleStats = undefined;
+    var instance: TestTimerModuleStats = undefined;
 
     const initial_stats: StatMeasurement = .{ .average_latency = 5, .average_throughput_per_tick = 3, .maximum_latency = 1, .maximum_throughput_per_tick = 11 };
-    system_data.write(.erd_timer_stats, initial_stats);
-    instance.init(&system_data, &timer_module, .erd_some_bool, .erd_timer_stats);
+    system_data.write(.stats, initial_stats);
+    instance.init(&system_data, &timer_module, .enable, .stats);
 
-    try std.testing.expectEqual(initial_stats, system_data.read(.erd_timer_stats));
-    system_data.write(.erd_some_bool, true);
-    try std.testing.expectEqual(std.mem.zeroes(StatMeasurement), system_data.read(.erd_timer_stats));
+    try std.testing.expectEqual(initial_stats, system_data.read(.stats));
+    system_data.write(.enable, true);
+    try std.testing.expectEqual(std.mem.zeroes(StatMeasurement), system_data.read(.stats));
 }
 
 test "throughput is measured" {
-    var system_data: SystemData = App.init();
+    var system_data: TestSystemData = TestSystem.init();
     var timer_module: TimerModule = .{};
-    var instance: TimerModuleStats = undefined;
+    var instance: TestTimerModuleStats = undefined;
 
-    system_data.write(.erd_some_bool, true);
-    instance.init(&system_data, &timer_module, .erd_some_bool, .erd_timer_stats);
+    system_data.write(.enable, true);
+    instance.init(&system_data, &timer_module, .enable, .stats);
 
     for (0..99) |_| {
         try std.testing.expect(timer_module.run());
     }
-    try std.testing.expectEqual(std.mem.zeroes(StatMeasurement), system_data.read(.erd_timer_stats));
+    try std.testing.expectEqual(std.mem.zeroes(StatMeasurement), system_data.read(.stats));
 
     timer_module.increment_current_time(1);
     try std.testing.expect(timer_module.run());
-    try std.testing.expectEqual(std.mem.zeroes(StatMeasurement), system_data.read(.erd_timer_stats));
+    try std.testing.expectEqual(std.mem.zeroes(StatMeasurement), system_data.read(.stats));
 
     try std.testing.expect(timer_module.run());
-    try std.testing.expectEqual(50, system_data.read(.erd_timer_stats).average_throughput_per_tick);
-    try std.testing.expectEqual(100, system_data.read(.erd_timer_stats).maximum_throughput_per_tick);
+    try std.testing.expectEqual(50, system_data.read(.stats).average_throughput_per_tick);
+    try std.testing.expectEqual(100, system_data.read(.stats).maximum_throughput_per_tick);
 
     for (0..98) |_| {
         try std.testing.expect(timer_module.run());
@@ -179,8 +186,8 @@ test "throughput is measured" {
     timer_module.increment_current_time(1);
     try std.testing.expect(timer_module.run());
     try std.testing.expect(timer_module.run());
-    try std.testing.expectEqual(74, system_data.read(.erd_timer_stats).average_throughput_per_tick);
-    try std.testing.expectEqual(100, system_data.read(.erd_timer_stats).maximum_throughput_per_tick);
+    try std.testing.expectEqual(74, system_data.read(.stats).average_throughput_per_tick);
+    try std.testing.expectEqual(100, system_data.read(.stats).maximum_throughput_per_tick);
 
     for (0..100) |_| {
         try std.testing.expect(timer_module.run());
@@ -189,55 +196,55 @@ test "throughput is measured" {
     timer_module.increment_current_time(1);
     try std.testing.expect(timer_module.run());
     try std.testing.expect(timer_module.run());
-    try std.testing.expectEqual(87, system_data.read(.erd_timer_stats).average_throughput_per_tick);
-    try std.testing.expectEqual(101, system_data.read(.erd_timer_stats).maximum_throughput_per_tick);
+    try std.testing.expectEqual(87, system_data.read(.stats).average_throughput_per_tick);
+    try std.testing.expectEqual(101, system_data.read(.stats).maximum_throughput_per_tick);
 }
 
 test "latency is measured" {
-    var system_data: SystemData = App.init();
+    var system_data: TestSystemData = TestSystem.init();
     var timer_module: TimerModule = .{};
-    var instance: TimerModuleStats = undefined;
+    var instance: TestTimerModuleStats = undefined;
 
-    system_data.write(.erd_some_bool, true);
-    instance.init(&system_data, &timer_module, .erd_some_bool, .erd_timer_stats);
+    system_data.write(.enable, true);
+    instance.init(&system_data, &timer_module, .enable, .stats);
 
-    try std.testing.expectEqual(std.mem.zeroes(StatMeasurement), system_data.read(.erd_timer_stats));
+    try std.testing.expectEqual(std.mem.zeroes(StatMeasurement), system_data.read(.stats));
 
     for (0..10) |_| {
         timer_module.increment_current_time(1);
         try std.testing.expect(timer_module.run());
         try std.testing.expect(timer_module.run());
-        try std.testing.expectEqual(0, system_data.read(.erd_timer_stats).average_latency);
-        try std.testing.expectEqual(1, system_data.read(.erd_timer_stats).maximum_latency);
+        try std.testing.expectEqual(0, system_data.read(.stats).average_latency);
+        try std.testing.expectEqual(1, system_data.read(.stats).maximum_latency);
     }
 
     timer_module.increment_current_time(10);
     try std.testing.expect(timer_module.run());
     try std.testing.expect(timer_module.run());
-    try std.testing.expectEqual(5, system_data.read(.erd_timer_stats).average_latency);
-    try std.testing.expectEqual(10, system_data.read(.erd_timer_stats).maximum_latency);
+    try std.testing.expectEqual(5, system_data.read(.stats).average_latency);
+    try std.testing.expectEqual(10, system_data.read(.stats).maximum_latency);
 
     timer_module.increment_current_time(10);
     try std.testing.expect(timer_module.run());
     try std.testing.expect(timer_module.run());
-    try std.testing.expectEqual(7, system_data.read(.erd_timer_stats).average_latency);
-    try std.testing.expectEqual(10, system_data.read(.erd_timer_stats).maximum_latency);
+    try std.testing.expectEqual(7, system_data.read(.stats).average_latency);
+    try std.testing.expectEqual(10, system_data.read(.stats).maximum_latency);
 
     timer_module.increment_current_time(10);
     try std.testing.expect(timer_module.run());
     try std.testing.expect(timer_module.run());
-    try std.testing.expectEqual(8, system_data.read(.erd_timer_stats).average_latency);
-    try std.testing.expectEqual(10, system_data.read(.erd_timer_stats).maximum_latency);
+    try std.testing.expectEqual(8, system_data.read(.stats).average_latency);
+    try std.testing.expectEqual(10, system_data.read(.stats).maximum_latency);
 
     timer_module.increment_current_time(10);
     try std.testing.expect(timer_module.run());
     try std.testing.expect(timer_module.run());
-    try std.testing.expectEqual(9, system_data.read(.erd_timer_stats).average_latency);
-    try std.testing.expectEqual(10, system_data.read(.erd_timer_stats).maximum_latency);
+    try std.testing.expectEqual(9, system_data.read(.stats).average_latency);
+    try std.testing.expectEqual(10, system_data.read(.stats).maximum_latency);
 
     timer_module.increment_current_time(10);
     try std.testing.expect(timer_module.run());
     try std.testing.expect(timer_module.run());
-    try std.testing.expectEqual(9, system_data.read(.erd_timer_stats).average_latency);
-    try std.testing.expectEqual(10, system_data.read(.erd_timer_stats).maximum_latency);
+    try std.testing.expectEqual(9, system_data.read(.stats).average_latency);
+    try std.testing.expectEqual(10, system_data.read(.stats).maximum_latency);
 }

--- a/src/common/timer_stats.zig
+++ b/src/common/timer_stats.zig
@@ -10,7 +10,8 @@
 //! `maximum_latency` = 1
 
 const std = @import("std");
-const SystemData = @import("../system_data.zig");
+const App = @import("../app.zig");
+const SystemData = App.SystemData;
 const SystemErds = @import("../system_erds.zig");
 const Erd = @import("../erd.zig");
 const timer = @import("../timer.zig");
@@ -127,7 +128,7 @@ pub fn init(
 }
 
 test "does nothing if disabled" {
-    var system_data: SystemData = .init();
+    var system_data: SystemData = App.init();
     var timer_module: TimerModule = .{};
     var instance: TimerModuleStats = undefined;
 
@@ -137,7 +138,7 @@ test "does nothing if disabled" {
 }
 
 test "stats are initialized to zero if enabled" {
-    var system_data: SystemData = .init();
+    var system_data: SystemData = App.init();
     var timer_module: TimerModule = .{};
     var instance: TimerModuleStats = undefined;
 
@@ -151,7 +152,7 @@ test "stats are initialized to zero if enabled" {
 }
 
 test "throughput is measured" {
-    var system_data: SystemData = .init();
+    var system_data: SystemData = App.init();
     var timer_module: TimerModule = .{};
     var instance: TimerModuleStats = undefined;
 
@@ -193,7 +194,7 @@ test "throughput is measured" {
 }
 
 test "latency is measured" {
-    var system_data: SystemData = .init();
+    var system_data: SystemData = App.init();
     var timer_module: TimerModule = .{};
     var instance: TimerModuleStats = undefined;
 

--- a/src/erd.zig
+++ b/src/erd.zig
@@ -4,33 +4,26 @@
 
 const std = @import("std");
 const Erd = @This();
-const ErdDefinitions = @import("system_erds.zig").ErdDefinitions;
 
 /// This is an optional public handle for an ERD.
 /// Without this, the ERD will not appear in the generated ERD JSON.
 erd_number: ?ErdHandle,
 /// Type of the ERD
 T: type,
-/// Owning Data Component
-owner: ErdOwner,
+/// Index of the owning data component in the Components struct
+component_idx: comptime_int,
 /// The number of subscription slots that are available
 subs: comptime_int,
 /// The relative index of the ERD in its data component
 data_component_idx: comptime_int = undefined,
 /// The relative index of the ERD in the aggregate system data.
 /// This field is sufficient for runtime ERD read/write/subscriptions.
-/// Performance is negatively affected due to constant-time lookups of `owner` and `data_component_idx`
+/// Performance is negatively affected due to constant-time lookups of `component_idx` and `data_component_idx`
 /// however this allows for enforcing a small code footprint
 system_data_idx: u16 = undefined,
 
 /// ERD identifier, allows for ERDs to be referenced externally
 pub const ErdHandle = u16; // TODO: Evaluate if this should be an non-exhaustive enum `ErdHandle = enum { _ };`
-
-// TODO: Consider moving this into system_data.zig
-pub const ErdOwner = enum {
-    Ram,
-    Indirect,
-};
 
 /// Allows ERDs to be printed as `0xXXXX`
 pub fn format(self: *const Erd, writer: *std.io.Writer) !void {
@@ -38,27 +31,5 @@ pub fn format(self: *const Erd, writer: *std.io.Writer) !void {
         return try writer.print("0x{x:0>4}", .{number});
     } else {
         @panic("Can't format erds with null number");
-    }
-}
-
-/// Allows ERDs to be directly transformed into JSON
-pub fn jsonStringify(comptime self: Erd, jws: anytype) !void {
-    if (self.erd_number != null) {
-        const erd_names = comptime std.meta.fieldNames(ErdDefinitions);
-
-        try jws.beginObject();
-        try jws.objectField("name");
-        try jws.write(erd_names[self.system_data_idx]);
-        try jws.objectField("id");
-        try jws.print("\"{f}\"", .{self});
-        try jws.objectField("type");
-        // TODO: Convert the type into type info consumable by external tools, rather than just a type name,
-        // Consider: https://jsontypedef.com/ ?
-        //
-        // try serialize_type(self.T, jws);
-        try jws.print("\"{}\"", .{self.T});
-        try jws.endObject();
-    } else {
-        @panic("Programmer error, ERDs with null erd_number should not be serialized!!!");
     }
 }

--- a/src/indirect_data_component.zig
+++ b/src/indirect_data_component.zig
@@ -4,59 +4,58 @@
 
 const std = @import("std");
 const Erd = @import("erd.zig");
-const SystemErds = @import("system_erds.zig");
 
-const IndirectDataComponent = @This();
+pub fn IndirectDataComponent(comptime erds: []const Erd) type {
+    return struct {
+        const Self = @This();
 
-const num_indirect_erds = SystemErds.indirect_definitions.len;
+        pub const component_erds = erds;
+        pub const supports_write = false;
 
-read_functions: [num_indirect_erds](*const anyopaque) = undefined,
+        read_functions: [erds.len](*const anyopaque) = undefined,
 
-pub const IndirectErdMapping = struct {
-    erd: Erd,
-    fn_ptr: *const anyopaque,
+        pub const IndirectErdMapping = struct {
+            erd: Erd,
+            fn_ptr: *const anyopaque,
 
-    /// Compile-time guarantees a valid mapping
-    pub fn map(comptime erd_enum: SystemErds.ErdEnum, func: *const fn (*SystemErds.erd_from_enum(erd_enum).T) void) IndirectErdMapping {
-        const erd: Erd = SystemErds.erd_from_enum(erd_enum);
-        return .{ .erd = erd, .fn_ptr = func };
-    }
-};
+            pub fn map(comptime erd: Erd, func: *const fn (*erd.T) void) IndirectErdMapping {
+                return .{ .erd = erd, .fn_ptr = func };
+            }
+        };
 
-pub fn init(erdMappings: [num_indirect_erds]IndirectErdMapping) IndirectDataComponent {
-    var indirect_data_component = IndirectDataComponent{};
+        pub fn init(erdMappings: [erds.len]IndirectErdMapping) Self {
+            var indirect_data_component = Self{};
 
-    inline for (erdMappings) |mapping| {
-        comptime {
-            std.debug.assert(mapping.erd.owner == .Indirect);
+            inline for (erdMappings) |mapping| {
+                indirect_data_component.read_functions[mapping.erd.data_component_idx] = mapping.fn_ptr;
+            }
+            return indirect_data_component;
         }
-        indirect_data_component.read_functions[mapping.erd.data_component_idx] = mapping.fn_ptr;
-    }
-    return indirect_data_component;
-}
 
-pub fn read(self: IndirectDataComponent, erd: Erd) erd.T {
-    const fn_ptr: *const fn (*erd.T) void = @ptrCast(self.read_functions[erd.data_component_idx]);
+        pub fn read(self: Self, erd: Erd) erd.T {
+            const fn_ptr: *const fn (*erd.T) void = @ptrCast(self.read_functions[erd.data_component_idx]);
 
-    var temp: erd.T = undefined;
-    fn_ptr(&temp);
-    return temp;
-}
+            var temp: erd.T = undefined;
+            fn_ptr(&temp);
+            return temp;
+        }
 
-pub fn runtime_read(self: IndirectDataComponent, data_component_idx: u16, data: *anyopaque) void {
-    const fn_ptr: *const fn ([*]u8) void = @ptrCast(self.read_functions[data_component_idx]);
-    fn_ptr(@ptrCast(data));
-}
+        pub fn runtime_read(self: Self, data_component_idx: u16, data: *anyopaque) void {
+            const fn_ptr: *const fn ([*]u8) void = @ptrCast(self.read_functions[data_component_idx]);
+            fn_ptr(@ptrCast(data));
+        }
 
-pub fn write(self: *IndirectDataComponent, erd: Erd, data: erd.T) bool {
-    _ = self;
-    _ = data;
-    @compileError("Indirect ERD writes are not allowed");
-}
+        pub fn write(self: *Self, erd: Erd, data: erd.T) bool {
+            _ = self;
+            _ = data;
+            @compileError("Indirect ERD writes are not allowed");
+        }
 
-pub fn runtime_write(self: *IndirectDataComponent, data_component_idx: u16, data: *const anyopaque) bool {
-    _ = self;
-    _ = data_component_idx;
-    _ = data;
-    @compileError("Indirect ERD writes are not allowed");
+        pub fn runtime_write(self: *Self, data_component_idx: u16, data: *const anyopaque) bool {
+            _ = self;
+            _ = data_component_idx;
+            _ = data;
+            @compileError("Indirect ERD writes are not allowed");
+        }
+    };
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -1,6 +1,4 @@
 const std = @import("std");
-const SystemData = @import("system_data.zig");
-const SystemErds = @import("system_erds.zig");
 const ErdJson = @import("erd_json.zig");
 
 pub fn main() !void {

--- a/src/ram_data_component.zig
+++ b/src/ram_data_component.zig
@@ -4,116 +4,121 @@
 
 const std = @import("std");
 const Erd = @import("erd.zig");
-const SystemErds = @import("system_erds.zig");
 
-const RamDataComponent = @This();
+pub fn RamDataComponent(comptime erds: []const Erd) type {
+    return struct {
+        const Self = @This();
 
-// TODO: Add a flag that reorders fields to efficiently pack this
-// and another that guarantees alignment for faster R/W.
-storage: [store_size()]u8 align(@alignOf(usize)) = undefined,
+        pub const component_erds = erds;
+        pub const supports_write = true;
 
-pub fn init() RamDataComponent {
-    var ram_data_component = RamDataComponent{};
-    @memset(ram_data_component.storage[0..], 0);
-    return ram_data_component;
+        // TODO: Add a flag that reorders fields to efficiently pack this
+        // and another that guarantees alignment for faster R/W.
+        storage: [store_size()]u8 align(@alignOf(usize)) = undefined,
+
+        pub fn init() Self {
+            var ram_data_component = Self{};
+            @memset(ram_data_component.storage[0..], 0);
+            return ram_data_component;
+        }
+
+        const ram_offsets = blk: {
+            var _ram_offsets: [erds.len]usize = undefined;
+            var cur_offset = 0;
+            for (erds, 0..) |erd, i| {
+                _ram_offsets[i] = cur_offset;
+                cur_offset += @sizeOf(erd.T);
+            }
+
+            break :blk _ram_offsets;
+        };
+        const data_size: [erds.len]u16 = blk: {
+            var _data_size: [erds.len]u16 = undefined;
+
+            for (erds, 0..) |erd, i| {
+                _data_size[i] = @sizeOf(erd.T);
+            }
+
+            break :blk _data_size;
+        };
+
+        fn store_size() usize {
+            var size: usize = 0;
+            for (erds) |erd| {
+                size += @sizeOf(erd.T);
+            }
+            return size;
+        }
+
+        pub fn read(self: Self, erd: Erd) erd.T {
+            const idx = erd.data_component_idx;
+
+            var value: erd.T = undefined;
+            @memcpy(std.mem.asBytes(&value), self.storage[ram_offsets[idx] .. ram_offsets[idx] + @sizeOf(erd.T)]);
+            return value;
+        }
+
+        pub fn runtime_read(self: Self, data_component_idx: u16, data: *anyopaque) void {
+            var data_slice: [*]u8 = @ptrCast(data);
+            const size = data_size[data_component_idx];
+
+            @memcpy(data_slice[0..size], self.storage[ram_offsets[data_component_idx] .. ram_offsets[data_component_idx] + size]);
+        }
+
+        pub fn write(self: *Self, erd: Erd, data: erd.T) bool {
+            const idx = erd.data_component_idx;
+
+            const data_bytes = std.mem.toBytes(data);
+
+            const data_changed = !std.mem.eql(u8, &data_bytes, self.storage[ram_offsets[idx] .. ram_offsets[idx] + @sizeOf(erd.T)]);
+            self.storage[ram_offsets[idx] .. ram_offsets[idx] + @sizeOf(erd.T)].* = data_bytes;
+
+            return data_changed;
+        }
+
+        pub fn runtime_write(self: *Self, data_component_idx: u16, data: *const anyopaque) bool {
+            const idx = data_component_idx;
+
+            var data_slice: [*]const u8 = @ptrCast(data);
+            const size = data_size[data_component_idx];
+
+            const data_changed = !std.mem.eql(u8, data_slice[0..size], self.storage[ram_offsets[idx] .. ram_offsets[idx] + size]);
+
+            @memcpy(self.storage[ram_offsets[idx] .. ram_offsets[idx] + size], data_slice[0..size]);
+
+            return data_changed;
+        }
+
+        // TODO: This is a neat way of gaining automatic optimized alignment, but MAN
+        //       it sucks for actually accessing fields, particularly using runtime info
+        //       see if it can eventually be used?
+        // const ram_fields: [erds.len]std.builtin.Type.StructField = blk: {
+        //     var _fields: [erds.len]std.builtin.Type.StructField = undefined;
+        //
+        //     for (erds, 0..) |erd, i| {
+        //         // Fields have the name of "_number"
+        //         const fieldName = std.fmt.comptimePrint("_{}", .{erd.data_component_idx});
+        //         _fields[i] = .{
+        //             .name = fieldName,
+        //             .type = erd.T,
+        //             .default_value_ptr = null,
+        //             .is_comptime = false,
+        //             // Proper alignment is the default. If you want denser memory
+        //             // then set alignment to 1.
+        //             .alignment = 0,
+        //         };
+        //     }
+        //
+        //     break :blk _fields;
+        // };
+        //
+        // const StoreStruct = @Type(.{
+        //     .@"struct" = .{
+        //         .layout = .auto,
+        //         .fields = ram_fields[0..],
+        //         .decls = &[_]std.builtin.Type.Declaration{},
+        //         .is_tuple = false,
+        //     },
+        // });
+    };
 }
-
-const num_ram_erds = SystemErds.ram_definitions.len;
-const ram_offsets = blk: {
-    var _ram_offsets: [num_ram_erds]usize = undefined;
-    var cur_offset = 0;
-    for (SystemErds.ram_definitions, 0..) |erd, i| {
-        _ram_offsets[i] = cur_offset;
-        cur_offset += @sizeOf(erd.T);
-    }
-
-    break :blk _ram_offsets;
-};
-const data_size: [num_ram_erds]u16 = blk: {
-    var _data_size: [num_ram_erds]u16 = undefined;
-
-    for (SystemErds.ram_definitions, 0..) |erd, i| {
-        _data_size[i] = @sizeOf(erd.T);
-    }
-
-    break :blk _data_size;
-};
-
-fn store_size() usize {
-    var size: usize = 0;
-    for (SystemErds.ram_definitions) |erd| {
-        size += @sizeOf(erd.T);
-    }
-    return size;
-}
-
-pub fn read(self: RamDataComponent, erd: Erd) erd.T {
-    const idx = erd.data_component_idx;
-
-    var value: erd.T = undefined;
-    @memcpy(std.mem.asBytes(&value), self.storage[ram_offsets[idx] .. ram_offsets[idx] + @sizeOf(erd.T)]);
-    return value;
-}
-
-pub fn runtime_read(self: RamDataComponent, data_component_idx: u16, data: *anyopaque) void {
-    var data_slice: [*]u8 = @ptrCast(data);
-    const size = data_size[data_component_idx];
-
-    @memcpy(data_slice[0..size], self.storage[ram_offsets[data_component_idx] .. ram_offsets[data_component_idx] + size]);
-}
-
-pub fn write(self: *RamDataComponent, erd: Erd, data: erd.T) bool {
-    const idx = erd.data_component_idx;
-
-    const data_bytes = std.mem.toBytes(data);
-
-    const data_changed = !std.mem.eql(u8, &data_bytes, self.storage[ram_offsets[idx] .. ram_offsets[idx] + @sizeOf(erd.T)]);
-    self.storage[ram_offsets[idx] .. ram_offsets[idx] + @sizeOf(erd.T)].* = data_bytes;
-
-    return data_changed;
-}
-
-pub fn runtime_write(self: *RamDataComponent, data_component_idx: u16, data: *const anyopaque) bool {
-    const idx = data_component_idx;
-
-    var data_slice: [*]const u8 = @ptrCast(data);
-    const size = data_size[data_component_idx];
-
-    const data_changed = !std.mem.eql(u8, data_slice[0..size], self.storage[ram_offsets[idx] .. ram_offsets[idx] + size]);
-
-    @memcpy(self.storage[ram_offsets[idx] .. ram_offsets[idx] + size], data_slice[0..size]);
-
-    return data_changed;
-}
-
-// TODO: This is a neat way of gaining automatic optimized alignment, but MAN
-//       it sucks for actually accessing fields, particularly using runtime info
-//       see if it can eventually be used?
-// const ram_fields: [num_ram_erds]std.builtin.Type.StructField = blk: {
-//     var _fields: [num_ram_erds]std.builtin.Type.StructField = undefined;
-//
-//     for (SystemErds.ram_definitions, 0..) |erd, i| {
-//         // Fields have the name of "_number"
-//         const fieldName = std.fmt.comptimePrint("_{}", .{erd.data_component_idx});
-//         _fields[i] = .{
-//             .name = fieldName,
-//             .type = erd.T,
-//             .default_value_ptr = null,
-//             .is_comptime = false,
-//             // Proper alignment is the default. If you want denser memory
-//             // then set alignment to 1.
-//             .alignment = 0,
-//         };
-//     }
-//
-//     break :blk _fields;
-// };
-//
-// const StoreStruct = @Type(.{
-//     .@"struct" = .{
-//         .layout = .auto,
-//         .fields = ram_fields[0..],
-//         .decls = &[_]std.builtin.Type.Declaration{},
-//         .is_tuple = false,
-//     },
-// });

--- a/src/subscription.zig
+++ b/src/subscription.zig
@@ -6,8 +6,6 @@
 //! `Subscription`s with the same identity cannot be known to the same publisher.
 //! However `Subscription`s with the same identity may subscribe to several source.
 
-const SystemData = @import("system_data.zig");
-
 const Subscription = @This();
 pub const Callback = *const fn (context: ?*anyopaque, args: ?*const anyopaque, publisher: *anyopaque) void;
 

--- a/src/system_data.zig
+++ b/src/system_data.zig
@@ -7,284 +7,309 @@
 
 const std = @import("std");
 const Erd = @import("erd.zig");
-const RamDataComponent = @import("ram_data_component.zig");
-const IndirectDataComponent = @import("indirect_data_component.zig");
-const SystemErds = @import("system_erds.zig");
 const Subscription = @import("subscription.zig");
 
-const SystemData = @This();
-
-/// Published for every on-change event
-pub const OnChangeArgs = struct {
-    system_data_idx: u16,
-    data: *const anyopaque,
-};
-
-ram: RamDataComponent = undefined,
-indirect: IndirectDataComponent = undefined,
-subscriptions: [total_subscriptions()]Subscription = undefined,
-/// This is a bump allocator meant to be reset at the end of a run to complete
-scratch: std.heap.FixedBufferAllocator = undefined,
-scratch_buf: [2048]u8 align(@alignOf(usize)) = undefined, // TODO: Does this actually need to be aligned?
-
-fn total_subscriptions() usize {
+pub fn SystemData(comptime ErdDefs: type, comptime ErdEnum: type, comptime erd_instance: ErdDefs, comptime Components: type) type {
+    // Validate ErdEnum matches ErdDefs fields
     comptime {
-        var size: usize = 0;
-        for (std.meta.fieldNames(SystemErds.ErdDefinitions)) |erd_name| {
-            size += @field(SystemErds.erd, erd_name).subs;
+        const erd_fields = std.meta.fieldNames(ErdDefs);
+        const erd_enum_names = std.meta.fieldNames(ErdEnum);
+        if (erd_fields.len != erd_enum_names.len) {
+            @compileError("ErdEnum field count does not match ErdDefs field count");
         }
-        return size;
-    }
-}
-
-const SystemErdsLength: usize = std.meta.fields(SystemErds.ErdDefinitions).len;
-
-// The size of this is 4*numErds which means this will reach well over 4kB of ROM.
-// TODO: Add the option to binary search and avoid a large chunk of this cost
-const subscription_offsets = blk: {
-    var _offsets: [SystemErdsLength]usize = undefined;
-    var cur_offset = 0;
-
-    for (std.meta.fieldNames(SystemErds.ErdDefinitions), 0..) |erd_name, i| {
-        if (@field(SystemErds.erd, erd_name).subs != 0) {
-            _offsets[i] = cur_offset;
-        }
-        cur_offset += @field(SystemErds.erd, erd_name).subs;
-    }
-    break :blk _offsets;
-};
-
-/// Returns a column from system_erds as an array of type []T
-fn system_erds_collect(T: type, column_name: []const u8) [SystemErdsLength]T {
-    var field_values: [SystemErdsLength]T = undefined;
-    for (std.meta.fieldNames(SystemErds.ErdDefinitions), 0..) |erd_name, i| {
-        field_values[i] = @field(@field(SystemErds.erd, erd_name), column_name);
-    }
-
-    return field_values;
-}
-
-// Create .rodata that is indexed by `system_data_idx`
-const subs_from_idx = system_erds_collect(u8, "subs");
-const owner_from_idx = system_erds_collect(Erd.ErdOwner, "owner");
-const data_component_idx_from_idx = system_erds_collect(u16, "data_component_idx");
-
-fn always_42(data: *u16) void {
-    data.* = 42;
-}
-
-fn plus_one(data: *u16) void {
-    var should_be_42: u16 = undefined;
-    always_42(&should_be_42);
-
-    data.* = should_be_42 + 1;
-}
-
-const indirectErdMapping = [_]IndirectDataComponent.IndirectErdMapping{
-    .map(.erd_always_42, always_42),
-    .map(.erd_another_erd_plus_one, plus_one),
-};
-
-pub fn init() SystemData {
-    var this = SystemData{};
-    this.ram = .init();
-    this.indirect = .init(indirectErdMapping);
-    this.scratch = .init(&this.scratch_buf);
-
-    @memset(&this.subscriptions, Subscription{ .context = null, .callback = null });
-    return this;
-}
-
-/// Read an ERD by-value using comptime information (the `Erd` type)
-/// Due to the performance and code size benefits, this should be preferred over `runtime_read`.
-pub fn read(this: SystemData, comptime erd_enum: SystemErds.ErdEnum) SystemErds.erd_from_enum(erd_enum).T {
-    const erd: Erd = SystemErds.erd_from_enum(erd_enum);
-    switch (erd.owner) {
-        .Ram => return this.ram.read(erd),
-        .Indirect => return this.indirect.read(erd),
-    }
-}
-
-/// Read an ERD into the provided `data` pointer, using the ERD's corresponding system_data_idx
-/// This will be significantly slower than a comptime read, and should only be used sparingly, for example:
-/// - When mapping from an `ErdHandle` to system_data_idx, eg. in response to UART commands
-/// - Reading an ERD using info from an on-change callback
-pub fn runtime_read(this: SystemData, system_data_idx: u16, data: *anyopaque) void {
-    const owner: Erd.ErdOwner = owner_from_idx[system_data_idx];
-    const data_component_idx: u16 = data_component_idx_from_idx[system_data_idx];
-
-    switch (owner) {
-        .Ram => this.ram.runtime_read(data_component_idx, data),
-        .Indirect => this.indirect.runtime_read(data_component_idx, data),
-    }
-}
-
-/// Write to an ERD by-value using comptime information (the `Erd` type)
-/// Due to the performance and code size benefits, this should be preferred over `runtime_write`.
-pub fn write(this: *SystemData, comptime erd_enum: SystemErds.ErdEnum, data: SystemErds.erd_from_enum(erd_enum).T) void {
-    const erd: Erd = SystemErds.erd_from_enum(erd_enum);
-    const publish_required = switch (erd.owner) {
-        .Ram => this.ram.write(erd, data),
-        .Indirect => comptime unreachable,
-    };
-
-    if (publish_required and erd.subs != 0) {
-        this.publish(erd.system_data_idx, &data);
-    }
-}
-
-/// Write to an ERD from the provided `data` pointer, using the ERD's corresponding system_data_idx
-/// This will be significantly slower than a comptime write, and should only be used sparingly, for example:
-/// - When mapping from an `ErdHandle` to system_data_idx, eg. in response to UART commands
-/// - Writing an ERD using info from an on-change callback (common for ERD multiplexers)
-///
-/// NOTE: `data` must be aligned!
-pub fn runtime_write(this: *SystemData, system_data_idx: u16, data: *const anyopaque) void {
-    const publish_required = switch (owner_from_idx[system_data_idx]) {
-        .Ram => this.ram.runtime_write(data_component_idx_from_idx[system_data_idx], data),
-        .Indirect => unreachable,
-    };
-
-    if (publish_required and subs_from_idx[system_data_idx] != 0) {
-        this.publish(system_data_idx, data);
-    }
-}
-
-fn publish(this: *SystemData, system_data_idx: u16, data: *const anyopaque) void {
-    const sub_offset = subscription_offsets[system_data_idx];
-
-    for (this.subscriptions[sub_offset .. sub_offset + subs_from_idx[system_data_idx]]) |_sub| {
-        if (_sub.callback) |_callback| {
-            const args: OnChangeArgs = .{ .system_data_idx = system_data_idx, .data = data };
-            _callback(_sub.context, &args, this);
-        }
-    }
-}
-
-pub fn subscribe(
-    this: *SystemData,
-    comptime erd_enum: SystemErds.ErdEnum,
-    context: ?*anyopaque,
-    fn_ptr: Subscription.Callback,
-) void {
-    const erd: Erd = SystemErds.erd_from_enum(erd_enum);
-    comptime {
-        std.debug.assert(erd.subs > 0);
-        std.debug.assert(erd.owner != .Indirect);
-    }
-    const sub_offset = subscription_offsets[erd.system_data_idx];
-    var first_free_spot: ?*Subscription = null;
-
-    for (this.subscriptions[sub_offset .. sub_offset + erd.subs]) |*_sub| {
-        if (first_free_spot == null and _sub.callback == null) {
-            first_free_spot = _sub;
-        }
-
-        if (_sub.callback == fn_ptr) {
-            // Subscriptions cannot be added to the same list twice
-            return;
-        }
-    }
-
-    // Failed to find an empty spot, over-subscribed
-    if (first_free_spot == null) {
-        // In tests this verifies we aren't subscribing beyond our array length
-        // These names should be stripped out of the binary if a panic handler isn't set.
-        // TODO: Validate this assumption and switch to using something lighter if needed
-        // This is a ROM savings of likely over 10kB on large projects :)
-        const erd_names = comptime std.meta.fieldNames(SystemErds.ErdDefinitions);
-        std.debug.panic("ERD {s} oversubscribed!", .{erd_names[erd.system_data_idx]});
-    }
-
-    first_free_spot.?.context = context;
-    first_free_spot.?.callback = fn_ptr;
-}
-
-pub fn unsubscribe(this: *SystemData, comptime erd_enum: SystemErds.ErdEnum, fn_ptr: Subscription.Callback) void {
-    const erd: Erd = SystemErds.erd_from_enum(erd_enum);
-    comptime {
-        std.debug.assert(erd.subs > 0);
-        // We know you can't sub/unsub to these:
-        std.debug.assert(erd.owner != .Indirect);
-    }
-
-    const sub_offset = subscription_offsets[erd.system_data_idx];
-
-    for (this.subscriptions[sub_offset .. sub_offset + erd.subs]) |*_sub| {
-        if (_sub.callback == fn_ptr) {
-            _sub.callback = null;
-            return;
-        }
-    }
-}
-
-/// Returns a slice allocated to the scratch buffer.
-pub fn scratch_alloc(this: *SystemData, comptime T: type, n: usize) []T {
-    return this.scratch.allocator().alloc(T, n) catch @panic("We ran out of scratch memory!!!");
-}
-
-/// Call this at the end of a run to complete in your main-loop
-pub fn scratch_reset(this: *SystemData) void {
-    this.scratch.reset();
-}
-
-/// A test only type used with verify_all_subs_are_saturated
-pub const SubException = struct { erd_enum: SystemErds.ErdEnum, missing: comptime_int };
-
-/// A test only function used to verify that after initialization, all of your subscriptions arrays are fully saturated
-pub fn verify_all_subs_are_saturated(this: *SystemData, comptime exceptions: []const SubException) !void {
-    var failed = false;
-
-    inline for (exceptions) |e| {
-        const erd_name = @tagName(e.erd_enum);
-        const num_subs = @field(SystemErds.erd, erd_name).subs;
-        if (num_subs == 0) {
-            std.log.warn("Remove {s} from exceptions list since subscriptions are disabled for it", .{erd_name});
-            failed = true;
-        }
-    }
-
-    if (failed) {
-        return error.ErdWithNoSubsInExceptions;
-    }
-
-    inline for (std.meta.fields(SystemErds.ErdDefinitions), 0..) |field_info, i| {
-        const erd_name = field_info.name;
-        const sub_offset = subscription_offsets[i];
-        const num_subs = @field(SystemErds.erd, erd_name).subs;
-
-        if (num_subs == 0) {
-            continue;
-        }
-
-        const expected_count = blk: {
-            comptime var _expected = num_subs;
-            inline for (exceptions) |e| {
-                if (comptime std.mem.eql(u8, @tagName(e.erd_enum), erd_name)) {
-                    _expected = num_subs - e.missing;
-                    break :blk _expected;
-                }
+        for (erd_fields, erd_enum_names) |field_name, enum_name| {
+            if (!std.mem.eql(u8, field_name, enum_name)) {
+                @compileError(std.fmt.comptimePrint("ErdDefs field {s} does not match ErdEnum variant {s}", .{ field_name, enum_name }));
             }
-            break :blk _expected;
+        }
+    }
+
+    const component_fields = std.meta.fields(Components);
+    const SystemErdsLength: usize = std.meta.fields(ErdDefs).len;
+
+    return struct {
+        const Self = @This();
+
+        /// Published for every on-change event
+        pub const OnChangeArgs = struct {
+            system_data_idx: u16,
+            data: *const anyopaque,
         };
 
-        var actual_count: u16 = 0;
-        for (this.subscriptions[sub_offset .. sub_offset + num_subs]) |_sub| {
-            if (_sub.callback != null) {
-                actual_count += 1;
+        /// A test only type used with verify_all_subs_are_saturated
+        pub const SubException = struct { erd_enum: ErdEnum, missing: comptime_int };
+
+        components: Components = undefined,
+        subscriptions: [total_subscriptions()]Subscription = undefined,
+        /// This is a bump allocator meant to be reset at the end of a run to complete
+        scratch: std.heap.FixedBufferAllocator = undefined,
+        scratch_buf: [2048]u8 align(@alignOf(usize)) = undefined, // TODO: Does this actually need to be aligned?
+
+        fn total_subscriptions() usize {
+            comptime {
+                var size: usize = 0;
+                for (std.meta.fieldNames(ErdDefs)) |erd_name| {
+                    size += @field(erd_instance, erd_name).subs;
+                }
+                return size;
             }
         }
 
-        if (actual_count < expected_count) {
-            std.log.warn("ERD: {s} is under-subscribing after init. Decrease subs, or increase missing.", .{erd_name});
-            failed = true;
-        } else if (actual_count > expected_count) {
-            std.log.warn("ERD: {s} is over-subscribed after init. Increase subs or decrease missing.", .{erd_name});
-            failed = true;
-        }
-    }
+        // The size of this is 4*numErds which means this will reach well over 4kB of ROM.
+        // TODO: Add the option to binary search and avoid a large chunk of this cost
+        const subscription_offsets = blk: {
+            var _offsets: [SystemErdsLength]usize = undefined;
+            var cur_offset = 0;
 
-    if (failed) {
-        return error.ErdWithUnexpectedSubCount;
-    }
+            for (std.meta.fieldNames(ErdDefs), 0..) |erd_name, i| {
+                if (@field(erd_instance, erd_name).subs != 0) {
+                    _offsets[i] = cur_offset;
+                }
+                cur_offset += @field(erd_instance, erd_name).subs;
+            }
+            break :blk _offsets;
+        };
+
+        /// Returns a column from erd_instance as an array of type []T
+        fn erd_collect(T: type, column_name: []const u8) [SystemErdsLength]T {
+            var field_values: [SystemErdsLength]T = undefined;
+            for (std.meta.fieldNames(ErdDefs), 0..) |erd_name, i| {
+                field_values[i] = @field(@field(erd_instance, erd_name), column_name);
+            }
+
+            return field_values;
+        }
+
+        // Create .rodata that is indexed by `system_data_idx`
+        const subs_from_idx = erd_collect(u8, "subs");
+        const component_idx_from_system_idx = erd_collect(u8, "component_idx");
+        const data_component_idx_from_system_idx = erd_collect(u16, "data_component_idx");
+
+        const supports_write_from_component_idx: [component_fields.len]bool = blk: {
+            var result: [component_fields.len]bool = undefined;
+            for (component_fields, 0..) |field, i| {
+                result[i] = field.type.supports_write;
+            }
+            break :blk result;
+        };
+
+        pub const ErdEnumType = ErdEnum;
+
+        pub fn erd_from_enum_pub(comptime erd_enum: ErdEnum) Erd {
+            return erd_from_enum(erd_enum);
+        }
+
+        fn erd_from_enum(comptime erd_enum: ErdEnum) Erd {
+            return @field(erd_instance, @tagName(erd_enum));
+        }
+
+        /// Read an ERD by-value using comptime information (the `Erd` type)
+        /// Due to the performance and code size benefits, this should be preferred over `runtime_read`.
+        pub fn read(this: Self, comptime erd_enum: ErdEnum) erd_from_enum(erd_enum).T {
+            const erd: Erd = erd_from_enum(erd_enum);
+            inline for (component_fields, 0..) |field, i| {
+                if (erd.component_idx == i) {
+                    return @field(this.components, field.name).read(erd);
+                }
+            }
+            unreachable;
+        }
+
+        /// Read an ERD into the provided `data` pointer, using the ERD's corresponding system_data_idx
+        /// This will be significantly slower than a comptime read, and should only be used sparingly, for example:
+        /// - When mapping from an `ErdHandle` to system_data_idx, eg. in response to UART commands
+        /// - Reading an ERD using info from an on-change callback
+        pub fn runtime_read(this: Self, system_data_idx: u16, data: *anyopaque) void {
+            const component_idx = component_idx_from_system_idx[system_data_idx];
+            const data_component_idx = data_component_idx_from_system_idx[system_data_idx];
+
+            inline for (component_fields, 0..) |field, i| {
+                if (component_idx == i) {
+                    @field(this.components, field.name).runtime_read(data_component_idx, data);
+                    return;
+                }
+            }
+        }
+
+        /// Write to an ERD by-value using comptime information (the `Erd` type)
+        /// Due to the performance and code size benefits, this should be preferred over `runtime_write`.
+        pub fn write(this: *Self, comptime erd_enum: ErdEnum, data: erd_from_enum(erd_enum).T) void {
+            const erd: Erd = erd_from_enum(erd_enum);
+
+            comptime {
+                if (!supports_write_from_component_idx[erd.component_idx]) {
+                    @compileError("This ERD's data component does not support writes");
+                }
+            }
+
+            const publish_required = inline for (component_fields, 0..) |field, i| {
+                if (erd.component_idx == i) {
+                    break @field(this.components, field.name).write(erd, data);
+                }
+            } else unreachable;
+
+            if (publish_required and erd.subs != 0) {
+                this.publish(erd.system_data_idx, &data);
+            }
+        }
+
+        /// Write to an ERD from the provided `data` pointer, using the ERD's corresponding system_data_idx
+        /// This will be significantly slower than a comptime write, and should only be used sparingly, for example:
+        /// - When mapping from an `ErdHandle` to system_data_idx, eg. in response to UART commands
+        /// - Writing an ERD using info from an on-change callback (common for ERD multiplexers)
+        ///
+        /// NOTE: `data` must be aligned!
+        pub fn runtime_write(this: *Self, system_data_idx: u16, data: *const anyopaque) void {
+            const component_idx = component_idx_from_system_idx[system_data_idx];
+            const data_component_idx = data_component_idx_from_system_idx[system_data_idx];
+
+            const publish_required = inline for (component_fields, 0..) |field, i| {
+                if (component_idx == i) {
+                    if (!supports_write_from_component_idx[i]) {
+                        unreachable;
+                    }
+                    break @field(this.components, field.name).runtime_write(data_component_idx, data);
+                }
+            } else unreachable;
+
+            if (publish_required and subs_from_idx[system_data_idx] != 0) {
+                this.publish(system_data_idx, data);
+            }
+        }
+
+        fn publish(this: *Self, system_data_idx: u16, data: *const anyopaque) void {
+            const sub_offset = subscription_offsets[system_data_idx];
+
+            for (this.subscriptions[sub_offset .. sub_offset + subs_from_idx[system_data_idx]]) |_sub| {
+                if (_sub.callback) |_callback| {
+                    const args: OnChangeArgs = .{ .system_data_idx = system_data_idx, .data = data };
+                    _callback(_sub.context, &args, this);
+                }
+            }
+        }
+
+        pub fn subscribe(
+            this: *Self,
+            comptime erd_enum: ErdEnum,
+            context: ?*anyopaque,
+            fn_ptr: Subscription.Callback,
+        ) void {
+            const erd: Erd = erd_from_enum(erd_enum);
+            comptime {
+                std.debug.assert(erd.subs > 0);
+                std.debug.assert(supports_write_from_component_idx[erd.component_idx]);
+            }
+            const sub_offset = subscription_offsets[erd.system_data_idx];
+            var first_free_spot: ?*Subscription = null;
+
+            for (this.subscriptions[sub_offset .. sub_offset + erd.subs]) |*_sub| {
+                if (first_free_spot == null and _sub.callback == null) {
+                    first_free_spot = _sub;
+                }
+
+                if (_sub.callback == fn_ptr) {
+                    // Subscriptions cannot be added to the same list twice
+                    return;
+                }
+            }
+
+            // Failed to find an empty spot, over-subscribed
+            if (first_free_spot == null) {
+                // In tests this verifies we aren't subscribing beyond our array length
+                // These names should be stripped out of the binary if a panic handler isn't set.
+                // TODO: Validate this assumption and switch to using something lighter if needed
+                // This is a ROM savings of likely over 10kB on large projects :)
+                const erd_names = comptime std.meta.fieldNames(ErdDefs);
+                std.debug.panic("ERD {s} oversubscribed!", .{erd_names[erd.system_data_idx]});
+            }
+
+            first_free_spot.?.context = context;
+            first_free_spot.?.callback = fn_ptr;
+        }
+
+        pub fn unsubscribe(this: *Self, comptime erd_enum: ErdEnum, fn_ptr: Subscription.Callback) void {
+            const erd: Erd = erd_from_enum(erd_enum);
+            comptime {
+                std.debug.assert(erd.subs > 0);
+                std.debug.assert(supports_write_from_component_idx[erd.component_idx]);
+            }
+
+            const sub_offset = subscription_offsets[erd.system_data_idx];
+
+            for (this.subscriptions[sub_offset .. sub_offset + erd.subs]) |*_sub| {
+                if (_sub.callback == fn_ptr) {
+                    _sub.callback = null;
+                    return;
+                }
+            }
+        }
+
+        /// Returns a slice allocated to the scratch buffer.
+        pub fn scratch_alloc(this: *Self, comptime T: type, n: usize) []T {
+            return this.scratch.allocator().alloc(T, n) catch @panic("We ran out of scratch memory!!!");
+        }
+
+        /// Call this at the end of a run to complete in your main-loop
+        pub fn scratch_reset(this: *Self) void {
+            this.scratch.reset();
+        }
+
+        /// A test only function used to verify that after initialization, all of your subscriptions arrays are fully saturated
+        pub fn verify_all_subs_are_saturated(this: *Self, comptime exceptions: []const SubException) !void {
+            var failed = false;
+
+            inline for (exceptions) |e| {
+                const erd_name = @tagName(e.erd_enum);
+                const num_subs = @field(erd_instance, erd_name).subs;
+                if (num_subs == 0) {
+                    std.log.warn("Remove {s} from exceptions list since subscriptions are disabled for it", .{erd_name});
+                    failed = true;
+                }
+            }
+
+            if (failed) {
+                return error.ErdWithNoSubsInExceptions;
+            }
+
+            inline for (std.meta.fields(ErdDefs), 0..) |field_info, i| {
+                const erd_name = field_info.name;
+                const sub_offset = subscription_offsets[i];
+                const num_subs = @field(erd_instance, erd_name).subs;
+
+                if (num_subs == 0) {
+                    continue;
+                }
+
+                const expected_count = blk: {
+                    comptime var _expected = num_subs;
+                    inline for (exceptions) |e| {
+                        if (comptime std.mem.eql(u8, @tagName(e.erd_enum), erd_name)) {
+                            _expected = num_subs - e.missing;
+                            break :blk _expected;
+                        }
+                    }
+                    break :blk _expected;
+                };
+
+                var actual_count: u16 = 0;
+                for (this.subscriptions[sub_offset .. sub_offset + num_subs]) |_sub| {
+                    if (_sub.callback != null) {
+                        actual_count += 1;
+                    }
+                }
+
+                if (actual_count < expected_count) {
+                    std.log.warn("ERD: {s} is under-subscribing after init. Decrease subs, or increase missing.", .{erd_name});
+                    failed = true;
+                } else if (actual_count > expected_count) {
+                    std.log.warn("ERD: {s} is over-subscribed after init. Increase subs or decrease missing.", .{erd_name});
+                    failed = true;
+                }
+            }
+
+            if (failed) {
+                return error.ErdWithUnexpectedSubCount;
+            }
+        }
+    };
 }

--- a/src/system_data.zig
+++ b/src/system_data.zig
@@ -45,6 +45,14 @@ pub fn SystemData(comptime ErdDefs: type, comptime ErdEnum: type, comptime erd_i
         scratch: std.heap.FixedBufferAllocator = undefined,
         scratch_buf: [2048]u8 align(@alignOf(usize)) = undefined, // TODO: Does this actually need to be aligned?
 
+        pub fn init(components: Components) Self {
+            var this = Self{};
+            this.components = components;
+            this.scratch = .init(&this.scratch_buf);
+            @memset(&this.subscriptions, .{ .context = null, .callback = null });
+            return this;
+        }
+
         fn total_subscriptions() usize {
             comptime {
                 var size: usize = 0;

--- a/src/system_data.zig
+++ b/src/system_data.zig
@@ -94,12 +94,9 @@ pub fn SystemData(comptime ErdDefs: type, comptime ErdEnum: type, comptime erd_i
         };
 
         pub const ErdEnumType = ErdEnum;
+        pub const erds = erd_instance;
 
-        pub fn erd_from_enum_pub(comptime erd_enum: ErdEnum) Erd {
-            return erd_from_enum(erd_enum);
-        }
-
-        fn erd_from_enum(comptime erd_enum: ErdEnum) Erd {
+        pub fn erd_from_enum(comptime erd_enum: ErdEnum) Erd {
             return @field(erd_instance, @tagName(erd_enum));
         }
 
@@ -197,7 +194,6 @@ pub fn SystemData(comptime ErdDefs: type, comptime ErdEnum: type, comptime erd_i
             const erd: Erd = erd_from_enum(erd_enum);
             comptime {
                 std.debug.assert(erd.subs > 0);
-                std.debug.assert(supports_write_from_component_idx[erd.component_idx]);
             }
             const sub_offset = subscription_offsets[erd.system_data_idx];
             var first_free_spot: ?*Subscription = null;
@@ -231,7 +227,6 @@ pub fn SystemData(comptime ErdDefs: type, comptime ErdEnum: type, comptime erd_i
             const erd: Erd = erd_from_enum(erd_enum);
             comptime {
                 std.debug.assert(erd.subs > 0);
-                std.debug.assert(supports_write_from_component_idx[erd.component_idx]);
             }
 
             const sub_offset = subscription_offsets[erd.system_data_idx];

--- a/src/system_erds.zig
+++ b/src/system_erds.zig
@@ -2,8 +2,13 @@ const std = @import("std");
 const Erd = @import("erd.zig");
 const TimerStats = @import("common/timer_stats.zig");
 
-const Ram = 0;
-const Indirect = 1;
+pub const ComponentId = enum(u8) {
+    ram,
+    indirect,
+};
+
+const Ram = @intFromEnum(ComponentId.ram);
+const Indirect = @intFromEnum(ComponentId.indirect);
 
 /// `ErdEnum` allows for use of decl literals which makes API use of ERDs *significantly* shorter
 pub const ErdEnum = enum {
@@ -120,7 +125,8 @@ pub const erd = blk: {
     break :blk _erds;
 };
 
-pub fn num_erds(comptime component_idx: comptime_int) comptime_int {
+pub fn num_erds(comptime id: ComponentId) comptime_int {
+    const component_idx = @intFromEnum(id);
     var i = 0;
     for (std.meta.fieldNames(ErdDefinitions)) |erd_name| {
         if (@field(erd, erd_name).component_idx == component_idx) {
@@ -130,8 +136,9 @@ pub fn num_erds(comptime component_idx: comptime_int) comptime_int {
     return i;
 }
 
-pub fn component_definitions(comptime component_idx: comptime_int) [num_erds(component_idx)]Erd {
-    var _erds: [num_erds(component_idx)]Erd = undefined;
+pub fn component_definitions(comptime id: ComponentId) [num_erds(id)]Erd {
+    const component_idx = @intFromEnum(id);
+    var _erds: [num_erds(id)]Erd = undefined;
     var i = 0;
 
     for (std.meta.fieldNames(ErdDefinitions)) |erd_name| {
@@ -145,8 +152,8 @@ pub fn component_definitions(comptime component_idx: comptime_int) [num_erds(com
 }
 
 // Array versions of ERDs. For easier iteration.
-pub const ram_definitions = component_definitions(Ram);
-pub const indirect_definitions = component_definitions(Indirect);
+pub const ram_definitions = component_definitions(.ram);
+pub const indirect_definitions = component_definitions(.indirect);
 
 /// Enum to Erd mapper
 pub fn erd_from_enum(comptime erd_enum: ErdEnum) Erd {

--- a/src/system_erds.zig
+++ b/src/system_erds.zig
@@ -2,6 +2,9 @@ const std = @import("std");
 const Erd = @import("erd.zig");
 const TimerStats = @import("common/timer_stats.zig");
 
+const Ram = 0;
+const Indirect = 1;
+
 /// `ErdEnum` allows for use of decl literals which makes API use of ERDs *significantly* shorter
 pub const ErdEnum = enum {
     // This must match one to one with ErdDefinitions
@@ -36,18 +39,18 @@ pub const ErdEnum = enum {
 
 pub const ErdDefinitions = struct {
     // zig fmt: off
-    erd_application_version:  Erd = .{ .erd_number = 0x0000, .T = u32,                         .owner = .Ram,      .subs = 0 },
-    erd_some_bool:            Erd = .{ .erd_number = 0x0001, .T = bool,                        .owner = .Ram,      .subs = 3 },
-    erd_unaligned_u16:        Erd = .{ .erd_number = 0x0002, .T = u16,                         .owner = .Ram,      .subs = 1 },
-    erd_well_packed:          Erd = .{ .erd_number = 0x0003, .T = WellPackedStruct,            .owner = .Ram,      .subs = 0 },
-    erd_padded:               Erd = .{ .erd_number = 0x0004, .T = PaddedStruct,                .owner = .Ram,      .subs = 0 },
-    erd_actually_packed_fr:   Erd = .{ .erd_number = 0x0005, .T = PackedFr,                    .owner = .Ram,      .subs = 0 },
-    erd_always_42:            Erd = .{ .erd_number = 0x0006, .T = u16,                         .owner = .Indirect, .subs = 0 },
-    erd_pointer_to_something: Erd = .{ .erd_number = null,   .T = ?*u16,                       .owner = .Ram,      .subs = 0 },
-    erd_another_erd_plus_one: Erd = .{ .erd_number = 0x0008, .T = u16,                         .owner = .Indirect, .subs = 0 },
-    erd_cool_u16:             Erd = .{ .erd_number = null,   .T = u16,                         .owner = .Ram,      .subs = 1 },
-    erd_best_u16:             Erd = .{ .erd_number = null,   .T = u16,                         .owner = .Ram,      .subs = 0 },
-    erd_timer_stats:          Erd = .{ .erd_number = null,   .T = TimerStats.StatMeasurement,  .owner = .Ram,      .subs = 0 },
+    erd_application_version:  Erd = .{ .erd_number = 0x0000, .T = u32,                         .component_idx = Ram,      .subs = 0 },
+    erd_some_bool:            Erd = .{ .erd_number = 0x0001, .T = bool,                        .component_idx = Ram,      .subs = 3 },
+    erd_unaligned_u16:        Erd = .{ .erd_number = 0x0002, .T = u16,                         .component_idx = Ram,      .subs = 1 },
+    erd_well_packed:          Erd = .{ .erd_number = 0x0003, .T = WellPackedStruct,            .component_idx = Ram,      .subs = 0 },
+    erd_padded:               Erd = .{ .erd_number = 0x0004, .T = PaddedStruct,                .component_idx = Ram,      .subs = 0 },
+    erd_actually_packed_fr:   Erd = .{ .erd_number = 0x0005, .T = PackedFr,                    .component_idx = Ram,      .subs = 0 },
+    erd_always_42:            Erd = .{ .erd_number = 0x0006, .T = u16,                         .component_idx = Indirect, .subs = 0 },
+    erd_pointer_to_something: Erd = .{ .erd_number = null,   .T = ?*u16,                       .component_idx = Ram,      .subs = 0 },
+    erd_another_erd_plus_one: Erd = .{ .erd_number = 0x0008, .T = u16,                         .component_idx = Indirect, .subs = 0 },
+    erd_cool_u16:             Erd = .{ .erd_number = null,   .T = u16,                         .component_idx = Ram,      .subs = 1 },
+    erd_best_u16:             Erd = .{ .erd_number = null,   .T = u16,                         .component_idx = Ram,      .subs = 0 },
+    erd_timer_stats:          Erd = .{ .erd_number = null,   .T = TimerStats.StatMeasurement,  .component_idx = Ram,      .subs = 0 },
     // zig fmt: on
 
     pub fn jsonStringify(self: ErdDefinitions, jws: anytype) !void {
@@ -62,8 +65,16 @@ pub const ErdDefinitions = struct {
             {
                 try jws.beginArray();
                 inline for (erd_names) |erd_name| {
-                    if (@field(self, erd_name).erd_number != null) {
-                        try jws.write(@field(self, erd_name));
+                    const e = @field(self, erd_name);
+                    if (e.erd_number != null) {
+                        try jws.beginObject();
+                        try jws.objectField("name");
+                        try jws.write(erd_name);
+                        try jws.objectField("id");
+                        try jws.print("\"0x{x:0>4}\"", .{e.erd_number.?});
+                        try jws.objectField("type");
+                        try jws.print("\"{}\"", .{e.T});
+                        try jws.endObject();
                     }
                 }
                 try jws.endArray();
@@ -77,9 +88,15 @@ pub const ErdDefinitions = struct {
 pub const erd = blk: {
     var _erds = ErdDefinitions{};
 
-    var owning_counts = std.mem.zeroes([std.meta.fields(Erd.ErdOwner).len]u16);
+    var max_component_idx: comptime_int = 0;
     for (std.meta.fieldNames(ErdDefinitions)) |erd_field_name| {
-        const idx = @intFromEnum(@field(_erds, erd_field_name).owner);
+        const idx = @field(_erds, erd_field_name).component_idx;
+        if (idx > max_component_idx) max_component_idx = idx;
+    }
+
+    var owning_counts = std.mem.zeroes([max_component_idx + 1]u16);
+    for (std.meta.fieldNames(ErdDefinitions)) |erd_field_name| {
+        const idx = @field(_erds, erd_field_name).component_idx;
         @field(_erds, erd_field_name).data_component_idx = owning_counts[idx];
         owning_counts[idx] += 1;
     }
@@ -103,22 +120,22 @@ pub const erd = blk: {
     break :blk _erds;
 };
 
-fn num_erds(owner: Erd.ErdOwner) comptime_int {
+pub fn num_erds(comptime component_idx: comptime_int) comptime_int {
     var i = 0;
     for (std.meta.fieldNames(ErdDefinitions)) |erd_name| {
-        if (@field(erd, erd_name).owner == owner) {
+        if (@field(erd, erd_name).component_idx == component_idx) {
             i += 1;
         }
     }
     return i;
 }
 
-fn component_definitions(comptime owner: Erd.ErdOwner) [num_erds(owner)]Erd {
-    var _erds: [num_erds(owner)]Erd = undefined;
+pub fn component_definitions(comptime component_idx: comptime_int) [num_erds(component_idx)]Erd {
+    var _erds: [num_erds(component_idx)]Erd = undefined;
     var i = 0;
 
     for (std.meta.fieldNames(ErdDefinitions)) |erd_name| {
-        if (@field(erd, erd_name).owner == owner) {
+        if (@field(erd, erd_name).component_idx == component_idx) {
             _erds[i] = @field(erd, erd_name);
             i += 1;
         }
@@ -128,8 +145,8 @@ fn component_definitions(comptime owner: Erd.ErdOwner) [num_erds(owner)]Erd {
 }
 
 // Array versions of ERDs. For easier iteration.
-pub const ram_definitions = component_definitions(.Ram);
-pub const indirect_definitions = component_definitions(.Indirect);
+pub const ram_definitions = component_definitions(Ram);
+pub const indirect_definitions = component_definitions(Indirect);
 
 /// Enum to Erd mapper
 pub fn erd_from_enum(comptime erd_enum: ErdEnum) Erd {

--- a/src/testing.zig
+++ b/src/testing.zig
@@ -1,0 +1,81 @@
+//! Test double for SystemData that backs all ERDs with a single RamDataComponent.
+//!
+//! Usage:
+//! ```
+//! const SystemDataTestDouble = @import("testing.zig");
+//!
+//! const TestSystem = SystemDataTestDouble.create(struct {
+//!     counter: SystemDataTestDouble.Erd = SystemDataTestDouble.ramErd(u32, .{ .subs = 2 }),
+//!     flag:    SystemDataTestDouble.Erd = SystemDataTestDouble.ramErd(bool, .{}),
+//! });
+//!
+//! test "example" {
+//!     var system_data = TestSystem.init();
+//!     system_data.write(.counter, 42);
+//!     try std.testing.expectEqual(42, system_data.read(.counter));
+//! }
+//! ```
+
+const std = @import("std");
+pub const Erd = @import("erd.zig");
+
+pub const RamErdOptions = struct {
+    subs: comptime_int = 0,
+    erd_number: ?Erd.ErdHandle = null,
+};
+
+pub fn ramErd(comptime T: type, comptime opts: RamErdOptions) Erd {
+    return .{
+        .erd_number = opts.erd_number,
+        .T = T,
+        .component_idx = 0,
+        .subs = opts.subs,
+    };
+}
+
+pub fn create(comptime ErdDefs: type) type {
+    const erd_instance = build_erd_instance(ErdDefs);
+    const erd_fields = std.meta.fieldNames(ErdDefs);
+
+    const all_erds: [erd_fields.len]Erd = blk: {
+        var erds: [erd_fields.len]Erd = undefined;
+        for (erd_fields, 0..) |name, i| {
+            erds[i] = @field(erd_instance, name);
+        }
+        break :blk erds;
+    };
+
+    const RamDataComponentType = @import("ram_data_component.zig").RamDataComponent(&all_erds);
+    const ErdEnum = std.meta.FieldEnum(ErdDefs);
+
+    const Components = struct {
+        ram: RamDataComponentType,
+    };
+
+    const SystemDataType = @import("system_data.zig").SystemData(ErdDefs, ErdEnum, erd_instance, Components);
+
+    return struct {
+        pub const SystemData = SystemDataType;
+
+        pub fn init() SystemDataType {
+            var system_data = SystemDataType{};
+            system_data.components.ram = RamDataComponentType.init();
+            system_data.scratch = .init(&system_data.scratch_buf);
+            @memset(&system_data.subscriptions, .{ .context = null, .callback = null });
+            return system_data;
+        }
+    };
+}
+
+fn build_erd_instance(comptime ErdDefs: type) ErdDefs {
+    var erds = ErdDefs{};
+
+    var data_component_idx: u16 = 0;
+    for (std.meta.fieldNames(ErdDefs), 0..) |name, i| {
+        @field(erds, name).data_component_idx = data_component_idx;
+        @field(erds, name).system_data_idx = i;
+        data_component_idx += 1;
+    }
+
+    return erds;
+}

--- a/src/testing.zig
+++ b/src/testing.zig
@@ -58,11 +58,9 @@ pub fn create(comptime ErdDefs: type) type {
         pub const SystemData = SystemDataType;
 
         pub fn init() SystemDataType {
-            var system_data = SystemDataType{};
-            system_data.components.ram = RamDataComponentType.init();
-            system_data.scratch = .init(&system_data.scratch_buf);
-            @memset(&system_data.subscriptions, .{ .context = null, .callback = null });
-            return system_data;
+            return SystemDataType.init(.{
+                .ram = RamDataComponentType.init(),
+            });
         }
     };
 }

--- a/src/tests/indirect_data_component_test.zig
+++ b/src/tests/indirect_data_component_test.zig
@@ -1,51 +1,55 @@
 const std = @import("std");
-const IndirectDataComponent = @import("../indirect_data_component.zig");
-const IndirectErdMapping = IndirectDataComponent.IndirectErdMapping;
-const SystemErds = @import("../system_erds.zig");
+const Erd = @import("../erd.zig");
 
-fn erd_always_42(data: *u16) void {
+const erds = [_]Erd{
+    .{ .erd_number = null, .T = u16, .component_idx = 0, .subs = 0, .data_component_idx = 0, .system_data_idx = 0 },
+    .{ .erd_number = null, .T = u16, .component_idx = 0, .subs = 0, .data_component_idx = 1, .system_data_idx = 1 },
+};
+
+const IndirectDataComponent = @import("../indirect_data_component.zig").IndirectDataComponent(&erds);
+const IndirectErdMapping = IndirectDataComponent.IndirectErdMapping;
+
+const erd_always_42 = erds[0];
+const erd_plus_one = erds[1];
+
+fn always_42(data: *u16) void {
     data.* = 42;
 }
 
 fn plus_one(data: *u16) void {
     var should_be_42: u16 = undefined;
-    erd_always_42(&should_be_42);
+    always_42(&should_be_42);
 
     data.* = should_be_42 + 1;
 }
 
-test "indirect data component read" {
-    var indirect_data = IndirectDataComponent.init([_]IndirectErdMapping{
-        .map(.erd_always_42, erd_always_42),
-        .map(.erd_another_erd_plus_one, plus_one),
-    });
+const mappings = [_]IndirectErdMapping{
+    IndirectErdMapping.map(erd_always_42, always_42),
+    IndirectErdMapping.map(erd_plus_one, plus_one),
+};
 
-    try std.testing.expectEqual(42, indirect_data.read(SystemErds.erd.erd_always_42));
-    try std.testing.expectEqual(42 + 1, indirect_data.read(SystemErds.erd.erd_another_erd_plus_one));
+test "indirect data component read" {
+    var indirect_data = IndirectDataComponent.init(mappings);
+
+    try std.testing.expectEqual(42, indirect_data.read(erd_always_42));
+    try std.testing.expectEqual(42 + 1, indirect_data.read(erd_plus_one));
 }
 
 test "indirect data component write" {
     return error.SkipZigTest; // Test for compile error
 
-    // var indirect_data = IndirectDataComponent.init([_]IndirectErdMapping{
-    //     .map(.erd_always_42, erd_always_42),
-    //     .map(.erd_another_erd_plus_one, plus_one),
-    // });
-
-    // _ = indirect_data.write(SystemErds.erd.erd_always_42, 41);
+    // var indirect_data = IndirectDataComponent.init(mappings);
+    // _ = indirect_data.write(erd_always_42, 41);
 }
 
 test "indirect data component runtime read" {
-    var indirect_data = IndirectDataComponent.init([_]IndirectErdMapping{
-        .map(.erd_always_42, erd_always_42),
-        .map(.erd_another_erd_plus_one, plus_one),
-    });
+    var indirect_data = IndirectDataComponent.init(mappings);
 
     var should_be_42: u16 = undefined;
     var should_be_43: u16 = undefined;
 
-    indirect_data.runtime_read(SystemErds.erd.erd_always_42.data_component_idx, &should_be_42);
-    indirect_data.runtime_read(SystemErds.erd.erd_another_erd_plus_one.data_component_idx, &should_be_43);
+    indirect_data.runtime_read(erd_always_42.data_component_idx, &should_be_42);
+    indirect_data.runtime_read(erd_plus_one.data_component_idx, &should_be_43);
 
     try std.testing.expectEqual(42, should_be_42);
     try std.testing.expectEqual(42 + 1, should_be_43);
@@ -54,10 +58,6 @@ test "indirect data component runtime read" {
 test "indirect data component runtime write" {
     return error.SkipZigTest; // Test for compile error
 
-    // var indirect_data = IndirectDataComponent.init([_]IndirectErdMapping{
-    //     .map(.erd_always_42, erd_always_42),
-    //     .map(.erd_another_erd_plus_one, plus_one),
-    // });
-
-    // _ = indirect_data.runtime_write(SystemErds.erd.erd_always_42.data_component_idx, &41);
+    // var indirect_data = IndirectDataComponent.init(mappings);
+    // _ = indirect_data.runtime_write(erd_always_42.data_component_idx, &41);
 }

--- a/src/tests/ram_data_component_test.zig
+++ b/src/tests/ram_data_component_test.zig
@@ -1,7 +1,6 @@
 const std = @import("std");
 const Erd = @import("../erd.zig");
 
-
 const WellPackedStruct = struct {
     a: u8,
     b: u8,

--- a/src/tests/ram_data_component_test.zig
+++ b/src/tests/ram_data_component_test.zig
@@ -1,76 +1,118 @@
 const std = @import("std");
-const RamDataComponent = @import("../ram_data_component.zig");
-const SystemErds = @import("../system_erds.zig");
+const Erd = @import("../erd.zig");
+
+
+const WellPackedStruct = struct {
+    a: u8,
+    b: u8,
+    c: u16,
+};
+
+const PaddedStruct = extern struct {
+    a: u8,
+    b: u16,
+    d: u32,
+    c: bool,
+};
+
+const PackedFr = packed struct {
+    a: u5,
+    b: u5,
+    c: u5,
+    d: u5,
+    e: u1,
+    f: u1,
+    g: u1,
+};
+
+const erds = [_]Erd{
+    .{ .erd_number = null, .T = u32, .component_idx = 0, .subs = 0, .data_component_idx = 0, .system_data_idx = 0 },
+    .{ .erd_number = null, .T = bool, .component_idx = 0, .subs = 0, .data_component_idx = 1, .system_data_idx = 1 },
+    .{ .erd_number = null, .T = u16, .component_idx = 0, .subs = 0, .data_component_idx = 2, .system_data_idx = 2 },
+    .{ .erd_number = null, .T = WellPackedStruct, .component_idx = 0, .subs = 0, .data_component_idx = 3, .system_data_idx = 3 },
+    .{ .erd_number = null, .T = PaddedStruct, .component_idx = 0, .subs = 0, .data_component_idx = 4, .system_data_idx = 4 },
+    .{ .erd_number = null, .T = PackedFr, .component_idx = 0, .subs = 0, .data_component_idx = 5, .system_data_idx = 5 },
+    .{ .erd_number = null, .T = ?*u16, .component_idx = 0, .subs = 0, .data_component_idx = 6, .system_data_idx = 6 },
+};
+
+const RamDataComponent = @import("../ram_data_component.zig").RamDataComponent(&erds);
+
+const erd_u32 = erds[0];
+const erd_bool = erds[1];
+const erd_u16 = erds[2];
+const erd_well_packed = erds[3];
+const erd_padded = erds[4];
+const erd_packed_fr = erds[5];
+const erd_ptr = erds[6];
 
 test "ram data component read and write" {
     var ram_data = RamDataComponent.init();
-    // Should zero init
-    try std.testing.expectEqual(0, ram_data.read(SystemErds.erd.erd_application_version));
-    try std.testing.expectEqual(false, ram_data.write(SystemErds.erd.erd_application_version, 0));
+    try std.testing.expectEqual(0, ram_data.read(erd_u32));
+    try std.testing.expectEqual(false, ram_data.write(erd_u32, 0));
 
-    const new_application_version: u32 = 0x12345678;
-    try std.testing.expectEqual(true, ram_data.write(SystemErds.erd.erd_application_version, new_application_version));
-    try std.testing.expectEqual(new_application_version, ram_data.read(SystemErds.erd.erd_application_version));
+    const new_ver: u32 = 0x12345678;
+    try std.testing.expectEqual(true, ram_data.write(erd_u32, new_ver));
+    try std.testing.expectEqual(new_ver, ram_data.read(erd_u32));
 }
 
 test "unaligned read and write" {
     var ram_data = RamDataComponent.init();
-    _ = ram_data.write(SystemErds.erd.erd_unaligned_u16, 0x1234);
-    try std.testing.expectEqual(0x1234, ram_data.read(SystemErds.erd.erd_unaligned_u16));
+    _ = ram_data.write(erd_u16, 0x1234);
+    try std.testing.expectEqual(0x1234, ram_data.read(erd_u16));
 
-    try std.testing.expectEqual(0, ram_data.read(SystemErds.erd.erd_application_version));
-    try std.testing.expectEqual(false, ram_data.read(SystemErds.erd.erd_some_bool));
+    try std.testing.expectEqual(0, ram_data.read(erd_u32));
+    try std.testing.expectEqual(false, ram_data.read(erd_bool));
 }
 
 test "read and write of type where @bitSizeOf is not multiple of 8" {
     var ram_data = RamDataComponent.init();
-    try std.testing.expectEqual(false, ram_data.read(SystemErds.erd.erd_some_bool));
+    try std.testing.expectEqual(false, ram_data.read(erd_bool));
 
-    _ = ram_data.write(SystemErds.erd.erd_some_bool, true);
-    try std.testing.expectEqual(true, ram_data.read(SystemErds.erd.erd_some_bool));
+    _ = ram_data.write(erd_bool, true);
+    try std.testing.expectEqual(true, ram_data.read(erd_bool));
 }
 
 test "pointers read/write" {
     var ram_data = RamDataComponent.init();
-    try std.testing.expectEqual(null, ram_data.read(SystemErds.erd.erd_pointer_to_something));
+    try std.testing.expectEqual(null, ram_data.read(erd_ptr));
 
     var temp: u16 = 2;
-    _ = ram_data.write(SystemErds.erd.erd_pointer_to_something, &temp);
-    try std.testing.expectEqual(2, ram_data.read(SystemErds.erd.erd_pointer_to_something).?.*);
+    _ = ram_data.write(erd_ptr, &temp);
+    try std.testing.expectEqual(2, ram_data.read(erd_ptr).?.*);
 }
 
 test "structs" {
     var ram_data = RamDataComponent.init();
-    const st = ram_data.read(SystemErds.erd.erd_well_packed);
+    const st = ram_data.read(erd_well_packed);
     try std.testing.expectEqual(@as(@TypeOf(st), .{ .a = 0, .b = 0, .c = 0 }), st);
 
-    const packed_st = ram_data.read(SystemErds.erd.erd_actually_packed_fr);
+    const packed_st = ram_data.read(erd_packed_fr);
     try std.testing.expectEqual(std.mem.zeroes(@TypeOf(packed_st)), packed_st);
 
-    _ = ram_data.write(SystemErds.erd.erd_actually_packed_fr, .{ .a = 1, .b = 0, .c = 0, .d = 0, .e = 1, .f = 0, .g = 1 });
-    const packed_st_with_data = ram_data.read(SystemErds.erd.erd_actually_packed_fr);
+    _ = ram_data.write(erd_packed_fr, .{ .a = 1, .b = 0, .c = 0, .d = 0, .e = 1, .f = 0, .g = 1 });
+    const packed_st_with_data = ram_data.read(erd_packed_fr);
     try std.testing.expectEqual(@TypeOf(packed_st_with_data){ .a = 1, .b = 0, .c = 0, .d = 0, .e = 1, .f = 0, .g = 1 }, packed_st_with_data);
 
-    _ = ram_data.write(SystemErds.erd.erd_padded, .{ .a = 0x12, .b = 0x3456, .c = true, .d = 0x09ABCDEF });
+    _ = ram_data.write(erd_padded, .{ .a = 0x12, .b = 0x3456, .c = true, .d = 0x09ABCDEF });
 
-    const erd_padded = ram_data.read(SystemErds.erd.erd_padded);
-    try std.testing.expectEqual(@TypeOf(erd_padded){ .a = 0x12, .b = 0x3456, .c = true, .d = 0x09ABCDEF }, erd_padded);
+    const padded = ram_data.read(erd_padded);
+    try std.testing.expectEqual(@TypeOf(padded){ .a = 0x12, .b = 0x3456, .c = true, .d = 0x09ABCDEF }, padded);
 }
 
 test "failure upon writing incorrect types" {
     return error.SkipZigTest; // Test for compile error
 
     // var ram_data = RamDataComponent.init();
-    // std.testing.expectError(, ram_data.write(SystemErds.erd.erd_some_bool, 20));
+    // std.testing.expectError(, ram_data.write(erd_bool, 20));
 }
 
 test "runtime reads" {
     var ram_data = RamDataComponent.init();
 
-    _ = ram_data.write(SystemErds.erd.erd_some_bool, true);
+    _ = ram_data.write(erd_bool, true);
 
     var bool_val: bool = undefined;
-    ram_data.runtime_read(SystemErds.erd.erd_some_bool.data_component_idx, &bool_val);
+    ram_data.runtime_read(erd_bool.data_component_idx, &bool_val);
 
     try std.testing.expectEqual(true, bool_val);
 }
@@ -79,15 +121,15 @@ test "runtime writes" {
     var ram_data = RamDataComponent.init();
 
     const very_true = true;
-    var changed = ram_data.runtime_write(SystemErds.erd.erd_some_bool.data_component_idx, &very_true);
+    var changed = ram_data.runtime_write(erd_bool.data_component_idx, &very_true);
     try std.testing.expect(changed);
 
-    const bool_val = ram_data.read(SystemErds.erd.erd_some_bool);
+    const bool_val = ram_data.read(erd_bool);
     try std.testing.expectEqual(true, bool_val);
 
-    changed = ram_data.write(SystemErds.erd.erd_some_bool, true);
+    changed = ram_data.write(erd_bool, true);
     try std.testing.expect(!changed);
 
-    changed = ram_data.write(SystemErds.erd.erd_some_bool, false);
+    changed = ram_data.write(erd_bool, false);
     try std.testing.expect(changed);
 }

--- a/src/tests/system_data_test.zig
+++ b/src/tests/system_data_test.zig
@@ -150,13 +150,13 @@ fn switch_on_system_data_idx(_: ?*anyopaque, _args: ?*const anyopaque, publisher
     const args: *const SystemData.OnChangeArgs = @ptrCast(@alignCast(_args.?));
     var system_data: *SystemData = @ptrCast(@alignCast(publisher));
 
-    if (args.system_data_idx != SystemData.erd_from_enum_pub(.some_bool).system_data_idx) {
+    if (args.system_data_idx != SystemData.erd_from_enum(.some_bool).system_data_idx) {
         system_data.write(.best_u16, system_data.read(.best_u16) + 1);
     }
 
     switch (args.system_data_idx) {
-        SystemData.erd_from_enum_pub(.cool_u16).system_data_idx => system_data.write(.some_bool, true),
-        SystemData.erd_from_enum_pub(.unaligned_u16).system_data_idx => system_data.write(.some_bool, false),
+        SystemData.erd_from_enum(.cool_u16).system_data_idx => system_data.write(.some_bool, true),
+        SystemData.erd_from_enum(.unaligned_u16).system_data_idx => system_data.write(.some_bool, false),
         else => {},
     }
 }

--- a/src/tests/system_data_test.zig
+++ b/src/tests/system_data_test.zig
@@ -1,67 +1,55 @@
 const std = @import("std");
-const SystemData = @import("../system_data.zig");
-const SystemErds = @import("../system_erds.zig");
+const SystemDataTestDouble = @import("../testing.zig");
 const Subscription = @import("../subscription.zig");
 
-test "ram data component read and write" {
-    var system_data = SystemData.init();
-    // Should zero init
-    try std.testing.expectEqual(0, system_data.read(.erd_application_version));
+const TestSystem = SystemDataTestDouble.create(struct {
+    application_version: SystemDataTestDouble.Erd = SystemDataTestDouble.ramErd(u32, .{}),
+    some_bool: SystemDataTestDouble.Erd = SystemDataTestDouble.ramErd(bool, .{ .subs = 3 }),
+    unaligned_u16: SystemDataTestDouble.Erd = SystemDataTestDouble.ramErd(u16, .{ .subs = 1 }),
+    cool_u16: SystemDataTestDouble.Erd = SystemDataTestDouble.ramErd(u16, .{ .subs = 1 }),
+    best_u16: SystemDataTestDouble.Erd = SystemDataTestDouble.ramErd(u16, .{}),
+});
+const SystemData = TestSystem.SystemData;
 
-    const new_application_version: u32 = 0x12345678;
-    system_data.write(.erd_application_version, new_application_version);
-    try std.testing.expectEqual(new_application_version, system_data.read(.erd_application_version));
+test "ram data component read and write" {
+    var system_data = TestSystem.init();
+    try std.testing.expectEqual(0, system_data.read(.application_version));
+
+    const new_ver: u32 = 0x12345678;
+    system_data.write(.application_version, new_ver);
+    try std.testing.expectEqual(new_ver, system_data.read(.application_version));
 }
 
 test "runtime read/write matches data components" {
-    var system_data = SystemData.init();
+    var system_data = TestSystem.init();
     var ver: u32 = undefined;
-    system_data.runtime_read(SystemErds.erd.erd_application_version.system_data_idx, &ver);
+    system_data.runtime_read(0, &ver);
     try std.testing.expectEqual(0, ver);
 
-    system_data.write(.erd_application_version, 1234);
-    system_data.runtime_read(SystemErds.erd.erd_application_version.system_data_idx, &ver);
+    system_data.write(.application_version, 1234);
+    system_data.runtime_read(0, &ver);
     try std.testing.expectEqual(1234, ver);
-
-    var should_be_42: u16 = undefined;
-    system_data.runtime_read(SystemErds.erd.erd_always_42.system_data_idx, &should_be_42);
-    system_data.runtime_read(SystemErds.erd.erd_always_42.system_data_idx, &ver);
-    try std.testing.expectEqual(42, should_be_42);
 }
 
-test "indirect data component read and a note on reads" {
-    var system_data = SystemData.init();
-    try std.testing.expectEqual(42, system_data.read(.erd_always_42));
-
-    // This does not work:
-    // src\system_data.zig:49:31: error: reached unreachable code
-    //     .Indirect => comptime unreachable,
-    // system_data.write(.erd_always_42, 43);
-}
-
-fn ExampleDo(system_data: *SystemData) !void {
-    try std.testing.expectEqual(42, system_data.read(.erd_always_42));
-
-    const new_application_version: u32 = 0x87654321;
-    system_data.write(.erd_application_version, new_application_version);
+fn example_do(system_data: *SystemData) !void {
+    const new_ver: u32 = 0x87654321;
+    system_data.write(.application_version, new_ver);
 }
 
 test "mutable system_data passing without error" {
-    var system_data = SystemData.init();
+    var system_data = TestSystem.init();
 
-    try ExampleDo(&system_data);
-    try std.testing.expectEqual(0x87654321, system_data.read(.erd_application_version));
+    try example_do(&system_data);
+    try std.testing.expectEqual(0x87654321, system_data.read(.application_version));
 }
 
 var persisted_system_data: *SystemData = undefined;
-fn ExampleCallbackEffect() !void {
-    try std.testing.expectEqual(42, persisted_system_data.read(.erd_always_42));
-
-    const new_application_version: u32 = 0xCAFEBABE;
-    persisted_system_data.write(.erd_application_version, new_application_version);
+fn example_callback_effect() !void {
+    const new_ver: u32 = 0xCAFEBABE;
+    persisted_system_data.write(.application_version, new_ver);
 }
 
-fn ExampleInit(system_data: *SystemData) void {
+fn example_init(system_data: *SystemData) void {
     if (!@inComptime()) {
         persisted_system_data = system_data;
     } else {
@@ -70,68 +58,65 @@ fn ExampleInit(system_data: *SystemData) void {
 }
 
 test "retain reference to system_data" {
-    var system_data = SystemData.init();
+    var system_data = TestSystem.init();
 
-    ExampleInit(&system_data);
+    example_init(&system_data);
 
-    try ExampleCallbackEffect();
-    try std.testing.expectEqual(0xCAFEBABE, system_data.read(.erd_application_version));
+    try example_callback_effect();
+    try std.testing.expectEqual(0xCAFEBABE, system_data.read(.application_version));
 }
 
-fn turn_off_some_bool_and_increment_application_version(_: ?*anyopaque, _: ?*const anyopaque, publisher: *anyopaque) void {
+fn turn_off_bool_and_bump_version(_: ?*anyopaque, _: ?*const anyopaque, publisher: *anyopaque) void {
     var system_data: *SystemData = @ptrCast(@alignCast(publisher));
 
-    system_data.write(.erd_some_bool, false);
-    system_data.write(.erd_application_version, system_data.read(.erd_application_version) + 1);
+    system_data.write(.some_bool, false);
+    system_data.write(.application_version, system_data.read(.application_version) + 1);
 }
 
 test "subscription_test" {
-    var system_data = SystemData.init();
-    // system_data.subscribe(.erd_some_bool, null, null); // This is a compile error!
+    var system_data = TestSystem.init();
 
-    system_data.subscribe(.erd_some_bool, null, turn_off_some_bool_and_increment_application_version);
-    // Subscriptions can be stored on the stack if it lives through all of its callbacks.
-    // defer pattern only makes sense if you stack initialize this. Here it's to show that it's safe to call unsub multiple times
-    defer system_data.unsubscribe(.erd_some_bool, turn_off_some_bool_and_increment_application_version);
+    system_data.subscribe(.some_bool, null, turn_off_bool_and_bump_version);
+    defer system_data.unsubscribe(.some_bool, turn_off_bool_and_bump_version);
 
-    system_data.write(.erd_some_bool, true);
-    try std.testing.expectEqual(false, system_data.read(.erd_some_bool));
-    try std.testing.expectEqual(2, system_data.read(.erd_application_version));
+    system_data.write(.some_bool, true);
+    try std.testing.expectEqual(false, system_data.read(.some_bool));
+    try std.testing.expectEqual(2, system_data.read(.application_version));
 
-    system_data.unsubscribe(.erd_some_bool, turn_off_some_bool_and_increment_application_version);
-    system_data.write(.erd_some_bool, true);
-    try std.testing.expectEqual(true, system_data.read(.erd_some_bool));
-    try std.testing.expectEqual(2, system_data.read(.erd_application_version));
+    system_data.unsubscribe(.some_bool, turn_off_bool_and_bump_version);
+    system_data.write(.some_bool, true);
+    try std.testing.expectEqual(true, system_data.read(.some_bool));
+    try std.testing.expectEqual(2, system_data.read(.application_version));
 }
 
 test "re-subscribe" {
-    var system_data = SystemData.init();
-    system_data.subscribe(.erd_some_bool, null, turn_off_some_bool_and_increment_application_version);
-    system_data.subscribe(.erd_some_bool, null, turn_off_some_bool_and_increment_application_version);
-    system_data.subscribe(.erd_some_bool, null, turn_off_some_bool_and_increment_application_version);
-    system_data.subscribe(.erd_some_bool, null, turn_off_some_bool_and_increment_application_version);
-    system_data.subscribe(.erd_some_bool, null, turn_off_some_bool_and_increment_application_version);
+    var system_data = TestSystem.init();
+    system_data.subscribe(.some_bool, null, turn_off_bool_and_bump_version);
+    system_data.subscribe(.some_bool, null, turn_off_bool_and_bump_version);
+    system_data.subscribe(.some_bool, null, turn_off_bool_and_bump_version);
+    system_data.subscribe(.some_bool, null, turn_off_bool_and_bump_version);
+    system_data.subscribe(.some_bool, null, turn_off_bool_and_bump_version);
 
-    system_data.write(.erd_some_bool, true);
-    try std.testing.expectEqual(false, system_data.read(.erd_some_bool));
-    try std.testing.expectEqual(2, system_data.read(.erd_application_version));
+    system_data.write(.some_bool, true);
+    try std.testing.expectEqual(false, system_data.read(.some_bool));
+    try std.testing.expectEqual(2, system_data.read(.application_version));
 }
 
 fn forward_context(context: ?*anyopaque, _: ?*const anyopaque, publisher: *anyopaque) void {
     var system_data: *SystemData = @ptrCast(@alignCast(publisher));
     const a: *u8 = @ptrCast(context.?);
 
-    system_data.write(.erd_unaligned_u16, a.*);
+    system_data.write(.unaligned_u16, a.*);
 }
 
 test "subscription with context" {
-    var system_data = SystemData.init();
+    var system_data = TestSystem.init();
 
     var a: u8 = 17;
-    system_data.subscribe(.erd_some_bool, &a, forward_context);
-    system_data.write(.erd_some_bool, true);
+    system_data.subscribe(.some_bool, &a, forward_context);
+    system_data.write(.some_bool, true);
 
-    try std.testing.expectEqual(17, system_data.read(.erd_unaligned_u16));
+    try std.testing.expectEqual(17, system_data.read(.unaligned_u16));
 }
 
 fn context_must_match_args(context: ?*anyopaque, _args: ?*const anyopaque, publisher: *anyopaque) void {
@@ -141,108 +126,102 @@ fn context_must_match_args(context: ?*anyopaque, _args: ?*const anyopaque, publi
     const a: *u16 = @ptrCast(@alignCast(context.?));
     const b: *const u16 = @ptrCast(@alignCast(args.data));
 
-    system_data.write(.erd_some_bool, a.* == b.*);
+    system_data.write(.some_bool, a.* == b.*);
 }
 
 test "subscription with args" {
-    var system_data = SystemData.init();
+    var system_data = TestSystem.init();
 
     var a: u16 = 1;
-    system_data.subscribe(.erd_unaligned_u16, &a, context_must_match_args);
-    system_data.write(.erd_unaligned_u16, 1);
-    try std.testing.expect(true == system_data.read(.erd_some_bool));
+    system_data.subscribe(.unaligned_u16, &a, context_must_match_args);
+    system_data.write(.unaligned_u16, 1);
+    try std.testing.expect(true == system_data.read(.some_bool));
 
-    system_data.write(.erd_unaligned_u16, 2);
-    try std.testing.expect(false == system_data.read(.erd_some_bool));
+    system_data.write(.unaligned_u16, 2);
+    try std.testing.expect(false == system_data.read(.some_bool));
 
     a = 2;
-    system_data.write(.erd_unaligned_u16, 2);
+    system_data.write(.unaligned_u16, 2);
     // NOTE: Stays false because no publish
-    try std.testing.expect(false == system_data.read(.erd_some_bool));
+    try std.testing.expect(false == system_data.read(.some_bool));
 }
 
 fn switch_on_system_data_idx(_: ?*anyopaque, _args: ?*const anyopaque, publisher: *anyopaque) void {
     const args: *const SystemData.OnChangeArgs = @ptrCast(@alignCast(_args.?));
     var system_data: *SystemData = @ptrCast(@alignCast(publisher));
 
-    // do something every time
-    if (args.system_data_idx != SystemErds.erd.erd_some_bool.system_data_idx) {
-        system_data.write(.erd_best_u16, system_data.read(.erd_best_u16) + 1);
+    if (args.system_data_idx != SystemData.erd_from_enum_pub(.some_bool).system_data_idx) {
+        system_data.write(.best_u16, system_data.read(.best_u16) + 1);
     }
 
     switch (args.system_data_idx) {
-        // Ideally I'd like to type this instead:
-        // .erd_cool_u16 => system_data.write(.erd_some_bool, true)
-        // TODO: That probably requires unifying `system_data_idx` and `ErdEnum` to be the same thing
-        SystemErds.erd.erd_cool_u16.system_data_idx => system_data.write(.erd_some_bool, true),
-        SystemErds.erd.erd_unaligned_u16.system_data_idx => system_data.write(.erd_some_bool, false),
+        SystemData.erd_from_enum_pub(.cool_u16).system_data_idx => system_data.write(.some_bool, true),
+        SystemData.erd_from_enum_pub(.unaligned_u16).system_data_idx => system_data.write(.some_bool, false),
         else => {},
     }
 }
 
 test "subscription args using system_data_idx" {
-    var system_data = SystemData.init();
+    var system_data = TestSystem.init();
 
-    system_data.subscribe(.erd_cool_u16, null, switch_on_system_data_idx);
-    system_data.subscribe(.erd_some_bool, null, switch_on_system_data_idx);
-    system_data.subscribe(.erd_unaligned_u16, null, switch_on_system_data_idx);
+    system_data.subscribe(.cool_u16, null, switch_on_system_data_idx);
+    system_data.subscribe(.some_bool, null, switch_on_system_data_idx);
+    system_data.subscribe(.unaligned_u16, null, switch_on_system_data_idx);
 
-    try std.testing.expectEqual(0, system_data.read(.erd_best_u16));
+    try std.testing.expectEqual(0, system_data.read(.best_u16));
 
-    system_data.write(.erd_cool_u16, 1);
-    try std.testing.expectEqual(1, system_data.read(.erd_best_u16));
-    try std.testing.expectEqual(true, system_data.read(.erd_some_bool));
+    system_data.write(.cool_u16, 1);
+    try std.testing.expectEqual(1, system_data.read(.best_u16));
+    try std.testing.expectEqual(true, system_data.read(.some_bool));
 
-    system_data.write(.erd_cool_u16, 2);
-    try std.testing.expectEqual(2, system_data.read(.erd_best_u16));
-    try std.testing.expectEqual(true, system_data.read(.erd_some_bool));
+    system_data.write(.cool_u16, 2);
+    try std.testing.expectEqual(2, system_data.read(.best_u16));
+    try std.testing.expectEqual(true, system_data.read(.some_bool));
 
-    system_data.write(.erd_unaligned_u16, 1);
-    try std.testing.expectEqual(3, system_data.read(.erd_best_u16));
-    try std.testing.expectEqual(false, system_data.read(.erd_some_bool));
+    system_data.write(.unaligned_u16, 1);
+    try std.testing.expectEqual(3, system_data.read(.best_u16));
+    try std.testing.expectEqual(false, system_data.read(.some_bool));
 
-    system_data.write(.erd_some_bool, true);
-    try std.testing.expectEqual(3, system_data.read(.erd_best_u16));
-    try std.testing.expectEqual(true, system_data.read(.erd_some_bool));
+    system_data.write(.some_bool, true);
+    try std.testing.expectEqual(3, system_data.read(.best_u16));
+    try std.testing.expectEqual(true, system_data.read(.some_bool));
 }
 
 fn bump_some_u16(_: ?*anyopaque, _: ?*const anyopaque, publisher: *anyopaque) void {
     var system_data: *SystemData = @ptrCast(@alignCast(publisher));
 
-    system_data.write(.erd_unaligned_u16, system_data.read(.erd_unaligned_u16) + 1);
+    system_data.write(.unaligned_u16, system_data.read(.unaligned_u16) + 1);
 }
 
 test "double sub test" {
-    var system_data = SystemData.init();
-    system_data.subscribe(.erd_some_bool, null, turn_off_some_bool_and_increment_application_version);
-    system_data.subscribe(.erd_some_bool, null, bump_some_u16);
+    var system_data = TestSystem.init();
+    system_data.subscribe(.some_bool, null, turn_off_bool_and_bump_version);
+    system_data.subscribe(.some_bool, null, bump_some_u16);
 
-    system_data.write(.erd_some_bool, true);
-    try std.testing.expectEqual(false, system_data.read(.erd_some_bool));
-    try std.testing.expectEqual(2, system_data.read(.erd_application_version));
-    try std.testing.expectEqual(2, system_data.read(.erd_unaligned_u16));
+    system_data.write(.some_bool, true);
+    try std.testing.expectEqual(false, system_data.read(.some_bool));
+    try std.testing.expectEqual(2, system_data.read(.application_version));
+    try std.testing.expectEqual(2, system_data.read(.unaligned_u16));
 
-    system_data.unsubscribe(.erd_some_bool, turn_off_some_bool_and_increment_application_version);
-    system_data.write(.erd_some_bool, true);
-    try std.testing.expectEqual(true, system_data.read(.erd_some_bool));
-    try std.testing.expectEqual(2, system_data.read(.erd_application_version));
-    try std.testing.expectEqual(3, system_data.read(.erd_unaligned_u16));
+    system_data.unsubscribe(.some_bool, turn_off_bool_and_bump_version);
+    system_data.write(.some_bool, true);
+    try std.testing.expectEqual(true, system_data.read(.some_bool));
+    try std.testing.expectEqual(2, system_data.read(.application_version));
+    try std.testing.expectEqual(3, system_data.read(.unaligned_u16));
 }
 
 fn whatever(_: ?*anyopaque, _: ?*const anyopaque, _: *anyopaque) void {}
 
 test "exact subscription enforcement" {
-    var system_data = SystemData.init();
+    var system_data = TestSystem.init();
 
-    system_data.subscribe(.erd_some_bool, null, whatever);
-    system_data.subscribe(.erd_some_bool, null, bump_some_u16);
-    system_data.subscribe(.erd_unaligned_u16, null, whatever);
-    system_data.subscribe(.erd_cool_u16, null, whatever);
+    system_data.subscribe(.some_bool, null, whatever);
+    system_data.subscribe(.some_bool, null, bump_some_u16);
+    system_data.subscribe(.unaligned_u16, null, whatever);
+    system_data.subscribe(.cool_u16, null, whatever);
 
-    // TODO: Move this test into the Application test file
-    // and replace all of the above with `application.init`
     const exceptions = [_]SystemData.SubException{
-        .{ .erd_enum = .erd_some_bool, .missing = 1 },
+        .{ .erd_enum = .some_bool, .missing = 1 },
     };
     try system_data.verify_all_subs_are_saturated(&exceptions);
 }
@@ -257,27 +236,23 @@ fn scratch_allocating(_: ?*anyopaque, _args: ?*const anyopaque, publisher: *anyo
         item.* = @intCast(i);
     }
 
-    system_data.write(.erd_application_version, allocated[allocated.len - 1]);
+    system_data.write(.application_version, allocated[allocated.len - 1]);
 }
 
 test "scratch allocations" {
-    var system_data: SystemData = .init();
+    var system_data: SystemData = TestSystem.init();
 
-    system_data.subscribe(.erd_unaligned_u16, null, scratch_allocating);
-    system_data.write(.erd_unaligned_u16, 7);
-    try std.testing.expectEqual(7, system_data.read(.erd_application_version));
+    system_data.subscribe(.unaligned_u16, null, scratch_allocating);
+    system_data.write(.unaligned_u16, 7);
+    try std.testing.expectEqual(7, system_data.read(.application_version));
 
     system_data.scratch_reset();
 
-    system_data.write(.erd_unaligned_u16, 5);
-    try std.testing.expectEqual(5, system_data.read(.erd_application_version));
+    system_data.write(.unaligned_u16, 5);
+    try std.testing.expectEqual(5, system_data.read(.application_version));
 
-    const more_allocation = system_data.scratch_alloc(u8, system_data.read(.erd_application_version));
+    const more_allocation = system_data.scratch_alloc(u8, system_data.read(.application_version));
     try std.testing.expect(system_data.scratch.ownsSlice(more_allocation));
 
     system_data.scratch_reset();
-    // NOTE: The below doesn't fail, but depending on optimization level may yield different results!
-    // One must be very careful since this data is now considered freed, but there's no runtime check on it.
-    // system_data.write(.erd_application_version, more_allocation[0]);
-    // try std.testing.expectEqual(0b10101010, system_data.read(.erd_application_version));
 }

--- a/src/tests/system_data_test.zig
+++ b/src/tests/system_data_test.zig
@@ -155,6 +155,9 @@ fn switch_on_system_data_idx(_: ?*anyopaque, _args: ?*const anyopaque, publisher
     }
 
     switch (args.system_data_idx) {
+        // Ideally I'd like to type this instead:
+        // .cool_u16 => system_data.write(.some_bool, true)
+        // TODO: That probably requires unifying `system_data_idx` and `ErdEnum` to be the same thing
         SystemData.erd_from_enum(.cool_u16).system_data_idx => system_data.write(.some_bool, true),
         SystemData.erd_from_enum(.unaligned_u16).system_data_idx => system_data.write(.some_bool, false),
         else => {},
@@ -220,6 +223,8 @@ test "exact subscription enforcement" {
     system_data.subscribe(.unaligned_u16, null, whatever);
     system_data.subscribe(.cool_u16, null, whatever);
 
+    // TODO: Move this test into the Application test file
+    // and replace all of the above with `application.init`
     const exceptions = [_]SystemData.SubException{
         .{ .erd_enum = .some_bool, .missing = 1 },
     };
@@ -255,4 +260,8 @@ test "scratch allocations" {
     try std.testing.expect(system_data.scratch.ownsSlice(more_allocation));
 
     system_data.scratch_reset();
+    // NOTE: The below doesn't fail, but depending on optimization level may yield different results!
+    // One must be very careful since this data is now considered freed, but there's no runtime check on it.
+    // system_data.write(.application_version, more_allocation[0]);
+    // try std.testing.expectEqual(0b10101010, system_data.read(.application_version));
 }


### PR DESCRIPTION
Decouples SystemErds from SystemData and allows for the software to have more than one of these tables in existence. This naturally enables test doubles and will allow for a clean split between library code and application glue code (the latter will come in a later PR). 

The main enabler for this is using generic programming to force the instantiation of unique `DataComponent` and `SystemData` types. Essentially you configure yourself into the topology you want, and then you can use everything normally. 

Modules depending on `SystemData` now depend on a `SystemDataType`. That's the only difference. You essentially instantiate a type that knows how to work with the `SystemData` in question.

You also still benefit from intellisense (or at least have the option to), since the creation of a `SystemData` type takes in the `ErdEnum` rather than constructing it for you (like the test double does). That means the same trick of manually maintaining a matching enum to your `SystemErds` struct lets `SystemData.read(.` auto complete to the list of ERDs. Very cool.