### PR TITLE
Update zlinter hash to match upstream 0.16.x branch

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -11,7 +11,7 @@
         .elf_size = .{ .path = "elf_size" },
         .zlinter = .{
             .url = "git+https://github.com/KurtWagner/zlinter#0.16.x",
-            .hash = "zlinter-0.0.1-OjQ08c7oCwDIwhlde7eDKMACNTsqAhGXy5vB7GdfGobG",
+            .hash = "zlinter-0.0.1-OjQ08avrCwDXLzWbn6PYtfEopUVPSxuNQDJ1dGvRhhCp",
         },
     },
 


### PR DESCRIPTION
## Summary
- The `zlinter` dependency tracks the `0.16.x` branch, which moved upstream after the recorded hash was captured.
- CI on master started failing with `hash mismatch` for `zlinter-0.0.1-OjQ08c7o...` vs the freshly fetched `zlinter-0.0.1-OjQ08avr...`.
- Update `build.zig.zon` to the new hash so fetches verify.

## Test plan
- [x] `zig build lint` succeeds locally
- [x] `zig build test -Doptimize=ReleaseSmall` succeeds locally
- [x] CI lint + test jobs pass on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)