### PR TITLE
Various bug fixes, refactors, and test coverage across all packages

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Repository Structure
 
-This is a **multi-package monorepo** with five Zig packages:
+This is a **multi-package monorepo** with six Zig packages:
 
 | Package | Path | Description |
 |---------|------|-------------|
@@ -13,6 +13,7 @@ This is a **multi-package monorepo** with five Zig packages:
 | **data_gen** | `data_gen/` | Constraint-based data generation for property-based testing |
 | **app** | `app/` | Demo application - wires ERD definitions to concrete components |
 | **esp8266** | `esp8266/` | ESP8266 firmware via Zig C backend - WiFi scanning, erd_core integration, LED blink |
+| **elf_size** | `elf_size/` | ELF section-size reporter for embedded firmware builds |
 
 ## Build & Test Commands
 
@@ -43,12 +44,16 @@ This is a **typed publish-subscribe data system** for embedded/real-time Zig app
 
 **ERD (Entity-Reference-Designator)** - A named, typed data field with a 16-bit handle. Each ERD declares its type, owner, and subscription slot count at comptime.
 
-**SystemData** - Top-level aggregator that owns data components and subscription arrays. Provides the public API: `read`, `write`, `subscribe`, `unsubscribe`, `publish`. Also has `runtime_read`/`runtime_write` for dynamic ERD access.
+**SystemData** - Top-level aggregator that owns data components and subscription arrays. Provides the public API: `read`, `write`, `modify`, `subscribe`, `unsubscribe`. Also has `runtimeRead`/`runtimeWrite` for dynamic ERD access. SystemData's comptime block rejects duplicate `erd_number` values in the ERD table.
 
 **Data Components** own ERDs and provide storage:
 - **RamDataComponent** (`erd_core/src/ram_data_component.zig`) - Packed byte-array storage with comptime-optimized reads/writes and on-change subscriptions.
 - **IndirectDataComponent** (`erd_core/src/indirect_data_component.zig`) - Read-only computed values via function pointers.
 - **ConvertedDataComponent** (`erd_core/src/converted_data_component.zig`) - Derived data computed from other ERDs via mappings.
+
+**erd_table** (`erd_core/src/erd_table.zig`) - Comptime helpers for populating `ErdDefinitions` instances: `autofill` assigns `data_component_idx`/`system_data_idx`; `numErdsByComponent` and `collectByComponent` extract per-component ERD slices.
+
+**erd_mapping** (`erd_core/src/erd_mapping.zig`) - Comptime helpers shared by IndirectDataComponent and ConvertedDataComponent for resolving ERD-to-function-pointer mappings.
 
 **Subscription** - Fixed-size callback arrays per ERD, identity by function pointer.
 
@@ -62,7 +67,7 @@ This is a **typed publish-subscribe data system** for embedded/real-time Zig app
 
 ### Data Generation Framework (data_gen)
 
-`data_gen/src/` - Constraint-based data generation for property-based testing. Completely standalone (no dependencies beyond std).
+`data_gen/src/` - Constraint-based comptime validation of embedded system configurations. Provides four modules: `constraint` (primitive checks returning `?[]const u8`), `contract` (recursive `contractValidate` protocol on struct/array fields), `transform` (float->fixed-point/scaled-int conversions with exactness errors), `generator` (comptime array builders for lookup tables). Completely standalone (no dependencies beyond std).
 
 ### Application (app)
 
@@ -78,6 +83,7 @@ Each package has its own tests aggregated via `src/root.zig` test blocks. The ro
 - **erd_schema** depends on `erd_core` (path dep)
 - **data_gen** has no dependencies
 - **app** depends on `erd_core` and `erd_schema` (path deps)
+- **elf_size** has no dependencies (standalone CLI + library)
 - **esp8266** depends on `erd_core` (via C backend `--dep`/`-M` flags), ESP8266 NonOS SDK 2.2.1 (git cloned to `esp8266/sdk/`, gitignored), `xtensa-lx106-elf-gcc` (apt), `esptool` (apt)
 
 ## Code Style
@@ -96,4 +102,4 @@ Before committing, run `zig build lint` from the repo root to check for style vi
 
 ## Formatting
 
-After completing any code changes, run `zig fmt erd_core/src/ erd_schema/src/ data_gen/src/ app/src/ esp8266/src/ esp8266/build.zig` to format all packages before reporting results.
+After completing any code changes, run `zig fmt erd_core/src/ erd_schema/src/ data_gen/src/ app/src/ elf_size/src/ esp8266/src/ esp8266/build.zig` to format all packages before reporting results.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # zig-pub-sub
 
-A typed publish-subscribe data system for embedded/real-time Zig applications. Uses comptime ERD (Entity-Reference-Descriptor) definitions to achieve zero-cost abstractions over static memory.
+A typed publish-subscribe data system for embedded/real-time Zig applications. Uses comptime ERD (Entity-Reference-Designator) definitions to achieve zero-cost abstractions over static memory.
 
 ## Packages
 
@@ -10,6 +10,8 @@ A typed publish-subscribe data system for embedded/real-time Zig applications. U
 | [`erd_schema`](erd_schema/) | ERD serialization - transforms ERD definitions into JSON |
 | [`data_gen`](data_gen/) | Constraint-based data generation |
 | [`app`](app/) | Demo application wiring ERD definitions to concrete components |
+| [`esp8266`](esp8266/) | ESP8266 firmware: erd_core on an embedded target via the Zig C backend |
+| [`elf_size`](elf_size/) | ELF section-size reporter for embedded firmware builds |
 
 ## Quick Start
 

--- a/app/src/app.zig
+++ b/app/src/app.zig
@@ -51,22 +51,12 @@ pub const Components = struct {
 
     comptime {
         const Id = system_erds.ComponentId;
-        const expected = .{
-            .{ Id.ram, RamDataComponent },
-            .{ Id.indirect, IndirectDataComponent },
-            .{ Id.converted, ConvertedDataComponent },
-        };
-        for (expected) |e| {
-            const id, const Expected = e;
-            const idx = @intFromEnum(id);
-            const Actual = std.meta.fields(Components)[idx].type;
-            if (Actual != Expected) {
-                @compileError(std.fmt.comptimePrint(
-                    "ComponentId.{s} (index {}) maps to {s}, expected {s}",
-                    .{ @tagName(id), idx, @typeName(Actual), @typeName(Expected) },
-                ));
-            }
-        }
+        if (std.meta.fields(Components)[@intFromEnum(Id.ram)].type != RamDataComponent)
+            @compileError("ComponentId.ram does not match RamDataComponent position in Components");
+        if (std.meta.fields(Components)[@intFromEnum(Id.indirect)].type != IndirectDataComponent)
+            @compileError("ComponentId.indirect does not match IndirectDataComponent position in Components");
+        if (std.meta.fields(Components)[@intFromEnum(Id.converted)].type != ConvertedDataComponent)
+            @compileError("ComponentId.converted does not match ConvertedDataComponent position in Components");
     }
 };
 

--- a/app/src/app.zig
+++ b/app/src/app.zig
@@ -51,12 +51,22 @@ pub const Components = struct {
 
     comptime {
         const Id = system_erds.ComponentId;
-        if (std.meta.fields(Components)[@intFromEnum(Id.ram)].type != RamDataComponent)
-            @compileError("ComponentId.ram does not match RamDataComponent position in Components");
-        if (std.meta.fields(Components)[@intFromEnum(Id.indirect)].type != IndirectDataComponent)
-            @compileError("ComponentId.indirect does not match IndirectDataComponent position in Components");
-        if (std.meta.fields(Components)[@intFromEnum(Id.converted)].type != ConvertedDataComponent)
-            @compileError("ComponentId.converted does not match ConvertedDataComponent position in Components");
+        const expected = .{
+            .{ Id.ram, RamDataComponent },
+            .{ Id.indirect, IndirectDataComponent },
+            .{ Id.converted, ConvertedDataComponent },
+        };
+        for (expected) |e| {
+            const id, const Expected = e;
+            const idx = @intFromEnum(id);
+            const Actual = std.meta.fields(Components)[idx].type;
+            if (Actual != Expected) {
+                @compileError(std.fmt.comptimePrint(
+                    "ComponentId.{s} (index {}) maps to {s}, expected {s}",
+                    .{ @tagName(id), idx, @typeName(Actual), @typeName(Expected) },
+                ));
+            }
+        }
     }
 };
 

--- a/app/src/main.zig
+++ b/app/src/main.zig
@@ -5,7 +5,7 @@ const system_erds = @import("system_erds.zig");
 /// Application entry point that dumps ERD definitions as JSON.
 // zlinter-disable-next-line no_inferred_error_unions
 pub fn main() !void {
-    const max_json_size = comptime std.fmt.parseIntSizeSuffix("1MiB", 10) catch unreachable; // zlinter-disable-current-line no_swallow_error
+    const max_json_size = 1 << 20; // 1 MiB
     var buf: [max_json_size]u8 = undefined;
 
     var out = std.Io.Writer.fixed(&buf);

--- a/app/src/main.zig
+++ b/app/src/main.zig
@@ -5,7 +5,7 @@ const system_erds = @import("system_erds.zig");
 /// Application entry point that dumps ERD definitions as JSON.
 // zlinter-disable-next-line no_inferred_error_unions
 pub fn main() !void {
-    const max_json_size = 1 << 20; // 1 MiB
+    const max_json_size = comptime std.fmt.parseIntSizeSuffix("1MiB", 10) catch unreachable; // zlinter-disable-current-line no_swallow_error
     var buf: [max_json_size]u8 = undefined;
 
     var out = std.Io.Writer.fixed(&buf);

--- a/app/src/system_erds.zig
+++ b/app/src/system_erds.zig
@@ -1,5 +1,4 @@
 const erd_core = @import("erd_core");
-const std = @import("std");
 const Erd = erd_core.Erd;
 const TimerStats = erd_core.common.timer_stats;
 
@@ -14,22 +13,12 @@ const Ram = @intFromEnum(ComponentId.ram);
 const Indirect = @intFromEnum(ComponentId.indirect);
 const Converted = @intFromEnum(ComponentId.converted);
 
-/// `ErdEnum` allows for use of decl literals which makes API use of ERDs *significantly* shorter
+/// `ErdEnum` allows for use of decl literals which makes API use of ERDs *significantly* shorter.
+/// Must match `ErdDefinitions` field names 1:1 in order. `std.meta.FieldEnum(ErdDefinitions)`
+/// would remove the duplication but loses LSP autocomplete.
 pub const ErdEnum = enum {
-    // This must match one to one with ErdDefinitions
-    //
-    // `std.meta.FieldEnum(ErdDefinitions)` would get rid of the duplication,
-    // but probably shouldn't be used until the LSP support would allow auto-complete
-    //
-    // for the meantime let's just throw a compile error if it fails to match
     comptime {
-        const erd_fields = std.meta.fieldNames(ErdDefinitions);
-        const erd_enum_names = std.meta.fieldNames(ErdEnum);
-        for (erd_fields, erd_enum_names) |field_name, enum_name| {
-            if (!std.mem.eql(u8, field_name, enum_name)) {
-                @compileError(std.fmt.comptimePrint("Field {s} does not match enum {s}", .{ field_name, enum_name }));
-            }
-        }
+        erd_core.erd_table.validateEnumMatchesDefs(ErdEnum, ErdDefinitions);
     }
 
     erd_application_version,
@@ -66,68 +55,17 @@ pub const ErdDefinitions = struct {
     // zig fmt: on
 };
 
-/// Erd Definitions with autofilled indexes
-pub const erd = blk: {
-    var _erds = ErdDefinitions{};
-
-    var max_component_idx: comptime_int = 0;
-    for (std.meta.fieldNames(ErdDefinitions)) |erd_field_name| {
-        const idx = @field(_erds, erd_field_name).component_idx;
-        if (idx > max_component_idx) max_component_idx = idx;
-    }
-
-    var owning_counts = std.mem.zeroes([max_component_idx + 1]u16);
-    for (std.meta.fieldNames(ErdDefinitions)) |erd_field_name| {
-        const idx = @field(_erds, erd_field_name).component_idx;
-        @field(_erds, erd_field_name).data_component_idx = owning_counts[idx];
-        owning_counts[idx] += 1;
-    }
-
-    // Assert because prints below assume this ERD size
-    std.debug.assert(0xffff == std.math.maxInt(Erd.ErdHandle));
-    var set: std.bit_set.ArrayBitSet(usize, std.math.maxInt(Erd.ErdHandle)) = .empty;
-
-    for (std.meta.fieldNames(ErdDefinitions), 0..) |erd_field_name, i| {
-        @field(_erds, erd_field_name).system_data_idx = i;
-
-        if (@field(_erds, erd_field_name).erd_number) |num| {
-            if (set.isSet(num)) {
-                @compileError(std.fmt.comptimePrint("Multiple ERD definitions with number 0x{x:0>4}", .{num}));
-            } else {
-                set.set(num);
-            }
-        }
-    }
-
-    break :blk _erds;
-};
+/// ERD definitions with `data_component_idx` and `system_data_idx` auto-assigned.
+pub const erd = erd_core.erd_table.autofill(ErdDefinitions);
 
 /// Count ERDs belonging to the given component.
 pub fn numErds(comptime id: ComponentId) comptime_int {
-    const component_idx = @intFromEnum(id);
-    var i = 0;
-    for (std.meta.fieldNames(ErdDefinitions)) |erd_name| {
-        if (@field(erd, erd_name).component_idx == component_idx) {
-            i += 1;
-        }
-    }
-    return i;
+    return erd_core.erd_table.numErdsByComponent(erd, @intFromEnum(id));
 }
 
 /// Extract ERD definitions for a specific component as an array.
 pub fn componentDefinitions(comptime id: ComponentId) [numErds(id)]Erd {
-    const component_idx = @intFromEnum(id);
-    var _erds: [numErds(id)]Erd = undefined;
-    var i = 0;
-
-    for (std.meta.fieldNames(ErdDefinitions)) |erd_name| {
-        if (@field(erd, erd_name).component_idx == component_idx) {
-            _erds[i] = @field(erd, erd_name);
-            i += 1;
-        }
-    }
-
-    return _erds;
+    return erd_core.erd_table.collectByComponent(erd, @intFromEnum(id));
 }
 
 // Array versions of ERDs. For easier iteration.

--- a/app/src/system_erds.zig
+++ b/app/src/system_erds.zig
@@ -14,13 +14,9 @@ const Indirect = @intFromEnum(ComponentId.indirect);
 const Converted = @intFromEnum(ComponentId.converted);
 
 /// `ErdEnum` allows for use of decl literals which makes API use of ERDs *significantly* shorter.
-/// Must match `ErdDefinitions` field names 1:1 in order. `std.meta.FieldEnum(ErdDefinitions)`
-/// would remove the duplication but loses LSP autocomplete.
+/// Variants are listed out manually (rather than via `std.meta.FieldEnum(ErdDefinitions)`)
+/// so LSP autocomplete works; ordering is checked against `ErdDefinitions` inside `SystemData`.
 pub const ErdEnum = enum {
-    comptime {
-        erd_core.erd_table.validateEnumMatchesDefs(ErdEnum, ErdDefinitions);
-    }
-
     erd_application_version,
     erd_some_bool,
     erd_unaligned_u16,

--- a/build.zig
+++ b/build.zig
@@ -84,6 +84,17 @@ pub fn build(b: *std.Build) void {
     data_gen_tests.root_module.addImport("data_gen", data_gen_tests.root_module);
     test_step.dependOn(&b.addRunArtifact(data_gen_tests).step);
 
+    // elf_size tests
+    const elf_size_dep = b.dependency("elf_size", .{ .target = target, .optimize = optimize });
+    const elf_size_tests = b.addTest(.{
+        .root_module = b.createModule(.{
+            .root_source_file = elf_size_dep.path("src/root.zig"),
+            .target = target,
+            .optimize = optimize,
+        }),
+    });
+    test_step.dependOn(&b.addRunArtifact(elf_size_tests).step);
+
     // --- Run step (forwards to app) ---
     const app_exe = app_dep.artifact("zig-pub-sub");
     const run_cmd = b.addRunArtifact(app_exe);

--- a/data_gen/README.md
+++ b/data_gen/README.md
@@ -1,7 +1,9 @@
 # data_gen
 
-Constraint-based data generation framework for compile-time validation
-of embedded system configurations. No runtime dependencies.
+Constraint-based data generation framework: compile-time validation,
+transformation, and generation of data tables. Often handy for embedded
+system configurations but not specific to them - any project that wants
+comptime-checked data tables can use it. No runtime dependencies.
 
 ## Concepts
 
@@ -10,8 +12,10 @@ of embedded system configurations. No runtime dependencies.
 - **contract**: protocol for types that carry their own validation.
   A type opts in by declaring
   `pub fn contractValidate(comptime self: T) ?[]const u8`.
-  `assertValid` / `validated` recursively walk struct fields and array
-  elements, invoking `contractValidate` on every nested type that has one.
+  `assertValid` / `validated` descend through struct fields, array and
+  slice elements, single-item pointers, present optionals, and the
+  active variant of tagged unions, invoking `contractValidate` on every
+  reachable type that has one.
 - **transform**: convert human-readable units (floats, percentages,
   frequencies) into machine representations (fixed-point, scaled
   integers, tick counts). Compile error if not exactly representable,
@@ -25,7 +29,7 @@ of embedded system configurations. No runtime dependencies.
 const constraint = @import("data_gen").constraint;
 const contract = @import("data_gen").contract;
 
-// Primitive constraints — comptime, return null on pass.
+// Primitive constraints - comptime, return null on pass.
 comptime {
     if (constraint.inRange(0, 100, 42)) |err| @compileError(err);
     if (constraint.isPowerOfTwo(1024)) |err| @compileError(err);

--- a/data_gen/README.md
+++ b/data_gen/README.md
@@ -1,13 +1,14 @@
 # data_gen
 
-Constraint-based data generation framework: compile-time validation,
-transformation, and generation of data tables. Often handy for embedded
-system configurations but not specific to them - any project that wants
-comptime-checked data tables can use it. No runtime dependencies.
+Constraint-based data generation framework.
+
+Provides compile-time validation, transformation, and generation of structured data. 
+Functions designed to be used at `comptime`, but can also be used in
+runtime contexts as well.
 
 ## Concepts
 
-- **constraint**: primitive comptime checks. Each returns `?[]const u8`
+- **constraint**: primitive checks. Each returns `?[]const u8`
   (null = passed, a string = error message).
 - **contract**: protocol for types that carry their own validation.
   A type opts in by declaring

--- a/data_gen/README.md
+++ b/data_gen/README.md
@@ -1,25 +1,52 @@
 # data_gen
 
-Constraint-based data generation framework.
+Constraint-based data generation framework for compile-time validation
+of embedded system configurations. No runtime dependencies.
 
-Provides composable constraints that can validate whether data matches
-specified rules. Uses no external dependencies.
+## Concepts
+
+- **constraint**: primitive comptime checks. Each returns `?[]const u8`
+  (null = passed, a string = error message).
+- **contract**: protocol for types that carry their own validation.
+  A type opts in by declaring
+  `pub fn contractValidate(comptime self: T) ?[]const u8`.
+  `assertValid` / `validated` recursively walk struct fields and array
+  elements, invoking `contractValidate` on every nested type that has one.
+- **transform**: convert human-readable units (floats, percentages,
+  frequencies) into machine representations (fixed-point, scaled
+  integers, tick counts). Compile error if not exactly representable,
+  with the two nearest representable values in the message.
+- **generator**: comptime array generators (`generateArray`) for
+  lookup tables, calibration arrays, repeated configs.
 
 ## Usage
 
 ```zig
-const DataGen = @import("data_gen").DataGen;
-const Constraint = DataGen.Constraint;
+const constraint = @import("data_gen").constraint;
+const contract = @import("data_gen").contract;
 
-const range = Constraint.in_range(0, 100);
-const valid = try range.evaluate(@as(i32, 42)); // true
+// Primitive constraints — comptime, return null on pass.
+comptime {
+    if (constraint.inRange(0, 100, 42)) |err| @compileError(err);
+    if (constraint.isPowerOfTwo(1024)) |err| @compileError(err);
+}
 
-const elements = Constraint.array_elements(&Constraint.in_range(0, 10));
-const ok = try elements.evaluate([_]i32{ 1, 5, 8 }); // true
+// Recursive struct validation via contractValidate.
+const Sensor = struct {
+    min: i16,
+    max: i16,
+
+    pub fn contractValidate(comptime self: Sensor) ?[]const u8 {
+        if (self.min >= self.max) return "min must be less than max";
+        return null;
+    }
+};
+
+const sensor = comptime contract.validated(Sensor{ .min = -40, .max = 125 });
 ```
 
 ## Build
 
 ```bash
-zig build test  # Run unit tests
+zig build test  # Run unit tests, including the comptime examples in tests/examples/
 ```

--- a/data_gen/src/constraint.zig
+++ b/data_gen/src/constraint.zig
@@ -40,7 +40,8 @@ pub fn lenInRange(comptime min: usize, comptime max: usize, comptime actual: usi
     return null;
 }
 
-/// Checks array is sorted in ascending order.
+/// Checks array is sorted in non-decreasing order (equal adjacent values
+/// are allowed). For strictly ascending, combine with `noDuplicates`.
 pub fn isSorted(T: type, comptime arr: []const T) ?[]const u8 {
     if (arr.len < 2) return null;
     for (1..arr.len) |i| {
@@ -56,7 +57,7 @@ pub fn noDuplicates(T: type, comptime arr: []const T) ?[]const u8 {
     for (0..arr.len) |i| {
         for (i + 1..arr.len) |j| {
             if (arr[i] == arr[j]) {
-                return std.fmt.comptimePrint("duplicate value at indices {} and {}", .{ i, j });
+                return std.fmt.comptimePrint("duplicate value {} at indices {} and {}", .{ arr[i], i, j });
             }
         }
     }
@@ -66,7 +67,9 @@ pub fn noDuplicates(T: type, comptime arr: []const T) ?[]const u8 {
 /// Checks value is a power of two. Value must be unsigned and non-zero.
 pub fn isPowerOfTwo(comptime value: anytype) ?[]const u8 {
     const T = @TypeOf(value);
-    if (@typeInfo(T) == .int and @typeInfo(T).int.signedness == .signed)
+    const info = @typeInfo(T);
+    const is_signed = (info == .int and info.int.signedness == .signed) or info == .comptime_int and value < 0;
+    if (is_signed)
         return "isPowerOfTwo requires an unsigned integer";
     if (value == 0 or (value & (value - 1)) != 0) {
         return std.fmt.comptimePrint("{} is not a power of two", .{value});

--- a/data_gen/src/constraint.zig
+++ b/data_gen/src/constraint.zig
@@ -52,12 +52,15 @@ pub fn isSorted(T: type, comptime arr: []const T) ?[]const u8 {
     return null;
 }
 
-/// Checks no duplicate values in the array.
+/// Checks no duplicate values in the array. Equality is by `std.meta.eql`
+/// so structs, optionals, arrays, and pointers (compared by address) all
+/// work; the offending value is not printed because not every `T` has a
+/// usable `{}` formatter.
 pub fn noDuplicates(T: type, comptime arr: []const T) ?[]const u8 {
     for (0..arr.len) |i| {
         for (i + 1..arr.len) |j| {
-            if (arr[i] == arr[j]) {
-                return std.fmt.comptimePrint("duplicate value {} at indices {} and {}", .{ arr[i], i, j });
+            if (std.meta.eql(arr[i], arr[j])) {
+                return std.fmt.comptimePrint("duplicate value at indices {} and {}", .{ i, j });
             }
         }
     }

--- a/data_gen/src/contract.zig
+++ b/data_gen/src/contract.zig
@@ -5,6 +5,11 @@
 //! assertValid/validated recursively walk struct fields and array elements,
 //! calling contractValidate on each sub-value that has one. Users get
 //! automatic deep validation without manually calling child validates.
+//!
+//! Recursion stops at non-struct, non-array fields — in particular,
+//! pointers, optionals, and unions are NOT followed. If you need to
+//! validate behind a pointer/optional, the parent struct's
+//! `contractValidate` must do it explicitly.
 
 const std = @import("std");
 
@@ -37,26 +42,19 @@ pub fn check(comptime value: anytype, comptime path: []const u8) ?[]const u8 {
             }
             inline for (info.fields) |field| {
                 const field_val = @field(value, field.name);
-                const field_path = if (path.len == 0) "." ++ field.name else path ++ "." ++ field.name;
-                if (checkInner(field.type, field_val, field_path)) |err| return err;
+                const field_path = path ++ "." ++ field.name;
+                if (check(field_val, field_path)) |err| return err;
             }
         },
-        .array => |arr_info| {
+        .array => {
             @setEvalBranchQuota(value.len * 1000 + 4000);
             for (0..value.len) |idx| {
                 const elem_path = path ++ std.fmt.comptimePrint("[{}]", .{idx});
-                if (checkInner(arr_info.child, value[idx], elem_path)) |err| return err;
+                if (check(value[idx], elem_path)) |err| return err;
             }
         },
         else => {},
     }
 
     return null;
-}
-
-fn checkInner(T: type, comptime value: T, comptime path: []const u8) ?[]const u8 {
-    switch (@typeInfo(T)) {
-        .@"struct", .array => return check(value, path),
-        else => return null,
-    }
 }

--- a/data_gen/src/contract.zig
+++ b/data_gen/src/contract.zig
@@ -2,14 +2,13 @@
 //! by declaring `pub fn contractValidate(comptime self: T) ?[]const u8`
 //! which returns null on success or an error message string on failure.
 //!
-//! assertValid/validated recursively walk struct fields and array elements,
-//! calling contractValidate on each sub-value that has one. Users get
-//! automatic deep validation without manually calling child validates.
-//!
-//! Recursion stops at non-struct, non-array fields — in particular,
-//! pointers, optionals, and unions are NOT followed. If you need to
-//! validate behind a pointer/optional, the parent struct's
-//! `contractValidate` must do it explicitly.
+//! `contractValidate` is only expected to check the value itself; the
+//! framework handles descent through structural types so that every
+//! `contractValidate` reachable from the root value is run automatically.
+//! Descent happens through: struct fields, array elements, slice elements,
+//! single-item pointer dereferences, present optionals, and the active
+//! variant of a tagged union. Untagged unions and many-item / C pointers
+//! are skipped because the framework can't safely pick what to inspect.
 
 const std = @import("std");
 
@@ -46,11 +45,39 @@ pub fn check(comptime value: anytype, comptime path: []const u8) ?[]const u8 {
                 if (check(field_val, field_path)) |err| return err;
             }
         },
+        .@"union" => |info| {
+            if (@hasDecl(T, "contractValidate")) {
+                if (T.contractValidate(value)) |msg| {
+                    return if (path.len == 0) msg else path ++ ": " ++ msg;
+                }
+            }
+            if (info.tag_type != null) {
+                const tag = std.meta.activeTag(value);
+                const field_path = path ++ "." ++ @tagName(tag);
+                if (check(@field(value, @tagName(tag)), field_path)) |err| return err;
+            }
+        },
         .array => {
             @setEvalBranchQuota(value.len * 1000 + 4000);
             for (0..value.len) |idx| {
                 const elem_path = path ++ std.fmt.comptimePrint("[{}]", .{idx});
                 if (check(value[idx], elem_path)) |err| return err;
+            }
+        },
+        .pointer => |info| switch (info.size) {
+            .one => return check(value.*, path),
+            .slice => {
+                @setEvalBranchQuota(value.len * 1000 + 4000);
+                for (0..value.len) |idx| {
+                    const elem_path = path ++ std.fmt.comptimePrint("[{}]", .{idx});
+                    if (check(value[idx], elem_path)) |err| return err;
+                }
+            },
+            .many, .c => {},
+        },
+        .optional => {
+            if (value) |unwrapped| {
+                if (check(unwrapped, path)) |err| return err;
             }
         },
         else => {},

--- a/data_gen/src/root.zig
+++ b/data_gen/src/root.zig
@@ -1,8 +1,6 @@
-//! Constraint-based data generation framework: comptime data validation,
-//! transformation, and generation. Often handy for embedded configurations
-//! but not specific to them - any project that wants comptime-checked
-//! data tables can use it. Four sub-modules:
-//!   - `constraint`: primitive comptime checks. Each returns `?[]const u8`
+//! Constraint-based data generation framework. Provides comptime data validation,
+//! transformation, and generation. Four sub-modules:
+//!   - `constraint`: primitive checks. Each returns `?[]const u8`
 //!     (null = passed, string = error message).
 //!   - `contract`: recursive `contractValidate` protocol that auto-walks struct
 //!     fields and array elements, calling each sub-value's `contractValidate`.

--- a/data_gen/src/root.zig
+++ b/data_gen/src/root.zig
@@ -1,7 +1,12 @@
-//! Comptime constraint-based data generation for embedded system configurations.
-//! Users define types with contractValidate functions. Constraints return
-//! ?[]const u8 (null = passed, string = error message) and compose with
-//! the contracts protocol for recursive struct validation.
+//! Comptime data validation and generation for embedded system configurations.
+//! Four sub-modules:
+//!   - `constraint`: primitive comptime checks. Each returns `?[]const u8`
+//!     (null = passed, string = error message).
+//!   - `contract`: recursive `contractValidate` protocol that auto-walks struct
+//!     fields and array elements, calling each sub-value's `contractValidate`.
+//!   - `transform`: float-to-fixed-point / scaled-integer / percent conversions
+//!     with `@compileError` on inexact representation or overflow.
+//!   - `generator`: comptime array builders for lookup tables and the like.
 
 // zlinter-disable require_doc_comment
 pub const constraint = @import("constraint.zig");

--- a/data_gen/src/root.zig
+++ b/data_gen/src/root.zig
@@ -1,5 +1,7 @@
-//! Comptime data validation and generation for embedded system configurations.
-//! Four sub-modules:
+//! Constraint-based data generation framework: comptime data validation,
+//! transformation, and generation. Often handy for embedded configurations
+//! but not specific to them - any project that wants comptime-checked
+//! data tables can use it. Four sub-modules:
 //!   - `constraint`: primitive comptime checks. Each returns `?[]const u8`
 //!     (null = passed, string = error message).
 //!   - `contract`: recursive `contractValidate` protocol that auto-walks struct

--- a/data_gen/src/tests/constraint_test.zig
+++ b/data_gen/src/tests/constraint_test.zig
@@ -117,8 +117,56 @@ test "noDuplicates passes on unique array" {
 test "noDuplicates error message" {
     comptime {
         try std.testing.expectEqualStrings(
-            "duplicate value 5 at indices 0 and 2",
+            "duplicate value at indices 0 and 2",
             constraint.noDuplicates(u8, &.{ 5, 3, 5 }).?,
+        );
+    }
+}
+
+test "noDuplicates works on struct elements" {
+    const Point = struct { x: i32, y: i32 };
+    comptime {
+        if (constraint.noDuplicates(Point, &.{
+            .{ .x = 0, .y = 0 },
+            .{ .x = 1, .y = 2 },
+            .{ .x = 3, .y = 4 },
+        })) |err| @compileError(err);
+
+        try std.testing.expectEqualStrings(
+            "duplicate value at indices 0 and 2",
+            constraint.noDuplicates(Point, &.{
+                .{ .x = 7, .y = 7 },
+                .{ .x = 1, .y = 2 },
+                .{ .x = 7, .y = 7 },
+            }).?,
+        );
+    }
+}
+
+test "noDuplicates works on pointer elements (address equality)" {
+    comptime {
+        const a: u8 = 1;
+        const b: u8 = 2;
+        if (constraint.noDuplicates(*const u8, &.{ &a, &b })) |err| @compileError(err);
+        try std.testing.expectEqualStrings(
+            "duplicate value at indices 0 and 2",
+            constraint.noDuplicates(*const u8, &.{ &a, &b, &a }).?,
+        );
+    }
+}
+
+test "noDuplicates works on optional and array elements" {
+    comptime {
+        if (constraint.noDuplicates(?u8, &.{ null, 1, 2 })) |err| @compileError(err);
+        try std.testing.expectEqualStrings(
+            "duplicate value at indices 0 and 2",
+            constraint.noDuplicates(?u8, &.{ null, 1, null }).?,
+        );
+
+        if (constraint.noDuplicates([2]u8, &.{ .{ 0, 0 }, .{ 0, 1 }, .{ 1, 0 } })) |err| @compileError(err);
+        try std.testing.expectEqualStrings(
+            "duplicate value at indices 0 and 2",
+            constraint.noDuplicates([2]u8, &.{ .{ 0, 0 }, .{ 0, 1 }, .{ 0, 0 } }).?,
         );
     }
 }

--- a/data_gen/src/tests/constraint_test.zig
+++ b/data_gen/src/tests/constraint_test.zig
@@ -53,6 +53,16 @@ test "oneOf error message" {
     }
 }
 
+test "oneOf with empty allowed set always fails" {
+    comptime {
+        const empty: [0]u32 = .{};
+        try std.testing.expectEqualStrings(
+            "value 5 is not in the allowed set: []",
+            constraint.oneOf(&empty, 5).?,
+        );
+    }
+}
+
 test "lenInRange passes within bounds" {
     comptime {
         if (constraint.lenInRange(2, 256, 2)) |err| @compileError(err);
@@ -88,6 +98,13 @@ test "isSorted error message" {
     }
 }
 
+test "isSorted accepts equal adjacent values (non-decreasing)" {
+    comptime {
+        if (constraint.isSorted(u8, &.{ 1, 2, 2, 3 })) |err| @compileError(err);
+        if (constraint.isSorted(u8, &.{ 5, 5, 5 })) |err| @compileError(err);
+    }
+}
+
 test "noDuplicates passes on unique array" {
     comptime {
         if (constraint.noDuplicates(u32, &.{ 1, 2, 3, 4, 5 })) |err| @compileError(err);
@@ -100,7 +117,7 @@ test "noDuplicates passes on unique array" {
 test "noDuplicates error message" {
     comptime {
         try std.testing.expectEqualStrings(
-            "duplicate value at indices 0 and 2",
+            "duplicate value 5 at indices 0 and 2",
             constraint.noDuplicates(u8, &.{ 5, 3, 5 }).?,
         );
     }
@@ -128,6 +145,15 @@ test "isPowerOfTwo rejects signed integers" {
         try std.testing.expectEqualStrings(
             "isPowerOfTwo requires an unsigned integer",
             constraint.isPowerOfTwo(@as(i8, 4)).?,
+        );
+    }
+}
+
+test "isPowerOfTwo rejects negative comptime_int" {
+    comptime {
+        try std.testing.expectEqualStrings(
+            "isPowerOfTwo requires an unsigned integer",
+            constraint.isPowerOfTwo(-4).?,
         );
     }
 }
@@ -176,6 +202,12 @@ test "lessThan error message" {
     }
 }
 
+test "lessThan rejects equal values (strictly less)" {
+    comptime {
+        try std.testing.expectEqualStrings("expected 5 < 5, but it is not", constraint.lessThan(5, 5).?);
+    }
+}
+
 test "greaterThan passes for strictly greater values" {
     comptime {
         if (constraint.greaterThan(10, 5)) |err| @compileError(err);
@@ -186,6 +218,12 @@ test "greaterThan passes for strictly greater values" {
 test "greaterThan error message" {
     comptime {
         try std.testing.expectEqualStrings("expected 3 > 5, but it is not", constraint.greaterThan(3, 5).?);
+    }
+}
+
+test "greaterThan rejects equal values (strictly greater)" {
+    comptime {
+        try std.testing.expectEqualStrings("expected 7 > 7, but it is not", constraint.greaterThan(7, 7).?);
     }
 }
 
@@ -212,6 +250,29 @@ test "anyOf error message lists all failures" {
         try std.testing.expectEqualStrings(
             "no alternative satisfied:\n  - value 50 is outside range [0, 10]\n  - value 50 is outside range [90, 100]",
             result,
+        );
+    }
+}
+
+test "anyOf with single failing alternative" {
+    comptime {
+        const result = constraint.anyOf(&.{
+            constraint.nonZero(0),
+        }).?;
+        try std.testing.expectEqualStrings(
+            "no alternative satisfied:\n  - value must not be zero",
+            result,
+        );
+    }
+}
+
+test "anyOf with empty checks list (vacuous failure)" {
+    comptime {
+        // Empty disjunction has no alternative to satisfy: returns the
+        // base message with no follow-up bullets.
+        try std.testing.expectEqualStrings(
+            "no alternative satisfied:",
+            constraint.anyOf(&.{}).?,
         );
     }
 }

--- a/data_gen/src/tests/contract_test.zig
+++ b/data_gen/src/tests/contract_test.zig
@@ -226,6 +226,98 @@ test "check error message for bare array element failure" {
     }
 }
 
+test "check follows single-item pointer to a struct with contractValidate" {
+    comptime {
+        var bad = BoundedPair{ .low = 50, .high = 10 };
+        try std.testing.expectEqualStrings(
+            ".ptr: low must be less than high",
+            contract.check(struct { ptr: *BoundedPair }{ .ptr = &bad }, "").?,
+        );
+    }
+}
+
+test "check follows pointer-to-array to inner element" {
+    comptime {
+        var items = [_]BoundedPair{
+            .{ .low = 1, .high = 10 },
+            .{ .low = 99, .high = 5 },
+        };
+        try std.testing.expectEqualStrings(
+            ".ptr[1]: low must be less than high",
+            contract.check(struct { ptr: *[2]BoundedPair }{ .ptr = &items }, "").?,
+        );
+    }
+}
+
+test "check iterates a slice of structs" {
+    comptime {
+        const items = [_]BoundedPair{
+            .{ .low = 1, .high = 10 },
+            .{ .low = 20, .high = 30 },
+            .{ .low = 100, .high = 2000 },
+        };
+        const slice: []const BoundedPair = &items;
+        try std.testing.expectEqualStrings(
+            "[2]: high exceeds 1000",
+            contract.check(slice, "").?,
+        );
+    }
+}
+
+test "check unwraps present optionals and skips null optionals" {
+    comptime {
+        const W = struct { maybe: ?BoundedPair };
+        try std.testing.expectEqualStrings(
+            ".maybe: low must be less than high",
+            contract.check(W{ .maybe = .{ .low = 50, .high = 10 } }, "").?,
+        );
+        try std.testing.expectEqual(
+            @as(?[]const u8, null),
+            contract.check(W{ .maybe = null }, ""),
+        );
+    }
+}
+
+test "check descends into the active variant of a tagged union" {
+    const Either = union(enum) {
+        pair: BoundedPair,
+        plain: u8,
+    };
+    comptime {
+        try std.testing.expectEqualStrings(
+            ".u.pair: low must be less than high",
+            contract.check(struct { u: Either }{
+                .u = .{ .pair = .{ .low = 50, .high = 10 } },
+            }, "").?,
+        );
+        try std.testing.expectEqual(
+            @as(?[]const u8, null),
+            contract.check(struct { u: Either }{ .u = .{ .plain = 7 } }, ""),
+        );
+    }
+}
+
+test "check runs contractValidate declared on a union type" {
+    const Tagged = union(enum) {
+        a: u8,
+        b: u16,
+
+        /// Validate constraints for this type.
+        pub fn contractValidate(comptime self: @This()) ?[]const u8 {
+            return switch (self) {
+                .a => |v| if (v == 0) "a must not be zero" else null,
+                .b => null,
+            };
+        }
+    };
+    comptime {
+        try std.testing.expectEqualStrings(
+            "a must not be zero",
+            contract.check(Tagged{ .a = 0 }, "").?,
+        );
+    }
+}
+
 test "check validates nested array of arrays" {
     const Inner = struct {
         val: u8,

--- a/data_gen/src/tests/contract_test.zig
+++ b/data_gen/src/tests/contract_test.zig
@@ -45,6 +45,15 @@ const ThreeLevels = struct {
     id: u8,
 };
 
+const EmptyStruct = struct {}; // zlinter-disable-current-line declaration_naming
+
+const TaggedEmptyStruct = struct { // zlinter-disable-current-line declaration_naming
+    /// Validate constraints for this type.
+    pub fn contractValidate(comptime _: TaggedEmptyStruct) ?[]const u8 {
+        return "always fails";
+    }
+};
+
 test "assertValid passes valid BoundedPair" {
     comptime {
         contract.assertValid(BoundedPair{ .low = 10, .high = 100 });
@@ -54,6 +63,18 @@ test "assertValid passes valid BoundedPair" {
 test "assertValid passes plain struct (no contractValidate)" {
     comptime {
         contract.assertValid(PlainStruct{ .x = 42, .y = 99 });
+    }
+}
+
+test "check on empty struct returns null" {
+    comptime {
+        try std.testing.expectEqual(@as(?[]const u8, null), contract.check(EmptyStruct{}, ""));
+    }
+}
+
+test "check on empty struct with contractValidate runs it" {
+    comptime {
+        try std.testing.expectEqualStrings("always fails", contract.check(TaggedEmptyStruct{}, "").?);
     }
 }
 

--- a/data_gen/src/tests/examples/register_map_test.zig
+++ b/data_gen/src/tests/examples/register_map_test.zig
@@ -73,13 +73,15 @@ const Register = struct {
 const RegisterMap = struct {
     regs: []const Register,
 
-    /// Validate constraints for this type.
+    /// Validate constraints for this type. Per-register validation is
+    /// delegated to the framework's recursion through `regs`; this method
+    /// only enforces collection-level invariants (length, unique IDs, no
+    /// address overlap).
     pub fn contractValidate(comptime self: RegisterMap) ?[]const u8 {
         if (constraint.lenInRange(1, 128, self.regs.len)) |err| return err;
 
         var ids: [self.regs.len]u8 = undefined;
         for (self.regs, 0..) |reg, i| {
-            if (contract.check(reg, "")) |err| return err;
             ids[i] = reg.name_id;
         }
         if (constraint.noDuplicates(u8, &ids)) |err| return err;

--- a/data_gen/src/tests/generator_test.zig
+++ b/data_gen/src/tests/generator_test.zig
@@ -32,3 +32,30 @@ test "generateArray with struct type" {
         try std.testing.expectEqual(300, arr[3].value);
     }
 }
+
+test "generateArray with n=0 yields empty array" {
+    const noop = struct {
+        fn f(comptime _: usize) u32 {
+            return 0;
+        }
+    }.f;
+
+    comptime {
+        const arr = generator.generateArray(u32, 0, noop);
+        try std.testing.expectEqual(0, arr.len);
+    }
+}
+
+test "generateArray with n=1 invokes func once" {
+    const constant = struct {
+        fn f(comptime _: usize) u32 {
+            return 0xDEAD;
+        }
+    }.f;
+
+    comptime {
+        const arr = generator.generateArray(u32, 1, constant);
+        try std.testing.expectEqual(1, arr.len);
+        try std.testing.expectEqual(0xDEAD, arr[0]);
+    }
+}

--- a/data_gen/src/tests/transform_test.zig
+++ b/data_gen/src/tests/transform_test.zig
@@ -50,3 +50,55 @@ test "percentOf with rounding" {
         try std.testing.expectEqual(@as(u8, 0), transform.percentOf(u8, 255, 0.0));
     }
 }
+
+test "percentOf rounds to nearest" {
+    comptime {
+        try std.testing.expectEqual(@as(u8, 100), transform.percentOf(u8, 1000, 10.0));
+        try std.testing.expectEqual(@as(u16, 33), transform.percentOf(u16, 100, 33.33));
+        try std.testing.expectEqual(@as(u16, 67), transform.percentOf(u16, 100, 66.67));
+    }
+}
+
+test "scaledNearest handles signed values" {
+    comptime {
+        try std.testing.expectEqual(@as(i16, -333), transform.scaledNearest(i16, 1000, -0.3333));
+        try std.testing.expectEqual(@as(i16, -1), transform.scaledNearest(i16, 100, -0.005));
+    }
+}
+
+test "fixedPoint signed extremes" {
+    comptime {
+        try std.testing.expectEqual(@as(i16, -32768), transform.fixedPoint(i16, 15, -1.0));
+        try std.testing.expectEqual(@as(i8, -128), transform.fixedPoint(i8, 0, -128.0));
+        try std.testing.expectEqual(@as(i8, 127), transform.fixedPoint(i8, 0, 127.0));
+    }
+}
+
+test "scaled zero is always representable" {
+    comptime {
+        try std.testing.expectEqual(@as(u16, 0), transform.scaled(u16, 1000, 0.0));
+        try std.testing.expectEqual(@as(i16, 0), transform.scaled(i16, 1000, 0.0));
+    }
+}
+
+test "scaled accepts values at the u16 boundary" {
+    comptime {
+        // 65.535 * 1000 = 65535, exactly fits in u16 max.
+        try std.testing.expectEqual(@as(u16, 65535), transform.scaled(u16, 1000, 65.535));
+    }
+}
+
+test "scaled accepts signed negative values" {
+    comptime {
+        try std.testing.expectEqual(@as(i16, -3300), transform.scaled(i16, 1000, -3.3));
+        try std.testing.expectEqual(@as(i16, -32768), transform.scaled(i16, 1, -32768.0));
+        try std.testing.expectEqual(@as(i8, -128), transform.scaled(i8, 1, -128.0));
+    }
+}
+
+test "scaledNearest at i16 boundaries" {
+    comptime {
+        try std.testing.expectEqual(@as(i16, 32767), transform.scaledNearest(i16, 1, 32767.0));
+        try std.testing.expectEqual(@as(i16, -32768), transform.scaledNearest(i16, 1, -32768.0));
+    }
+}

--- a/data_gen/src/tests/transform_test.zig
+++ b/data_gen/src/tests/transform_test.zig
@@ -102,3 +102,16 @@ test "scaledNearest at i16 boundaries" {
         try std.testing.expectEqual(@as(i16, -32768), transform.scaledNearest(i16, 1, -32768.0));
     }
 }
+
+test "scaledNearest accepts fractional values that round to in-range max" {
+    comptime {
+        // Values just below max where @round stays in range must still pass:
+        // catches a regression where checkFitsIn rejects pre-round values.
+        try std.testing.expectEqual(@as(i16, 32767), transform.scaledNearest(i16, 1, 32767.4));
+        try std.testing.expectEqual(@as(i16, -32768), transform.scaledNearest(i16, 1, -32768.4));
+        try std.testing.expectEqual(@as(u8, 255), transform.scaledNearest(u8, 1, 255.4));
+    }
+    // Note: the symmetric overflow case (e.g. scaledNearest(i16, 1, 32767.5)
+    // where @round = 32768) is rejected by checkFitsIn at @compileError time
+    // and so can't be exercised by a runtime test. Verified manually.
+}

--- a/data_gen/src/transform.zig
+++ b/data_gen/src/transform.zig
@@ -51,6 +51,7 @@ pub fn scaled(T: type, scale: comptime_int, value: comptime_float) T {
         ));
     }
 
+    checkFitsIn(T, truncated, value);
     return @intCast(truncated);
 }
 
@@ -59,6 +60,7 @@ pub fn scaled(T: type, scale: comptime_int, value: comptime_float) T {
 pub fn scaledNearest(T: type, scale: comptime_int, value: comptime_float) T {
     const result = value * @as(comptime_float, @floatFromInt(scale));
     const rounded: comptime_int = @round(result);
+    checkFitsIn(T, rounded, value);
     return @intCast(rounded);
 }
 
@@ -78,4 +80,22 @@ pub fn percentOf(T: type, max: comptime_int, pct: comptime_float) T {
 
 fn comptimePow2(exp: comptime_int) comptime_float {
     return @floatFromInt(@as(u128, 1) << @intCast(exp));
+}
+
+/// Comptime range check for integer casts. Emits a friendly @compileError
+/// naming the original `value` if `truncated` won't fit in `T`.
+fn checkFitsIn(T: type, truncated: comptime_int, value: comptime_float) void {
+    const info = @typeInfo(T).int;
+    const min_val: comptime_int = if (info.signedness == .signed)
+        -(@as(comptime_int, 1) << @intCast(info.bits - 1))
+    else
+        0;
+    const max_val: comptime_int = (@as(comptime_int, 1) <<
+        @intCast(if (info.signedness == .signed) info.bits - 1 else info.bits)) - 1;
+    if (truncated < min_val or truncated > max_val) {
+        @compileError(std.fmt.comptimePrint(
+            "scaled value {d} -> {} overflows {} (representable range [{}, {}])",
+            .{ value, truncated, @typeName(T), min_val, max_val },
+        ));
+    }
 }

--- a/elf_size/README.md
+++ b/elf_size/README.md
@@ -70,7 +70,7 @@ const regions = [_]elf_size.MemoryRegion{
 };
 
 var buf: [4096]u8 = undefined;
-const len = try elf_size.format_summary("firmware.elf", &regions, &buf);
+const len = try elf_size.formatSummary("firmware.elf", &regions, &buf);
 // buf[0..len] contains the formatted report
 ```
 

--- a/elf_size/build.zig
+++ b/elf_size/build.zig
@@ -20,4 +20,15 @@ pub fn build(b: *std.Build) void {
         }),
     });
     b.installArtifact(exe);
+
+    const tests = b.addTest(.{
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/root.zig"),
+            .target = target,
+            .optimize = optimize,
+        }),
+    });
+    const run_tests = b.addRunArtifact(tests);
+    const test_step = b.step("test", "Run elf_size unit tests");
+    test_step.dependOn(&run_tests.step);
 }

--- a/elf_size/build.zig.zon
+++ b/elf_size/build.zig.zon
@@ -8,5 +8,7 @@
         "build.zig",
         "build.zig.zon",
         "src",
+        "../LICENSE",
+        "README.md",
     },
 }

--- a/elf_size/src/main.zig
+++ b/elf_size/src/main.zig
@@ -29,7 +29,7 @@ pub fn main(init: std.process.Init) !void {
     };
 
     var output_path: ?[]const u8 = null;
-    var regions: [16]elf_size.MemoryRegion = undefined;
+    var regions: [elf_size.MAX_REGIONS]elf_size.MemoryRegion = undefined;
     var count: usize = 0;
 
     while (args.next()) |arg| {
@@ -37,8 +37,11 @@ pub fn main(init: std.process.Init) !void {
             output_path = args.next();
             continue;
         }
-        if (count >= 16) break;
-        regions[count] = parseRegion(arg) orelse {
+        if (count >= elf_size.MAX_REGIONS) {
+            writeAll(io, "Too many regions specified\n");
+            return;
+        }
+        regions[count] = elf_size.parseRegion(arg) orelse {
             writeAll(io, "Invalid region spec\n");
             return;
         };
@@ -63,16 +66,4 @@ pub fn main(init: std.process.Init) !void {
         try w.interface.writeAll(buf[0..len]);
         try w.interface.flush();
     }
-}
-
-fn parseRegion(spec: []const u8) ?elf_size.MemoryRegion {
-    var it = std.mem.splitScalar(u8, spec, ':');
-    const name = it.next() orelse return null;
-    const origin_str = it.next() orelse return null;
-    const length_str = it.next() orelse return null;
-
-    const origin = std.fmt.parseInt(u32, origin_str, 16) catch return null;
-    const length = std.fmt.parseInt(u32, length_str, 16) catch return null;
-
-    return .{ .name = name, .origin = origin, .length = length };
 }

--- a/elf_size/src/root.zig
+++ b/elf_size/src/root.zig
@@ -12,6 +12,24 @@ pub const MemoryRegion = struct {
     length: u32,
 };
 
+/// Parse a CLI region spec of the form `name:origin:length` (hex, no `0x` prefix).
+/// Returns null on any parse failure (missing colon, non-hex digits, value too large).
+pub fn parseRegion(spec: []const u8) ?MemoryRegion {
+    var it = std.mem.splitScalar(u8, spec, ':');
+    const name = it.next() orelse return null;
+    const origin_str = it.next() orelse return null;
+    const length_str = it.next() orelse return null;
+    // Reject trailing parts (e.g. "RAM:1000:2000:extra") so callers
+    // can't silently lose data after a typo.
+    if (it.next() != null) return null;
+    if (name.len == 0) return null;
+
+    const origin = std.fmt.parseInt(u32, origin_str, 16) catch return null;
+    const length = std.fmt.parseInt(u32, length_str, 16) catch return null;
+
+    return .{ .name = name, .origin = origin, .length = length };
+}
+
 const SectionInfo = struct {
     name: [32]u8 = .{0} ** 32,
     addr: u32 = 0,
@@ -53,12 +71,16 @@ const Elf32_Shdr = extern struct {
 
 const SHF_ALLOC = 0x2;
 const MAX_SECTIONS_PER_REGION = 32;
-const MAX_REGIONS = 16;
+/// Maximum number of `MemoryRegion`s `formatSummary` will accept. Exposed
+/// for callers that want to size their region array consistently.
+pub const MAX_REGIONS = 16;
 // zlinter-enable declaration_naming
 
 /// Format a memory usage summary into the provided buffer. Returns the number of bytes written.
 // zlinter-disable-next-line no_inferred_error_unions
 pub fn formatSummary(elf_path: []const u8, regions: []const MemoryRegion, out: []u8) !usize {
+    if (regions.len > MAX_REGIONS) return error.TooManyRegions;
+
     const io = std.Io.Threaded.global_single_threaded.io();
     const file = try std.Io.Dir.cwd().openFile(io, elf_path, .{});
     defer file.close(io);
@@ -96,9 +118,11 @@ pub fn formatSummary(elf_path: []const u8, regions: []const MemoryRegion, out: [
         _ = try file.readPositionalAll(io, &name_buf, shstrtab_offset + shdr.sh_name);
 
         for (regions, 0..) |region, ri| {
-            const region_end = region.origin + region.length;
+            // Saturating add so a region near u32 max doesn't wrap to 0
+            // and silently exclude every section that falls in its tail.
+            const region_end = region.origin +| region.length;
             if (shdr.sh_addr >= region.origin and shdr.sh_addr < region_end) {
-                region_used[ri] += shdr.sh_size;
+                region_used[ri] +|= shdr.sh_size;
                 const dc = region_detail_count[ri];
                 if (dc < MAX_SECTIONS_PER_REGION) {
                     region_details[ri][dc] = .{
@@ -219,4 +243,95 @@ fn emitPct(buf: []u8, pct_x100: u64) usize {
         pos += 1;
     }
     return pos;
+}
+
+const testing = std.testing;
+
+test "emitU32 formats zero" {
+    var buf: [10]u8 = undefined;
+    const n = emitU32(&buf, 0);
+    try testing.expectEqualStrings("0", buf[0..n]);
+}
+
+test "emitU32 formats large values" {
+    var buf: [10]u8 = undefined;
+    const n = emitU32(&buf, 4294967295);
+    try testing.expectEqualStrings("4294967295", buf[0..n]);
+}
+
+test "emitU32Right pads with spaces to width" {
+    var buf: [10]u8 = undefined;
+    const n = emitU32Right(&buf, 42, 6);
+    try testing.expectEqualStrings("    42", buf[0..n]);
+}
+
+test "emitU32Right does not truncate when value exceeds width" {
+    var buf: [10]u8 = undefined;
+    const n = emitU32Right(&buf, 12345, 3);
+    try testing.expectEqualStrings("12345", buf[0..n]);
+}
+
+test "emitPct formats percentage with two decimal digits" {
+    var buf: [10]u8 = undefined;
+    // pct_x100 = 5293 means 52.93%
+    var n = emitPct(&buf, 5293);
+    try testing.expectEqualStrings("52.93%", buf[0..n]);
+
+    // pct_x100 = 5205 means 52.05% — exercises the leading-zero branch on `frac`
+    n = emitPct(&buf, 5205);
+    try testing.expectEqualStrings("52.05%", buf[0..n]);
+
+    // pct_x100 = 10000 means exactly 100%
+    n = emitPct(&buf, 10000);
+    try testing.expectEqualStrings("100.00%", buf[0..n]);
+}
+
+test "emitPadded right-pads short strings" {
+    var buf: [10]u8 = undefined;
+    const n = emitPadded(&buf, "abc", 6);
+    try testing.expectEqualStrings("abc   ", buf[0..n]);
+}
+
+test "parseRegion parses a valid name:origin:length spec" {
+    const r = parseRegion("RAM:3FFE8000:14000").?;
+    try testing.expectEqualStrings("RAM", r.name);
+    try testing.expectEqual(@as(u32, 0x3FFE8000), r.origin);
+    try testing.expectEqual(@as(u32, 0x14000), r.length);
+}
+
+test "parseRegion is case-insensitive on hex digits" {
+    const r = parseRegion("FLASH:deadbeef:cafe").?;
+    try testing.expectEqual(@as(u32, 0xDEADBEEF), r.origin);
+    try testing.expectEqual(@as(u32, 0xCAFE), r.length);
+}
+
+test "parseRegion rejects missing colons" {
+    try testing.expectEqual(@as(?MemoryRegion, null), parseRegion("RAM"));
+    try testing.expectEqual(@as(?MemoryRegion, null), parseRegion("RAM:3FFE8000"));
+}
+
+test "parseRegion rejects non-hex digits" {
+    try testing.expectEqual(@as(?MemoryRegion, null), parseRegion("RAM:notahex:14000"));
+    try testing.expectEqual(@as(?MemoryRegion, null), parseRegion("RAM:3FFE8000:zzz"));
+}
+
+test "parseRegion rejects overflow" {
+    // value larger than u32 max
+    try testing.expectEqual(@as(?MemoryRegion, null), parseRegion("RAM:100000000:1000"));
+}
+
+test "parseRegion rejects trailing parts" {
+    try testing.expectEqual(@as(?MemoryRegion, null), parseRegion("RAM:1000:2000:extra"));
+}
+
+test "parseRegion rejects empty name" {
+    try testing.expectEqual(@as(?MemoryRegion, null), parseRegion(":1000:2000"));
+}
+
+test "formatSummary rejects too many regions" {
+    const too_many: [MAX_REGIONS + 1]MemoryRegion = @splat(
+        MemoryRegion{ .name = "X", .origin = 0, .length = 0 },
+    );
+    var out: [16]u8 = undefined;
+    try testing.expectError(error.TooManyRegions, formatSummary("/dev/null", &too_many, &out));
 }

--- a/elf_size/src/root.zig
+++ b/elf_size/src/root.zig
@@ -280,7 +280,7 @@ test "emitPct formats percentage with two decimal digits" {
     var n = emitPct(&buf, 5293);
     try testing.expectEqualStrings("52.93%", buf[0..n]);
 
-    // pct_x100 = 5205 means 52.05% — exercises the leading-zero branch on `frac`
+    // pct_x100 = 5205 means 52.05% - exercises the leading-zero branch on `frac`
     n = emitPct(&buf, 5205);
     try testing.expectEqualStrings("52.05%", buf[0..n]);
 

--- a/elf_size/src/root.zig
+++ b/elf_size/src/root.zig
@@ -26,6 +26,9 @@ pub fn parseRegion(spec: []const u8) ?MemoryRegion {
 
     const origin = std.fmt.parseInt(u32, origin_str, 16) catch return null;
     const length = std.fmt.parseInt(u32, length_str, 16) catch return null;
+    // A zero-length region matches no sections and almost certainly indicates
+    // an argument-ordering mistake at the call site.
+    if (length == 0) return null;
 
     return .{ .name = name, .origin = origin, .length = length };
 }
@@ -326,6 +329,10 @@ test "parseRegion rejects trailing parts" {
 
 test "parseRegion rejects empty name" {
     try testing.expectEqual(@as(?MemoryRegion, null), parseRegion(":1000:2000"));
+}
+
+test "parseRegion rejects zero length" {
+    try testing.expectEqual(@as(?MemoryRegion, null), parseRegion("RAM:1000:0"));
 }
 
 test "formatSummary rejects too many regions" {

--- a/elf_size/src/root.zig
+++ b/elf_size/src/root.zig
@@ -125,7 +125,11 @@ pub fn formatSummary(elf_path: []const u8, regions: []const MemoryRegion, out: [
             // and silently exclude every section that falls in its tail.
             const region_end = region.origin +| region.length;
             if (shdr.sh_addr >= region.origin and shdr.sh_addr < region_end) {
-                region_used[ri] +|= shdr.sh_size;
+                // Sections of an in-range region can't sum past u32; if they
+                // did, the ELF would have overlapping sections. Assert rather
+                // than saturate so the bug surfaces instead of being hidden.
+                std.debug.assert(region_used[ri] <= std.math.maxInt(u32) - shdr.sh_size);
+                region_used[ri] += shdr.sh_size;
                 const dc = region_detail_count[ri];
                 if (dc < MAX_SECTIONS_PER_REGION) {
                     region_details[ri][dc] = .{

--- a/erd_core/README.md
+++ b/erd_core/README.md
@@ -4,13 +4,15 @@ Core framework for a typed publish-subscribe data system targeting embedded/real
 
 ## What's in here
 
-- **ERD** (`erd.zig`) : Entity-Reference-Designator type: a named, typed data field with a 16-bit handle
-- **SystemData** : Top-level aggregator binding multiple data components into one namespace with `read`/`write`/`subscribe`/`publish` APIs
-  - **RamDataComponent** : Packed byte-array storage with comptime-optimized reads/writes and on-change subscriptions
-  - **IndirectDataComponent** : Read-only computed values via function pointers
-  - **ConvertedDataComponent** : Derived data computed from other ERDs via mappings
+- **ERD** (`Erd.zig`) : Entity-Reference-Designator type: a named, typed data field with a 16-bit handle
+- **SystemData** (`system_data.zig`) : Top-level aggregator binding multiple data components into one namespace with `read`/`write`/`subscribe`/`publish` APIs
+  - **RamDataComponent** (`data_component.Ram`) : Packed byte-array storage with comptime-optimized reads/writes and on-change subscriptions
+  - **IndirectDataComponent** (`data_component.Indirect`) : Read-only computed values via function pointers
+  - **ConvertedDataComponent** (`data_component.Converted`) : Derived data computed from other ERDs via mappings
 - **Subscription** : Fixed-size callback arrays per ERD, identity by function pointer
 - **Timer** : Lightweight software scheduler (periodic/one-shot) for tick-based run-to-completion loops
+- **erd_table** : Comptime helpers to populate `data_component_idx`/`system_data_idx` and extract per-component ERD slices
+- **erd_mapping** : Comptime helpers shared by `Indirect`/`Converted` for resolving ERD-to-function-pointer mappings
 - **testing** : Test double infrastructure (`SystemDataTestDouble`) for creating standalone test ERD systems
 
 A number of utility modules are available in `common/`.
@@ -24,7 +26,11 @@ const MyErds = struct {
     sensor: erd_core.Erd = .{ .erd_number = 0x0000, .T = u16, .component_idx = 0, .subs = 1 },
 };
 
-const Ram = erd_core.RamDataComponent(&my_defs);
+const my_erds = erd_core.erd_table.autofill(MyErds);
+const ram_defs = erd_core.erd_table.collectByComponent(my_erds, 0);
+const Ram = erd_core.data_component.Ram(&ram_defs);
+const Components = struct { ram: Ram };
+const MyEnum = std.meta.FieldEnum(MyErds);
 const SD = erd_core.SystemData(MyErds, MyEnum, my_erds, Components);
 ```
 

--- a/erd_core/codegen/ReleaseFast/cross_erd_compute.s
+++ b/erd_core/codegen/ReleaseFast/cross_erd_compute.s
@@ -24,11 +24,11 @@ cross_erd_compute:
         mov	r8, rcx
         mov	rcx, rdx
         movzx	eax, si
-        mov	rdx, qword ptr [8*rax + __anon_1]
-        movzx	esi, byte ptr [rax + __anon_2]
+        mov	rdx, qword ptr [8*rax + __anon_0]
+        movzx	esi, byte ptr [rax + __anon_1]
         shl	rdx, 4
         add	rdi, rdx
         add	rdi, 16
-        movzx	edx, word ptr [rax + rax + __anon_3]
+        movzx	edx, word ptr [rax + rax + __anon_2]
         jmp	Subscription.publish
 

--- a/erd_core/codegen/ReleaseFast/double_write_diff_values.s
+++ b/erd_core/codegen/ReleaseFast/double_write_diff_values.s
@@ -47,11 +47,11 @@ double_write_diff_values:
         mov	r8, rcx
         mov	rcx, rdx
         movzx	eax, si
-        mov	rdx, qword ptr [8*rax + __anon_3]
-        movzx	esi, byte ptr [rax + __anon_4]
+        mov	rdx, qword ptr [8*rax + __anon_0]
+        movzx	esi, byte ptr [rax + __anon_1]
         shl	rdx, 4
         add	rdi, rdx
         add	rdi, 16
-        movzx	edx, word ptr [rax + rax + __anon_5]
+        movzx	edx, word ptr [rax + rax + __anon_2]
         jmp	Subscription.publish
 

--- a/erd_core/codegen/ReleaseFast/double_write_same_value.s
+++ b/erd_core/codegen/ReleaseFast/double_write_same_value.s
@@ -49,11 +49,11 @@ double_write_same_value:
         mov	r8, rcx
         mov	rcx, rdx
         movzx	eax, si
-        mov	rdx, qword ptr [8*rax + __anon_3]
-        movzx	esi, byte ptr [rax + __anon_4]
+        mov	rdx, qword ptr [8*rax + __anon_0]
+        movzx	esi, byte ptr [rax + __anon_1]
         shl	rdx, 4
         add	rdi, rdx
         add	rdi, 16
-        movzx	edx, word ptr [rax + rax + __anon_5]
+        movzx	edx, word ptr [rax + rax + __anon_2]
         jmp	Subscription.publish
 

--- a/erd_core/codegen/ReleaseFast/multi_runtime_read.s
+++ b/erd_core/codegen/ReleaseFast/multi_runtime_read.s
@@ -12,18 +12,18 @@ multi_runtime_read:
         movzx	edx, byte ptr [rcx + __anon_0]
         movzx	ecx, word ptr [rcx + rcx + __anon_1]
         cmp	edx, 2
-        je	.L2
+        je	.L0
         cmp	edx, 1
-        jne	.L3
+        jne	.L1
         mov	rdi, rax
-        jmp	qword ptr [8*rcx + __anon_4]
-.L2:
+        jmp	qword ptr [8*rcx + __anon_2]
+.L0:
         mov	rsi, qword ptr [rdi + 136]
         mov	rdi, rax
-        jmp	qword ptr [8*rcx + __anon_5]
-.L3:
-        add	rdi, qword ptr [8*rcx + __anon_6]
-        movzx	edx, word ptr [rcx + rcx + __anon_7]
+        jmp	qword ptr [8*rcx + __anon_3]
+.L1:
+        add	rdi, qword ptr [8*rcx + __anon_4]
+        movzx	edx, word ptr [rcx + rcx + __anon_5]
         mov	rsi, rdi
         mov	rdi, rax
         jmp	memcpy@PLT

--- a/erd_core/codegen/ReleaseFast/multi_runtime_read.s
+++ b/erd_core/codegen/ReleaseFast/multi_runtime_read.s
@@ -7,30 +7,24 @@ multi_runtime_read:
 ; --- called functions ---
 
 "system_data.SystemData(codegen_harness.MultiErdDefs,meta.FieldEnum(codegen_harness.MultiErdDefs),.{ .ram_counter = .{ ... }, .ram_flag = .{ ... }, .ram_value = .{ ... }, .ind_constant = .{ ... }, .ind_computed = .{ ... }, .conv_sum = .{ ... }, .conv_flag_inv = .{ ... } },codegen_harness.MultiComponents).runtimeRead":
-        mov	rax, rdi
+        mov	rax, rdx
         movzx	ecx, si
-        movzx	esi, byte ptr [rcx + __anon_0]
+        movzx	edx, byte ptr [rcx + __anon_0]
         movzx	ecx, word ptr [rcx + rcx + __anon_1]
-        test	esi, esi
+        cmp	edx, 2
         je	.L2
-        cmp	esi, 1
-        je	.L3
-        cmp	esi, 2
-        jne	.L4
-        mov	rcx, qword ptr [rax + 8*rcx + 88]
-        mov	rsi, qword ptr [rax + 168]
-        mov	rdi, rdx
-        jmp	rcx
-.L3:
-        mov	rdi, rdx
-        jmp	qword ptr [rax + 8*rcx + 72]
+        cmp	edx, 1
+        jne	.L3
+        mov	rdi, rax
+        jmp	qword ptr [8*rcx + __anon_4]
 .L2:
-        add	rax, qword ptr [8*rcx + __anon_5]
-        movzx	ecx, word ptr [rcx + rcx + __anon_6]
-        mov	rdi, rdx
-        mov	rsi, rax
-        mov	rdx, rcx
+        mov	rsi, qword ptr [rdi + 136]
+        mov	rdi, rax
+        jmp	qword ptr [8*rcx + __anon_5]
+.L3:
+        add	rdi, qword ptr [8*rcx + __anon_6]
+        movzx	edx, word ptr [rcx + rcx + __anon_7]
+        mov	rsi, rdi
+        mov	rdi, rax
         jmp	memcpy@PLT
-.L4:
-        ret
 

--- a/erd_core/codegen/ReleaseFast/multi_runtime_write.s
+++ b/erd_core/codegen/ReleaseFast/multi_runtime_write.s
@@ -15,14 +15,12 @@ multi_runtime_write:
         push	r12
         push	rbx
         push	rax
-        movzx	eax, si
-        cmp	byte ptr [rax + __anon_0], 0
-        jne	.L1
         mov	rbx, rdx
         mov	r14, rdi
-        movzx	r15d, word ptr [rax + rax + __anon_2]
-        movzx	r12d, word ptr [r15 + r15 + __anon_3]
-        mov	r13, qword ptr [8*r15 + __anon_4]
+        movzx	eax, si
+        movzx	r15d, word ptr [rax + rax + __anon_0]
+        movzx	r12d, word ptr [r15 + r15 + __anon_1]
+        mov	r13, qword ptr [8*r15 + __anon_2]
         add	r13, rdi
         mov	rdi, rdx
         mov	rsi, r13
@@ -34,9 +32,9 @@ multi_runtime_write:
         mov	rdx, r12
         call	memcpy@PLT
         test	bpl, 1
-        jne	.L1
-        cmp	byte ptr [r15 + __anon_5], 0
-        je	.L1
+        jne	.L3
+        cmp	byte ptr [r15 + __anon_4], 0
+        je	.L3
         mov	rdi, r14
         mov	esi, r15d
         mov	rdx, rbx
@@ -48,8 +46,8 @@ multi_runtime_write:
         pop	r14
         pop	r15
         pop	rbp
-        jmp	"ram_data_component.RamDataComponent(@as([*]const Erd, @ptrCast(&codegen_harness.ram_defs))[0..3]).publish"
-.L1:
+        jmp	"ram_data_component.RamDataComponent(@as([*]const Erd, @ptrCast(&codegen_harness.multi_ram_erds))[0..3]).publish"
+.L3:
         add	rsp, 8
         pop	rbx
         pop	r12

--- a/erd_core/codegen/ReleaseFast/multi_runtime_write.s
+++ b/erd_core/codegen/ReleaseFast/multi_runtime_write.s
@@ -32,9 +32,9 @@ multi_runtime_write:
         mov	rdx, r12
         call	memcpy@PLT
         test	bpl, 1
-        jne	.L3
-        cmp	byte ptr [r15 + __anon_4], 0
-        je	.L3
+        jne	.L0
+        cmp	byte ptr [r15 + __anon_3], 0
+        je	.L0
         mov	rdi, r14
         mov	esi, r15d
         mov	rdx, rbx
@@ -47,7 +47,7 @@ multi_runtime_write:
         pop	r15
         pop	rbp
         jmp	"ram_data_component.RamDataComponent(@as([*]const Erd, @ptrCast(&codegen_harness.multi_ram_erds))[0..3]).publish"
-.L3:
+.L0:
         add	rsp, 8
         pop	rbx
         pop	r12

--- a/erd_core/codegen/ReleaseFast/read_all_component_types.s
+++ b/erd_core/codegen/ReleaseFast/read_all_component_types.s
@@ -4,7 +4,7 @@
 ;
 read_all_component_types:
         mov	eax, dword ptr [rdi]
-        mov	rcx, qword ptr [rdi + 168]
+        mov	rcx, qword ptr [rdi + 136]
         movzx	edx, word ptr [rcx + 5]
         add	eax, dword ptr [rcx]
         add	eax, edx

--- a/erd_core/codegen/ReleaseFast/read_converted_both.s
+++ b/erd_core/codegen/ReleaseFast/read_converted_both.s
@@ -3,7 +3,7 @@
 ; PER-ERD: two converted reads, each unique compute function.
 ;
 read_converted_both:
-        mov	rax, qword ptr [rdi + 168]
+        mov	rax, qword ptr [rdi + 136]
         movzx	ecx, word ptr [rax + 5]
         add	ecx, dword ptr [rax]
         mov	eax, dword ptr [rax + 4]

--- a/erd_core/codegen/ReleaseFast/read_converted_flag_inv.s
+++ b/erd_core/codegen/ReleaseFast/read_converted_flag_inv.s
@@ -3,7 +3,7 @@
 ; PER-ERD: compute inlined. Same tradeoff as read_converted_sum.
 ;
 read_converted_flag_inv:
-        mov	rax, qword ptr [rdi + 168]
+        mov	rax, qword ptr [rdi + 136]
         movzx	eax, byte ptr [rax + 4]
         xor	al, 1
         ret

--- a/erd_core/codegen/ReleaseFast/read_converted_sum.s
+++ b/erd_core/codegen/ReleaseFast/read_converted_sum.s
@@ -3,7 +3,7 @@
 ; PER-ERD: compute inlined. Cannot per-type share (unique fn).
 ;
 read_converted_sum:
-        mov	rcx, qword ptr [rdi + 168]
+        mov	rcx, qword ptr [rdi + 136]
         movzx	eax, word ptr [rcx + 5]
         add	eax, dword ptr [rcx]
         ret

--- a/erd_core/codegen/ReleaseFast/read_ram_then_converted.s
+++ b/erd_core/codegen/ReleaseFast/read_ram_then_converted.s
@@ -3,7 +3,7 @@
 ; PER-ERD: RAM load + converted compute inlined.
 ;
 read_ram_then_converted:
-        mov	rcx, qword ptr [rdi + 168]
+        mov	rcx, qword ptr [rdi + 136]
         mov	eax, dword ptr [rcx]
         movzx	ecx, word ptr [rcx + 5]
         add	eax, dword ptr [rdi]

--- a/erd_core/codegen/ReleaseFast/read_write_other_read.s
+++ b/erd_core/codegen/ReleaseFast/read_write_other_read.s
@@ -32,11 +32,11 @@ read_write_other_read:
         mov	r8, rcx
         mov	rcx, rdx
         movzx	eax, si
-        mov	rdx, qword ptr [8*rax + __anon_1]
-        movzx	esi, byte ptr [rax + __anon_2]
+        mov	rdx, qword ptr [8*rax + __anon_0]
+        movzx	esi, byte ptr [rax + __anon_1]
         shl	rdx, 4
         add	rdi, rdx
         add	rdi, 16
-        movzx	edx, word ptr [rax + rax + __anon_3]
+        movzx	edx, word ptr [rax + rax + __anon_2]
         jmp	Subscription.publish
 

--- a/erd_core/codegen/ReleaseFast/runtime_write.s
+++ b/erd_core/codegen/ReleaseFast/runtime_write.s
@@ -32,9 +32,9 @@ runtime_write:
         mov	rdx, r12
         call	memcpy@PLT
         test	bpl, 1
-        jne	.L4
-        cmp	byte ptr [r15 + __anon_5], 0
-        je	.L4
+        jne	.L0
+        cmp	byte ptr [r15 + __anon_4], 0
+        je	.L0
         mov	rdi, r14
         mov	esi, r15d
         mov	rdx, rbx
@@ -47,7 +47,7 @@ runtime_write:
         pop	r15
         pop	rbp
         jmp	"ram_data_component.RamDataComponent(&.{ .{ ... }, .{ ... }, .{ ... }, .{ ... } }[0..4]).publish.2"
-.L4:
+.L0:
         add	rsp, 8
         pop	rbx
         pop	r12

--- a/erd_core/codegen/ReleaseFast/runtime_write_three.s
+++ b/erd_core/codegen/ReleaseFast/runtime_write_three.s
@@ -55,9 +55,9 @@ runtime_write_three:
         mov	rdx, r12
         call	memcpy@PLT
         test	bpl, 1
-        jne	.L4
-        cmp	byte ptr [r15 + __anon_5], 0
-        je	.L4
+        jne	.L0
+        cmp	byte ptr [r15 + __anon_4], 0
+        je	.L0
         mov	rdi, r14
         mov	esi, r15d
         mov	rdx, rbx
@@ -70,7 +70,7 @@ runtime_write_three:
         pop	r15
         pop	rbp
         jmp	"ram_data_component.RamDataComponent(&.{ .{ ... }, .{ ... }, .{ ... }, .{ ... } }[0..4]).publish.2"
-.L4:
+.L0:
         add	rsp, 8
         pop	rbx
         pop	r12

--- a/erd_core/codegen/ReleaseFast/runtime_write_two.s
+++ b/erd_core/codegen/ReleaseFast/runtime_write_two.s
@@ -45,9 +45,9 @@ runtime_write_two:
         mov	rdx, r12
         call	memcpy@PLT
         test	bpl, 1
-        jne	.L4
-        cmp	byte ptr [r15 + __anon_5], 0
-        je	.L4
+        jne	.L0
+        cmp	byte ptr [r15 + __anon_4], 0
+        je	.L0
         mov	rdi, r14
         mov	esi, r15d
         mov	rdx, rbx
@@ -60,7 +60,7 @@ runtime_write_two:
         pop	r15
         pop	rbp
         jmp	"ram_data_component.RamDataComponent(&.{ .{ ... }, .{ ... }, .{ ... }, .{ ... } }[0..4]).publish.2"
-.L4:
+.L0:
         add	rsp, 8
         pop	rbx
         pop	r12

--- a/erd_core/codegen/ReleaseFast/setup_timer_callback.s
+++ b/erd_core/codegen/ReleaseFast/setup_timer_callback.s
@@ -10,26 +10,26 @@ setup_timer_callback:
         sete	r9b
         or	r9b, r8b
         je	.L0
-        test	rcx, rcx
-        je	.L1
         mov	r8, rsi
         cmp	rcx, rax
+        je	.L1
+        test	rcx, rcx
         je	.L2
 .L3:
         mov	r9, qword ptr [rcx]
         test	r9, r9
-        je	.L1
+        je	.L2
         mov	r8, rcx
         mov	rcx, r9
         cmp	r9, rax
         jne	.L3
-        jmp	.L2
-.L1:
+        jmp	.L1
+.L2:
         mov	rcx, qword ptr [rsi + 8]
-        test	rcx, rcx
-        je	.L0
         cmp	rcx, rax
         je	.L4
+        test	rcx, rcx
+        je	.L0
 .L5:
         mov	r9, qword ptr [rcx]
         test	r9, r9
@@ -38,10 +38,10 @@ setup_timer_callback:
         mov	rcx, r9
         cmp	r9, rax
         jne	.L5
-        jmp	.L2
+        jmp	.L1
 .L4:
         lea	r8, [rsi + 8]
-.L2:
+.L1:
         mov	rcx, qword ptr [rax]
         mov	qword ptr [r8], rcx
 .L0:

--- a/erd_core/codegen/ReleaseFast/setup_timer_callback.s
+++ b/erd_core/codegen/ReleaseFast/setup_timer_callback.s
@@ -10,26 +10,26 @@ setup_timer_callback:
         sete	r9b
         or	r9b, r8b
         je	.L0
+        test	rcx, rcx
+        je	.L1
         mov	r8, rsi
         cmp	rcx, rax
-        je	.L1
-        test	rcx, rcx
         je	.L2
 .L3:
         mov	r9, qword ptr [rcx]
         test	r9, r9
-        je	.L2
+        je	.L1
         mov	r8, rcx
         mov	rcx, r9
         cmp	r9, rax
         jne	.L3
-        jmp	.L1
-.L2:
+        jmp	.L2
+.L1:
         mov	rcx, qword ptr [rsi + 8]
-        cmp	rcx, rax
-        je	.L4
         test	rcx, rcx
         je	.L0
+        cmp	rcx, rax
+        je	.L4
 .L5:
         mov	r9, qword ptr [rcx]
         test	r9, r9
@@ -38,10 +38,10 @@ setup_timer_callback:
         mov	rcx, r9
         cmp	r9, rax
         jne	.L5
-        jmp	.L1
+        jmp	.L2
 .L4:
         lea	r8, [rsi + 8]
-.L1:
+.L2:
         mov	rcx, qword ptr [rax]
         mov	qword ptr [r8], rcx
 .L0:

--- a/erd_core/codegen/ReleaseFast/subscribe_converted.s
+++ b/erd_core/codegen/ReleaseFast/subscribe_converted.s
@@ -2,13 +2,13 @@
 ; Speed: Optimal | Size: Optimal (until 2 calls)
 ;
 subscribe_converted:
-        add	rdi, 104
+        add	rdi, 72
         xor	esi, esi
-        jmp	"data_component_subscription.DataComponentSubscription(@as([*]const Erd, @ptrCast(&codegen_harness.converted_defs))[0..2]).subscribeInner"
+        jmp	"data_component_subscription.DataComponentSubscription(@as([*]const Erd, @ptrCast(&codegen_harness.multi_converted_erds))[0..2]).subscribeInner"
 
 ; --- called functions ---
 
-"data_component_subscription.DataComponentSubscription(@as([*]const Erd, @ptrCast(&codegen_harness.converted_defs))[0..2]).subscribeInner":
+"data_component_subscription.DataComponentSubscription(@as([*]const Erd, @ptrCast(&codegen_harness.multi_converted_erds))[0..2]).subscribeInner":
         shl	rsi, 4
         add	rdi, rsi
         mov	esi, 2

--- a/erd_core/codegen/ReleaseFast/subscribe_converted_flag.s
+++ b/erd_core/codegen/ReleaseFast/subscribe_converted_flag.s
@@ -2,13 +2,13 @@
 ; Speed: Optimal | Size: Optimal (until 2 calls)
 ;
 subscribe_converted_flag:
-        add	rdi, 104
+        add	rdi, 72
         mov	esi, 2
-        jmp	"data_component_subscription.DataComponentSubscription(@as([*]const Erd, @ptrCast(&codegen_harness.converted_defs))[0..2]).subscribeInner"
+        jmp	"data_component_subscription.DataComponentSubscription(@as([*]const Erd, @ptrCast(&codegen_harness.multi_converted_erds))[0..2]).subscribeInner"
 
 ; --- called functions ---
 
-"data_component_subscription.DataComponentSubscription(@as([*]const Erd, @ptrCast(&codegen_harness.converted_defs))[0..2]).subscribeInner":
+"data_component_subscription.DataComponentSubscription(@as([*]const Erd, @ptrCast(&codegen_harness.multi_converted_erds))[0..2]).subscribeInner":
         shl	rsi, 4
         add	rdi, rsi
         mov	esi, 2

--- a/erd_core/codegen/ReleaseFast/triple_write_increment.s
+++ b/erd_core/codegen/ReleaseFast/triple_write_increment.s
@@ -55,11 +55,11 @@ triple_write_increment:
         mov	r8, rcx
         mov	rcx, rdx
         movzx	eax, si
-        mov	rdx, qword ptr [8*rax + __anon_4]
-        movzx	esi, byte ptr [rax + __anon_5]
+        mov	rdx, qword ptr [8*rax + __anon_0]
+        movzx	esi, byte ptr [rax + __anon_1]
         shl	rdx, 4
         add	rdi, rdx
         add	rdi, 16
-        movzx	edx, word ptr [rax + rax + __anon_6]
+        movzx	edx, word ptr [rax + rax + __anon_2]
         jmp	Subscription.publish
 

--- a/erd_core/codegen/ReleaseFast/unsubscribe_converted.s
+++ b/erd_core/codegen/ReleaseFast/unsubscribe_converted.s
@@ -2,13 +2,13 @@
 ; Speed: Optimal | Size: Optimal (until 3 calls)
 ;
 unsubscribe_converted:
-        add	rdi, 104
+        add	rdi, 72
         xor	esi, esi
-        jmp	"data_component_subscription.DataComponentSubscription(@as([*]const Erd, @ptrCast(&codegen_harness.converted_defs))[0..2]).unsubscribeInner"
+        jmp	"data_component_subscription.DataComponentSubscription(@as([*]const Erd, @ptrCast(&codegen_harness.multi_converted_erds))[0..2]).unsubscribeInner"
 
 ; --- called functions ---
 
-"data_component_subscription.DataComponentSubscription(@as([*]const Erd, @ptrCast(&codegen_harness.converted_defs))[0..2]).unsubscribeInner":
+"data_component_subscription.DataComponentSubscription(@as([*]const Erd, @ptrCast(&codegen_harness.multi_converted_erds))[0..2]).unsubscribeInner":
         shl	rsi, 4
         add	rdi, rsi
         jmp	Subscription.unsubscribe

--- a/erd_core/codegen/ReleaseFast/unsubscribe_converted_flag.s
+++ b/erd_core/codegen/ReleaseFast/unsubscribe_converted_flag.s
@@ -2,13 +2,13 @@
 ; Speed: Optimal | Size: Optimal (until 2 calls)
 ;
 unsubscribe_converted_flag:
-        add	rdi, 104
+        add	rdi, 72
         mov	esi, 2
-        jmp	"data_component_subscription.DataComponentSubscription(@as([*]const Erd, @ptrCast(&codegen_harness.converted_defs))[0..2]).unsubscribeInner"
+        jmp	"data_component_subscription.DataComponentSubscription(@as([*]const Erd, @ptrCast(&codegen_harness.multi_converted_erds))[0..2]).unsubscribeInner"
 
 ; --- called functions ---
 
-"data_component_subscription.DataComponentSubscription(@as([*]const Erd, @ptrCast(&codegen_harness.converted_defs))[0..2]).unsubscribeInner":
+"data_component_subscription.DataComponentSubscription(@as([*]const Erd, @ptrCast(&codegen_harness.multi_converted_erds))[0..2]).unsubscribeInner":
         shl	rsi, 4
         add	rdi, rsi
         jmp	Subscription.unsubscribe

--- a/erd_core/codegen/ReleaseFast/write_bool_with_subs.s
+++ b/erd_core/codegen/ReleaseFast/write_bool_with_subs.s
@@ -23,11 +23,11 @@ write_bool_with_subs:
         mov	r8, rcx
         mov	rcx, rdx
         movzx	eax, si
-        mov	rdx, qword ptr [8*rax + __anon_1]
-        movzx	esi, byte ptr [rax + __anon_2]
+        mov	rdx, qword ptr [8*rax + __anon_0]
+        movzx	esi, byte ptr [rax + __anon_1]
         shl	rdx, 4
         add	rdi, rdx
         add	rdi, 16
-        movzx	edx, word ptr [rax + rax + __anon_3]
+        movzx	edx, word ptr [rax + rax + __anon_2]
         jmp	Subscription.publish
 

--- a/erd_core/codegen/ReleaseFast/write_junk_read_write.s
+++ b/erd_core/codegen/ReleaseFast/write_junk_read_write.s
@@ -41,11 +41,11 @@ write_junk_read_write:
         mov	r8, rcx
         mov	rcx, rdx
         movzx	eax, si
-        mov	rdx, qword ptr [8*rax + __anon_3]
-        movzx	esi, byte ptr [rax + __anon_4]
+        mov	rdx, qword ptr [8*rax + __anon_0]
+        movzx	esi, byte ptr [rax + __anon_1]
         shl	rdx, 4
         add	rdi, rdx
         add	rdi, 16
-        movzx	edx, word ptr [rax + rax + __anon_5]
+        movzx	edx, word ptr [rax + rax + __anon_2]
         jmp	Subscription.publish
 

--- a/erd_core/codegen/ReleaseFast/write_ram_flag_with_converted_dep.s
+++ b/erd_core/codegen/ReleaseFast/write_ram_flag_with_converted_dep.s
@@ -12,14 +12,14 @@ write_ram_flag_with_converted_dep:
         lea	rdx, [rsp + 6]
         mov	esi, 1
         mov	rcx, rdi
-        call	"ram_data_component.RamDataComponent(@as([*]const Erd, @ptrCast(&codegen_harness.ram_defs))[0..3]).publish"
+        call	"ram_data_component.RamDataComponent(@as([*]const Erd, @ptrCast(&codegen_harness.multi_ram_erds))[0..3]).publish"
 .L0:
         pop	rax
         ret
 
 ; --- called functions ---
 
-"ram_data_component.RamDataComponent(@as([*]const Erd, @ptrCast(&codegen_harness.ram_defs))[0..3]).publish":
+"ram_data_component.RamDataComponent(@as([*]const Erd, @ptrCast(&codegen_harness.multi_ram_erds))[0..3]).publish":
         mov	r8, rcx
         mov	rcx, rdx
         movzx	eax, si

--- a/erd_core/codegen/ReleaseFast/write_ram_flag_with_converted_dep.s
+++ b/erd_core/codegen/ReleaseFast/write_ram_flag_with_converted_dep.s
@@ -23,11 +23,11 @@ write_ram_flag_with_converted_dep:
         mov	r8, rcx
         mov	rcx, rdx
         movzx	eax, si
-        mov	rdx, qword ptr [8*rax + __anon_1]
-        movzx	esi, byte ptr [rax + __anon_2]
+        mov	rdx, qword ptr [8*rax + __anon_0]
+        movzx	esi, byte ptr [rax + __anon_1]
         shl	rdx, 4
         add	rdi, rdx
         add	rdi, 8
-        movzx	edx, word ptr [rax + rax + __anon_3]
+        movzx	edx, word ptr [rax + rax + __anon_2]
         jmp	Subscription.publish
 

--- a/erd_core/codegen/ReleaseFast/write_ram_with_converted_deps.s
+++ b/erd_core/codegen/ReleaseFast/write_ram_with_converted_deps.s
@@ -22,11 +22,11 @@ write_ram_with_converted_deps:
         mov	r8, rcx
         mov	rcx, rdx
         movzx	eax, si
-        mov	rdx, qword ptr [8*rax + __anon_1]
-        movzx	esi, byte ptr [rax + __anon_2]
+        mov	rdx, qword ptr [8*rax + __anon_0]
+        movzx	esi, byte ptr [rax + __anon_1]
         shl	rdx, 4
         add	rdi, rdx
         add	rdi, 8
-        movzx	edx, word ptr [rax + rax + __anon_3]
+        movzx	edx, word ptr [rax + rax + __anon_2]
         jmp	Subscription.publish
 

--- a/erd_core/codegen/ReleaseFast/write_ram_with_converted_deps.s
+++ b/erd_core/codegen/ReleaseFast/write_ram_with_converted_deps.s
@@ -11,14 +11,14 @@ write_ram_with_converted_deps:
         lea	rdx, [rsp + 4]
         xor	esi, esi
         mov	rcx, rdi
-        call	"ram_data_component.RamDataComponent(@as([*]const Erd, @ptrCast(&codegen_harness.ram_defs))[0..3]).publish"
+        call	"ram_data_component.RamDataComponent(@as([*]const Erd, @ptrCast(&codegen_harness.multi_ram_erds))[0..3]).publish"
 .L0:
         pop	rax
         ret
 
 ; --- called functions ---
 
-"ram_data_component.RamDataComponent(@as([*]const Erd, @ptrCast(&codegen_harness.ram_defs))[0..3]).publish":
+"ram_data_component.RamDataComponent(@as([*]const Erd, @ptrCast(&codegen_harness.multi_ram_erds))[0..3]).publish":
         mov	r8, rcx
         mov	rcx, rdx
         movzx	eax, si

--- a/erd_core/codegen/ReleaseFast/write_then_read_converted.s
+++ b/erd_core/codegen/ReleaseFast/write_then_read_converted.s
@@ -14,9 +14,9 @@ write_then_read_converted:
         mov	rdi, rbx
         xor	esi, esi
         mov	rcx, rbx
-        call	"ram_data_component.RamDataComponent(@as([*]const Erd, @ptrCast(&codegen_harness.ram_defs))[0..3]).publish"
+        call	"ram_data_component.RamDataComponent(@as([*]const Erd, @ptrCast(&codegen_harness.multi_ram_erds))[0..3]).publish"
 .L0:
-        mov	rcx, qword ptr [rbx + 168]
+        mov	rcx, qword ptr [rbx + 136]
         movzx	eax, word ptr [rcx + 5]
         add	eax, dword ptr [rcx]
         add	rsp, 16
@@ -25,7 +25,7 @@ write_then_read_converted:
 
 ; --- called functions ---
 
-"ram_data_component.RamDataComponent(@as([*]const Erd, @ptrCast(&codegen_harness.ram_defs))[0..3]).publish":
+"ram_data_component.RamDataComponent(@as([*]const Erd, @ptrCast(&codegen_harness.multi_ram_erds))[0..3]).publish":
         mov	r8, rcx
         mov	rcx, rdx
         movzx	eax, si

--- a/erd_core/codegen/ReleaseFast/write_then_read_converted.s
+++ b/erd_core/codegen/ReleaseFast/write_then_read_converted.s
@@ -29,11 +29,11 @@ write_then_read_converted:
         mov	r8, rcx
         mov	rcx, rdx
         movzx	eax, si
-        mov	rdx, qword ptr [8*rax + __anon_1]
-        movzx	esi, byte ptr [rax + __anon_2]
+        mov	rdx, qword ptr [8*rax + __anon_0]
+        movzx	esi, byte ptr [rax + __anon_1]
         shl	rdx, 4
         add	rdi, rdx
         add	rdi, 8
-        movzx	edx, word ptr [rax + rax + __anon_3]
+        movzx	edx, word ptr [rax + rax + __anon_2]
         jmp	Subscription.publish
 

--- a/erd_core/codegen/ReleaseFast/write_triggering_callback.s
+++ b/erd_core/codegen/ReleaseFast/write_triggering_callback.s
@@ -22,11 +22,11 @@ write_triggering_callback:
         mov	r8, rcx
         mov	rcx, rdx
         movzx	eax, si
-        mov	rdx, qword ptr [8*rax + __anon_1]
-        movzx	esi, byte ptr [rax + __anon_2]
+        mov	rdx, qword ptr [8*rax + __anon_0]
+        movzx	esi, byte ptr [rax + __anon_1]
         shl	rdx, 4
         add	rdi, rdx
         add	rdi, 16
-        movzx	edx, word ptr [rax + rax + __anon_3]
+        movzx	edx, word ptr [rax + rax + __anon_2]
         jmp	Subscription.publish
 

--- a/erd_core/codegen/ReleaseFast/write_u16_with_subs.s
+++ b/erd_core/codegen/ReleaseFast/write_u16_with_subs.s
@@ -22,11 +22,11 @@ write_u16_with_subs:
         mov	r8, rcx
         mov	rcx, rdx
         movzx	eax, si
-        mov	rdx, qword ptr [8*rax + __anon_1]
-        movzx	esi, byte ptr [rax + __anon_2]
+        mov	rdx, qword ptr [8*rax + __anon_0]
+        movzx	esi, byte ptr [rax + __anon_1]
         shl	rdx, 4
         add	rdi, rdx
         add	rdi, 16
-        movzx	edx, word ptr [rax + rax + __anon_3]
+        movzx	edx, word ptr [rax + rax + __anon_2]
         jmp	Subscription.publish
 

--- a/erd_core/codegen/ReleaseSmall/cross_erd_compute.s
+++ b/erd_core/codegen/ReleaseSmall/cross_erd_compute.s
@@ -14,12 +14,12 @@ cross_erd_compute:
         mov	word ptr [rsp + 6], si
         cmp	word ptr [rdi + 7], si
         mov	word ptr [rdi + 7], si
-        je	.L2
+        je	.L0
         lea	rdx, [rsp + 6]
         mov	esi, 3
         mov	rcx, rdi
         call	".Lram_data_component.RamDataComponent(&.{ .{ ... }, .{ ... }, .{ ... }, .{ ... } }[0..4]).publish.2"
-.L2:
+.L0:
         pop	rax
         ret
 

--- a/erd_core/codegen/ReleaseSmall/double_write_diff_values.s
+++ b/erd_core/codegen/ReleaseSmall/double_write_diff_values.s
@@ -20,12 +20,12 @@ double_write_diff_values:
         mov	byte ptr [rsp + 6], sil
         cmp	byte ptr [rdi + 4], sil
         mov	byte ptr [rdi + 4], sil
-        je	.L2
+        je	.L0
         lea	rdx, [rsp + 6]
         mov	esi, 1
         mov	rcx, rdi
         call	".Lram_data_component.RamDataComponent(&.{ .{ ... }, .{ ... }, .{ ... }, .{ ... } }[0..4]).publish.2"
-.L2:
+.L0:
         pop	rax
         ret
 

--- a/erd_core/codegen/ReleaseSmall/double_write_same_value.s
+++ b/erd_core/codegen/ReleaseSmall/double_write_same_value.s
@@ -25,12 +25,12 @@ double_write_same_value:
         mov	byte ptr [rsp + 6], sil
         cmp	byte ptr [rdi + 4], sil
         mov	byte ptr [rdi + 4], sil
-        je	.L2
+        je	.L0
         lea	rdx, [rsp + 6]
         mov	esi, 1
         mov	rcx, rdi
         call	".Lram_data_component.RamDataComponent(&.{ .{ ... }, .{ ... }, .{ ... }, .{ ... } }[0..4]).publish.2"
-.L2:
+.L0:
         pop	rax
         ret
 

--- a/erd_core/codegen/ReleaseSmall/multi_runtime_read.s
+++ b/erd_core/codegen/ReleaseSmall/multi_runtime_read.s
@@ -7,30 +7,24 @@ multi_runtime_read:
 ; --- called functions ---
 
 ".Lsystem_data.SystemData(codegen_harness.MultiErdDefs,meta.FieldEnum(codegen_harness.MultiErdDefs),.{ .ram_counter = .{ ... }, .ram_flag = .{ ... }, .ram_value = .{ ... }, .ind_constant = .{ ... }, .ind_computed = .{ ... }, .conv_sum = .{ ... }, .conv_flag_inv = .{ ... } },codegen_harness.MultiComponents).runtimeRead":
-        mov	rax, rdi
+        mov	rax, rdx
         movzx	ecx, si
-        movzx	esi, byte ptr [rcx + .L__anon_0]
+        movzx	edx, byte ptr [rcx + .L__anon_0]
         movzx	ecx, word ptr [rcx + rcx + .L__anon_1]
-        test	esi, esi
+        cmp	edx, 2
         je	.L2
-        cmp	esi, 1
-        je	.L3
-        cmp	esi, 2
-        jne	.L4
-        mov	rcx, qword ptr [rax + 8*rcx + 88]
-        mov	rsi, qword ptr [rax + 168]
-        mov	rdi, rdx
-        jmp	rcx
-.L3:
-        mov	rdi, rdx
-        jmp	qword ptr [rax + 8*rcx + 72]
+        cmp	edx, 1
+        jne	.L3
+        mov	rdi, rax
+        jmp	qword ptr [8*rcx + .L__anon_4]
 .L2:
-        add	rax, qword ptr [8*rcx + .L__anon_5]
-        movzx	ecx, word ptr [rcx + rcx + .L__anon_6]
-        mov	rdi, rdx
-        mov	rsi, rax
-        mov	rdx, rcx
+        mov	rsi, qword ptr [rdi + 136]
+        mov	rdi, rax
+        jmp	qword ptr [8*rcx + .L__anon_5]
+.L3:
+        add	rdi, qword ptr [8*rcx + .L__anon_6]
+        movzx	edx, word ptr [rcx + rcx + .L__anon_7]
+        mov	rsi, rdi
+        mov	rdi, rax
         jmp	memcpy@PLT
-.L4:
-        ret
 

--- a/erd_core/codegen/ReleaseSmall/multi_runtime_read.s
+++ b/erd_core/codegen/ReleaseSmall/multi_runtime_read.s
@@ -12,18 +12,18 @@ multi_runtime_read:
         movzx	edx, byte ptr [rcx + .L__anon_0]
         movzx	ecx, word ptr [rcx + rcx + .L__anon_1]
         cmp	edx, 2
-        je	.L2
+        je	.L0
         cmp	edx, 1
-        jne	.L3
+        jne	.L1
         mov	rdi, rax
-        jmp	qword ptr [8*rcx + .L__anon_4]
-.L2:
+        jmp	qword ptr [8*rcx + .L__anon_2]
+.L0:
         mov	rsi, qword ptr [rdi + 136]
         mov	rdi, rax
-        jmp	qword ptr [8*rcx + .L__anon_5]
-.L3:
-        add	rdi, qword ptr [8*rcx + .L__anon_6]
-        movzx	edx, word ptr [rcx + rcx + .L__anon_7]
+        jmp	qword ptr [8*rcx + .L__anon_3]
+.L1:
+        add	rdi, qword ptr [8*rcx + .L__anon_4]
+        movzx	edx, word ptr [rcx + rcx + .L__anon_5]
         mov	rsi, rdi
         mov	rdi, rax
         jmp	memcpy@PLT

--- a/erd_core/codegen/ReleaseSmall/multi_runtime_write.s
+++ b/erd_core/codegen/ReleaseSmall/multi_runtime_write.s
@@ -15,14 +15,12 @@ multi_runtime_write:
         push	r12
         push	rbx
         push	rax
-        movzx	eax, si
-        cmp	byte ptr [rax + .L__anon_0], 0
-        jne	.L1
         mov	rbx, rdx
         mov	r14, rdi
-        movzx	r15d, word ptr [rax + rax + .L__anon_2]
-        movzx	r12d, word ptr [r15 + r15 + .L__anon_3]
-        mov	r13, qword ptr [8*r15 + .L__anon_4]
+        movzx	eax, si
+        movzx	r15d, word ptr [rax + rax + .L__anon_0]
+        movzx	r12d, word ptr [r15 + r15 + .L__anon_1]
+        mov	r13, qword ptr [8*r15 + .L__anon_2]
         add	r13, rdi
         mov	rdi, rdx
         mov	rsi, r13
@@ -34,9 +32,9 @@ multi_runtime_write:
         mov	rdx, r12
         call	memcpy@PLT
         test	bpl, 1
-        jne	.L1
-        cmp	byte ptr [r15 + .L__anon_5], 0
-        je	.L1
+        jne	.L3
+        cmp	byte ptr [r15 + .L__anon_4], 0
+        je	.L3
         mov	rdi, r14
         mov	esi, r15d
         mov	rdx, rbx
@@ -48,8 +46,8 @@ multi_runtime_write:
         pop	r14
         pop	r15
         pop	rbp
-        jmp	".Lram_data_component.RamDataComponent(@as([*]const Erd, @ptrCast(&codegen_harness.ram_defs))[0..3]).publish"
-.L1:
+        jmp	".Lram_data_component.RamDataComponent(@as([*]const Erd, @ptrCast(&codegen_harness.multi_ram_erds))[0..3]).publish"
+.L3:
         add	rsp, 8
         pop	rbx
         pop	r12

--- a/erd_core/codegen/ReleaseSmall/multi_runtime_write.s
+++ b/erd_core/codegen/ReleaseSmall/multi_runtime_write.s
@@ -32,9 +32,9 @@ multi_runtime_write:
         mov	rdx, r12
         call	memcpy@PLT
         test	bpl, 1
-        jne	.L3
-        cmp	byte ptr [r15 + .L__anon_4], 0
-        je	.L3
+        jne	.L0
+        cmp	byte ptr [r15 + .L__anon_3], 0
+        je	.L0
         mov	rdi, r14
         mov	esi, r15d
         mov	rdx, rbx
@@ -47,7 +47,7 @@ multi_runtime_write:
         pop	r15
         pop	rbp
         jmp	".Lram_data_component.RamDataComponent(@as([*]const Erd, @ptrCast(&codegen_harness.multi_ram_erds))[0..3]).publish"
-.L3:
+.L0:
         add	rsp, 8
         pop	rbx
         pop	r12

--- a/erd_core/codegen/ReleaseSmall/read_all_component_types.s
+++ b/erd_core/codegen/ReleaseSmall/read_all_component_types.s
@@ -4,7 +4,7 @@
 ;
 read_all_component_types:
         mov	eax, dword ptr [rdi]
-        mov	rcx, qword ptr [rdi + 168]
+        mov	rcx, qword ptr [rdi + 136]
         movzx	edx, word ptr [rcx + 5]
         add	eax, dword ptr [rcx]
         add	eax, edx

--- a/erd_core/codegen/ReleaseSmall/read_converted_both.s
+++ b/erd_core/codegen/ReleaseSmall/read_converted_both.s
@@ -3,7 +3,7 @@
 ; PER-ERD: two converted reads, each unique compute function.
 ;
 read_converted_both:
-        mov	rax, qword ptr [rdi + 168]
+        mov	rax, qword ptr [rdi + 136]
         movzx	ecx, word ptr [rax + 5]
         add	ecx, dword ptr [rax]
         mov	eax, dword ptr [rax + 4]

--- a/erd_core/codegen/ReleaseSmall/read_converted_flag_inv.s
+++ b/erd_core/codegen/ReleaseSmall/read_converted_flag_inv.s
@@ -3,7 +3,7 @@
 ; PER-ERD: compute inlined. Same tradeoff as read_converted_sum.
 ;
 read_converted_flag_inv:
-        mov	rax, qword ptr [rdi + 168]
+        mov	rax, qword ptr [rdi + 136]
         mov	al, byte ptr [rax + 4]
         xor	al, 1
         ret

--- a/erd_core/codegen/ReleaseSmall/read_converted_sum.s
+++ b/erd_core/codegen/ReleaseSmall/read_converted_sum.s
@@ -3,7 +3,7 @@
 ; PER-ERD: compute inlined. Cannot per-type share (unique fn).
 ;
 read_converted_sum:
-        mov	rcx, qword ptr [rdi + 168]
+        mov	rcx, qword ptr [rdi + 136]
         movzx	eax, word ptr [rcx + 5]
         add	eax, dword ptr [rcx]
         ret

--- a/erd_core/codegen/ReleaseSmall/read_ram_then_converted.s
+++ b/erd_core/codegen/ReleaseSmall/read_ram_then_converted.s
@@ -3,7 +3,7 @@
 ; PER-ERD: RAM load + converted compute inlined.
 ;
 read_ram_then_converted:
-        mov	rcx, qword ptr [rdi + 168]
+        mov	rcx, qword ptr [rdi + 136]
         mov	eax, dword ptr [rcx]
         movzx	ecx, word ptr [rcx + 5]
         add	eax, dword ptr [rdi]

--- a/erd_core/codegen/ReleaseSmall/read_write_other_read.s
+++ b/erd_core/codegen/ReleaseSmall/read_write_other_read.s
@@ -23,12 +23,12 @@ read_write_other_read:
         mov	byte ptr [rsp + 6], sil
         cmp	byte ptr [rdi + 4], sil
         mov	byte ptr [rdi + 4], sil
-        je	.L2
+        je	.L0
         lea	rdx, [rsp + 6]
         mov	esi, 1
         mov	rcx, rdi
         call	".Lram_data_component.RamDataComponent(&.{ .{ ... }, .{ ... }, .{ ... }, .{ ... } }[0..4]).publish.2"
-.L2:
+.L0:
         pop	rax
         ret
 

--- a/erd_core/codegen/ReleaseSmall/runtime_write.s
+++ b/erd_core/codegen/ReleaseSmall/runtime_write.s
@@ -32,9 +32,9 @@ runtime_write:
         mov	rdx, r12
         call	memcpy@PLT
         test	bpl, 1
-        jne	.L4
-        cmp	byte ptr [r15 + .L__anon_5], 0
-        je	.L4
+        jne	.L0
+        cmp	byte ptr [r15 + .L__anon_4], 0
+        je	.L0
         mov	rdi, r14
         mov	esi, r15d
         mov	rdx, rbx
@@ -47,7 +47,7 @@ runtime_write:
         pop	r15
         pop	rbp
         jmp	".Lram_data_component.RamDataComponent(&.{ .{ ... }, .{ ... }, .{ ... }, .{ ... } }[0..4]).publish.2"
-.L4:
+.L0:
         add	rsp, 8
         pop	rbx
         pop	r12

--- a/erd_core/codegen/ReleaseSmall/runtime_write_three.s
+++ b/erd_core/codegen/ReleaseSmall/runtime_write_three.s
@@ -55,9 +55,9 @@ runtime_write_three:
         mov	rdx, r12
         call	memcpy@PLT
         test	bpl, 1
-        jne	.L4
-        cmp	byte ptr [r15 + .L__anon_5], 0
-        je	.L4
+        jne	.L0
+        cmp	byte ptr [r15 + .L__anon_4], 0
+        je	.L0
         mov	rdi, r14
         mov	esi, r15d
         mov	rdx, rbx
@@ -70,7 +70,7 @@ runtime_write_three:
         pop	r15
         pop	rbp
         jmp	".Lram_data_component.RamDataComponent(&.{ .{ ... }, .{ ... }, .{ ... }, .{ ... } }[0..4]).publish.2"
-.L4:
+.L0:
         add	rsp, 8
         pop	rbx
         pop	r12

--- a/erd_core/codegen/ReleaseSmall/runtime_write_two.s
+++ b/erd_core/codegen/ReleaseSmall/runtime_write_two.s
@@ -45,9 +45,9 @@ runtime_write_two:
         mov	rdx, r12
         call	memcpy@PLT
         test	bpl, 1
-        jne	.L4
-        cmp	byte ptr [r15 + .L__anon_5], 0
-        je	.L4
+        jne	.L0
+        cmp	byte ptr [r15 + .L__anon_4], 0
+        je	.L0
         mov	rdi, r14
         mov	esi, r15d
         mov	rdx, rbx
@@ -60,7 +60,7 @@ runtime_write_two:
         pop	r15
         pop	rbp
         jmp	".Lram_data_component.RamDataComponent(&.{ .{ ... }, .{ ... }, .{ ... }, .{ ... } }[0..4]).publish.2"
-.L4:
+.L0:
         add	rsp, 8
         pop	rbx
         pop	r12

--- a/erd_core/codegen/ReleaseSmall/setup_timer_callback.s
+++ b/erd_core/codegen/ReleaseSmall/setup_timer_callback.s
@@ -69,24 +69,24 @@ setup_timer_callback:
 
 .Ltimer.TimerModule.tryRemove:
         mov	rax, qword ptr [rdi]
-        cmp	rax, rsi
-        je	.L6
         test	rax, rax
+        je	.L6
+        cmp	rax, rsi
         je	.L7
 .L8:
         mov	rcx, qword ptr [rax]
         test	rcx, rcx
-        je	.L7
+        je	.L6
         mov	rdi, rax
         mov	rax, rcx
         cmp	rcx, rsi
         jne	.L8
-.L6:
+.L7:
         mov	rax, qword ptr [rsi]
         mov	qword ptr [rdi], rax
         mov	al, 1
         ret
-.L7:
+.L6:
         xor	eax, eax
         ret
 

--- a/erd_core/codegen/ReleaseSmall/setup_timer_callback.s
+++ b/erd_core/codegen/ReleaseSmall/setup_timer_callback.s
@@ -69,24 +69,24 @@ setup_timer_callback:
 
 .Ltimer.TimerModule.tryRemove:
         mov	rax, qword ptr [rdi]
-        test	rax, rax
-        je	.L6
         cmp	rax, rsi
+        je	.L6
+        test	rax, rax
         je	.L7
 .L8:
         mov	rcx, qword ptr [rax]
         test	rcx, rcx
-        je	.L6
+        je	.L7
         mov	rdi, rax
         mov	rax, rcx
         cmp	rcx, rsi
         jne	.L8
-.L7:
+.L6:
         mov	rax, qword ptr [rsi]
         mov	qword ptr [rdi], rax
         mov	al, 1
         ret
-.L6:
+.L7:
         xor	eax, eax
         ret
 

--- a/erd_core/codegen/ReleaseSmall/subscribe_converted.s
+++ b/erd_core/codegen/ReleaseSmall/subscribe_converted.s
@@ -2,13 +2,13 @@
 ; Speed: Optimal | Size: Optimal (until 2 calls)
 ;
 subscribe_converted:
-        add	rdi, 104
+        add	rdi, 72
         xor	esi, esi
-        jmp	".Ldata_component_subscription.DataComponentSubscription(@as([*]const Erd, @ptrCast(&codegen_harness.converted_defs))[0..2]).subscribeInner"
+        jmp	".Ldata_component_subscription.DataComponentSubscription(@as([*]const Erd, @ptrCast(&codegen_harness.multi_converted_erds))[0..2]).subscribeInner"
 
 ; --- called functions ---
 
-".Ldata_component_subscription.DataComponentSubscription(@as([*]const Erd, @ptrCast(&codegen_harness.converted_defs))[0..2]).subscribeInner":
+".Ldata_component_subscription.DataComponentSubscription(@as([*]const Erd, @ptrCast(&codegen_harness.multi_converted_erds))[0..2]).subscribeInner":
         shl	rsi, 4
         add	rdi, rsi
         mov	esi, 2

--- a/erd_core/codegen/ReleaseSmall/subscribe_converted_flag.s
+++ b/erd_core/codegen/ReleaseSmall/subscribe_converted_flag.s
@@ -2,14 +2,14 @@
 ; Speed: Optimal | Size: Optimal (until 3 calls)
 ;
 subscribe_converted_flag:
-        add	rdi, 104
+        add	rdi, 72
         push	2
         pop	rsi
-        jmp	".Ldata_component_subscription.DataComponentSubscription(@as([*]const Erd, @ptrCast(&codegen_harness.converted_defs))[0..2]).subscribeInner"
+        jmp	".Ldata_component_subscription.DataComponentSubscription(@as([*]const Erd, @ptrCast(&codegen_harness.multi_converted_erds))[0..2]).subscribeInner"
 
 ; --- called functions ---
 
-".Ldata_component_subscription.DataComponentSubscription(@as([*]const Erd, @ptrCast(&codegen_harness.converted_defs))[0..2]).subscribeInner":
+".Ldata_component_subscription.DataComponentSubscription(@as([*]const Erd, @ptrCast(&codegen_harness.multi_converted_erds))[0..2]).subscribeInner":
         shl	rsi, 4
         add	rdi, rsi
         mov	esi, 2

--- a/erd_core/codegen/ReleaseSmall/triple_write_increment.s
+++ b/erd_core/codegen/ReleaseSmall/triple_write_increment.s
@@ -25,12 +25,12 @@ triple_write_increment:
         mov	word ptr [rsp + 6], si
         cmp	word ptr [rdi + 7], si
         mov	word ptr [rdi + 7], si
-        je	.L2
+        je	.L0
         lea	rdx, [rsp + 6]
         mov	esi, 3
         mov	rcx, rdi
         call	".Lram_data_component.RamDataComponent(&.{ .{ ... }, .{ ... }, .{ ... }, .{ ... } }[0..4]).publish.2"
-.L2:
+.L0:
         pop	rax
         ret
 

--- a/erd_core/codegen/ReleaseSmall/unsubscribe_converted.s
+++ b/erd_core/codegen/ReleaseSmall/unsubscribe_converted.s
@@ -2,13 +2,13 @@
 ; Speed: Optimal | Size: Optimal (until 3 calls)
 ;
 unsubscribe_converted:
-        add	rdi, 104
+        add	rdi, 72
         xor	esi, esi
-        jmp	".Ldata_component_subscription.DataComponentSubscription(@as([*]const Erd, @ptrCast(&codegen_harness.converted_defs))[0..2]).unsubscribeInner"
+        jmp	".Ldata_component_subscription.DataComponentSubscription(@as([*]const Erd, @ptrCast(&codegen_harness.multi_converted_erds))[0..2]).unsubscribeInner"
 
 ; --- called functions ---
 
-".Ldata_component_subscription.DataComponentSubscription(@as([*]const Erd, @ptrCast(&codegen_harness.converted_defs))[0..2]).unsubscribeInner":
+".Ldata_component_subscription.DataComponentSubscription(@as([*]const Erd, @ptrCast(&codegen_harness.multi_converted_erds))[0..2]).unsubscribeInner":
         shl	rsi, 4
         add	rdi, rsi
         jmp	.LSubscription.unsubscribe

--- a/erd_core/codegen/ReleaseSmall/unsubscribe_converted_flag.s
+++ b/erd_core/codegen/ReleaseSmall/unsubscribe_converted_flag.s
@@ -2,14 +2,14 @@
 ; Speed: Optimal | Size: Optimal (until 3 calls)
 ;
 unsubscribe_converted_flag:
-        add	rdi, 104
+        add	rdi, 72
         push	2
         pop	rsi
-        jmp	".Ldata_component_subscription.DataComponentSubscription(@as([*]const Erd, @ptrCast(&codegen_harness.converted_defs))[0..2]).unsubscribeInner"
+        jmp	".Ldata_component_subscription.DataComponentSubscription(@as([*]const Erd, @ptrCast(&codegen_harness.multi_converted_erds))[0..2]).unsubscribeInner"
 
 ; --- called functions ---
 
-".Ldata_component_subscription.DataComponentSubscription(@as([*]const Erd, @ptrCast(&codegen_harness.converted_defs))[0..2]).unsubscribeInner":
+".Ldata_component_subscription.DataComponentSubscription(@as([*]const Erd, @ptrCast(&codegen_harness.multi_converted_erds))[0..2]).unsubscribeInner":
         shl	rsi, 4
         add	rdi, rsi
         jmp	.LSubscription.unsubscribe

--- a/erd_core/codegen/ReleaseSmall/write_bool_with_subs.s
+++ b/erd_core/codegen/ReleaseSmall/write_bool_with_subs.s
@@ -12,12 +12,12 @@ write_bool_with_subs:
         mov	byte ptr [rsp + 6], sil
         cmp	byte ptr [rdi + 4], sil
         mov	byte ptr [rdi + 4], sil
-        je	.L2
+        je	.L0
         lea	rdx, [rsp + 6]
         mov	esi, 1
         mov	rcx, rdi
         call	".Lram_data_component.RamDataComponent(&.{ .{ ... }, .{ ... }, .{ ... }, .{ ... } }[0..4]).publish.2"
-.L2:
+.L0:
         pop	rax
         ret
 

--- a/erd_core/codegen/ReleaseSmall/write_junk_read_write.s
+++ b/erd_core/codegen/ReleaseSmall/write_junk_read_write.s
@@ -21,12 +21,12 @@ write_junk_read_write:
         mov	word ptr [rsp + 6], si
         cmp	word ptr [rdi + 7], si
         mov	word ptr [rdi + 7], si
-        je	.L2
+        je	.L0
         lea	rdx, [rsp + 6]
         mov	esi, 3
         mov	rcx, rdi
         call	".Lram_data_component.RamDataComponent(&.{ .{ ... }, .{ ... }, .{ ... }, .{ ... } }[0..4]).publish.2"
-.L2:
+.L0:
         pop	rax
         ret
 

--- a/erd_core/codegen/ReleaseSmall/write_ram_flag_with_converted_dep.s
+++ b/erd_core/codegen/ReleaseSmall/write_ram_flag_with_converted_dep.s
@@ -23,11 +23,11 @@ write_ram_flag_with_converted_dep:
         mov	r8, rcx
         mov	rcx, rdx
         movzx	eax, si
-        mov	rdx, qword ptr [8*rax + .L__anon_1]
-        movzx	esi, byte ptr [rax + .L__anon_2]
+        mov	rdx, qword ptr [8*rax + .L__anon_0]
+        movzx	esi, byte ptr [rax + .L__anon_1]
         shl	rdx, 4
         add	rdi, rdx
         add	rdi, 8
-        movzx	edx, word ptr [rax + rax + .L__anon_3]
+        movzx	edx, word ptr [rax + rax + .L__anon_2]
         jmp	.LSubscription.publish
 

--- a/erd_core/codegen/ReleaseSmall/write_ram_flag_with_converted_dep.s
+++ b/erd_core/codegen/ReleaseSmall/write_ram_flag_with_converted_dep.s
@@ -12,14 +12,14 @@ write_ram_flag_with_converted_dep:
         pop	rsi
         lea	rdx, [rsp + 6]
         mov	rcx, rdi
-        call	".Lram_data_component.RamDataComponent(@as([*]const Erd, @ptrCast(&codegen_harness.ram_defs))[0..3]).publish"
+        call	".Lram_data_component.RamDataComponent(@as([*]const Erd, @ptrCast(&codegen_harness.multi_ram_erds))[0..3]).publish"
 .L0:
         pop	rax
         ret
 
 ; --- called functions ---
 
-".Lram_data_component.RamDataComponent(@as([*]const Erd, @ptrCast(&codegen_harness.ram_defs))[0..3]).publish":
+".Lram_data_component.RamDataComponent(@as([*]const Erd, @ptrCast(&codegen_harness.multi_ram_erds))[0..3]).publish":
         mov	r8, rcx
         mov	rcx, rdx
         movzx	eax, si

--- a/erd_core/codegen/ReleaseSmall/write_ram_with_converted_deps.s
+++ b/erd_core/codegen/ReleaseSmall/write_ram_with_converted_deps.s
@@ -15,7 +15,7 @@ write_ram_with_converted_deps:
         lea	rdx, [rsp + 4]
         xor	esi, esi
         mov	rcx, rdi
-        call	".Lram_data_component.RamDataComponent(@as([*]const Erd, @ptrCast(&codegen_harness.ram_defs))[0..3]).publish"
+        call	".Lram_data_component.RamDataComponent(@as([*]const Erd, @ptrCast(&codegen_harness.multi_ram_erds))[0..3]).publish"
 .L1:
         pop	rax
         ret

--- a/erd_core/codegen/ReleaseSmall/write_ram_with_converted_deps.s
+++ b/erd_core/codegen/ReleaseSmall/write_ram_with_converted_deps.s
@@ -11,12 +11,12 @@ write_ram_with_converted_deps:
         mov	dword ptr [rsp + 4], esi
         cmp	dword ptr [rdi], esi
         mov	dword ptr [rdi], esi
-        je	.L1
+        je	.L0
         lea	rdx, [rsp + 4]
         xor	esi, esi
         mov	rcx, rdi
         call	".Lram_data_component.RamDataComponent(@as([*]const Erd, @ptrCast(&codegen_harness.multi_ram_erds))[0..3]).publish"
-.L1:
+.L0:
         pop	rax
         ret
 

--- a/erd_core/codegen/ReleaseSmall/write_then_read_converted.s
+++ b/erd_core/codegen/ReleaseSmall/write_then_read_converted.s
@@ -6,7 +6,7 @@ write_then_read_converted:
         push	rbx
         mov	rbx, rdi
         call	".Lsystem_data.SystemData(codegen_harness.MultiErdDefs,meta.FieldEnum(codegen_harness.MultiErdDefs),.{ .ram_counter = .{ ... }, .ram_flag = .{ ... }, .ram_value = .{ ... }, .ind_constant = .{ ... }, .ind_computed = .{ ... }, .conv_sum = .{ ... }, .conv_flag_inv = .{ ... } },codegen_harness.MultiComponents).write__anon_0"
-        mov	rcx, qword ptr [rbx + 168]
+        mov	rcx, qword ptr [rbx + 136]
         movzx	eax, word ptr [rcx + 5]
         add	eax, dword ptr [rcx]
         pop	rbx
@@ -23,7 +23,7 @@ write_then_read_converted:
         lea	rdx, [rsp + 4]
         xor	esi, esi
         mov	rcx, rdi
-        call	".Lram_data_component.RamDataComponent(@as([*]const Erd, @ptrCast(&codegen_harness.ram_defs))[0..3]).publish"
+        call	".Lram_data_component.RamDataComponent(@as([*]const Erd, @ptrCast(&codegen_harness.multi_ram_erds))[0..3]).publish"
 .L1:
         pop	rax
         ret

--- a/erd_core/codegen/ReleaseSmall/write_then_read_converted.s
+++ b/erd_core/codegen/ReleaseSmall/write_then_read_converted.s
@@ -19,12 +19,12 @@ write_then_read_converted:
         mov	dword ptr [rsp + 4], esi
         cmp	dword ptr [rdi], esi
         mov	dword ptr [rdi], esi
-        je	.L1
+        je	.L0
         lea	rdx, [rsp + 4]
         xor	esi, esi
         mov	rcx, rdi
         call	".Lram_data_component.RamDataComponent(@as([*]const Erd, @ptrCast(&codegen_harness.multi_ram_erds))[0..3]).publish"
-.L1:
+.L0:
         pop	rax
         ret
 

--- a/erd_core/codegen/ReleaseSmall/write_triggering_callback.s
+++ b/erd_core/codegen/ReleaseSmall/write_triggering_callback.s
@@ -14,12 +14,12 @@ write_triggering_callback:
         mov	byte ptr [rsp + 6], sil
         cmp	byte ptr [rdi + 4], sil
         mov	byte ptr [rdi + 4], sil
-        je	.L2
+        je	.L0
         lea	rdx, [rsp + 6]
         mov	esi, 1
         mov	rcx, rdi
         call	".Lram_data_component.RamDataComponent(&.{ .{ ... }, .{ ... }, .{ ... }, .{ ... } }[0..4]).publish.2"
-.L2:
+.L0:
         pop	rax
         ret
 

--- a/erd_core/codegen/ReleaseSmall/write_u16_with_subs.s
+++ b/erd_core/codegen/ReleaseSmall/write_u16_with_subs.s
@@ -11,12 +11,12 @@ write_u16_with_subs:
         mov	word ptr [rsp + 6], si
         cmp	word ptr [rdi + 7], si
         mov	word ptr [rdi + 7], si
-        je	.L2
+        je	.L0
         lea	rdx, [rsp + 6]
         mov	esi, 3
         mov	rcx, rdi
         call	".Lram_data_component.RamDataComponent(&.{ .{ ... }, .{ ... }, .{ ... }, .{ ... } }[0..4]).publish.2"
-.L2:
+.L0:
         pop	rax
         ret
 

--- a/erd_core/codegen/mono/ReleaseFast/mixed_modify.s
+++ b/erd_core/codegen/mono/ReleaseFast/mixed_modify.s
@@ -7,11 +7,11 @@ mixed_modify:
         add	dword ptr [rdi + 15], 1
         mov	esi, 4
         mov	rcx, rdi
-        jmp	"ram_data_component.RamDataComponent(@as([*]const Erd, @ptrCast(&codegen_mono_stress.mixed_ram_defs))[0..5]).publish"
+        jmp	"ram_data_component.RamDataComponent(@as([*]const Erd, @ptrCast(&codegen_mono_stress.mixed_ram_erds))[0..5]).publish"
 
 ; --- called functions ---
 
-"ram_data_component.RamDataComponent(@as([*]const Erd, @ptrCast(&codegen_mono_stress.mixed_ram_defs))[0..5]).publish":
+"ram_data_component.RamDataComponent(@as([*]const Erd, @ptrCast(&codegen_mono_stress.mixed_ram_erds))[0..5]).publish":
         mov	r8, rcx
         mov	rcx, rdx
         movzx	eax, si

--- a/erd_core/codegen/mono/ReleaseFast/mixed_read_all.s
+++ b/erd_core/codegen/mono/ReleaseFast/mixed_read_all.s
@@ -7,7 +7,7 @@ mixed_read_all:
         add	rcx, rax
         movzx	eax, byte ptr [rdi + 6]
         and	eax, 1
-        mov	rdx, qword ptr [rdi + 208]
+        mov	rdx, qword ptr [rdi + 168]
         mov	esi, dword ptr [rdx]
         movzx	r8d, word ptr [rdx + 4]
         add	r8d, esi

--- a/erd_core/codegen/mono/ReleaseFast/mixed_runtime_read.s
+++ b/erd_core/codegen/mono/ReleaseFast/mixed_runtime_read.s
@@ -12,18 +12,18 @@ mixed_runtime_read:
         movzx	edx, byte ptr [rcx + __anon_0]
         movzx	ecx, word ptr [rcx + rcx + __anon_1]
         cmp	edx, 2
-        je	.L2
+        je	.L0
         cmp	edx, 1
-        jne	.L3
+        jne	.L1
         mov	rdi, rax
-        jmp	qword ptr [8*rcx + __anon_4]
-.L2:
+        jmp	qword ptr [8*rcx + __anon_2]
+.L0:
         mov	rsi, qword ptr [rdi + 168]
         mov	rdi, rax
-        jmp	qword ptr [8*rcx + __anon_5]
-.L3:
-        add	rdi, qword ptr [8*rcx + __anon_6]
-        movzx	edx, word ptr [rcx + rcx + __anon_7]
+        jmp	qword ptr [8*rcx + __anon_3]
+.L1:
+        add	rdi, qword ptr [8*rcx + __anon_4]
+        movzx	edx, word ptr [rcx + rcx + __anon_5]
         mov	rsi, rdi
         mov	rdi, rax
         jmp	memcpy@PLT

--- a/erd_core/codegen/mono/ReleaseFast/mixed_runtime_read.s
+++ b/erd_core/codegen/mono/ReleaseFast/mixed_runtime_read.s
@@ -7,30 +7,24 @@ mixed_runtime_read:
 ; --- called functions ---
 
 "system_data.SystemData(codegen_mono_stress.MixedDefs,meta.FieldEnum(codegen_mono_stress.MixedDefs),.{ .ram_a = .{ ... }, .ram_b = .{ ... }, .ram_c = .{ ... }, .ram_d = .{ ... }, .ind_x = .{ ... }, .ind_y = .{ ... }, .conv_sum = .{ ... }, .conv_flag = .{ ... }, .conv_wide = .{ ... }, .ram_pair = .{ ... } },codegen_mono_stress.MixedComponents).runtimeRead":
-        mov	rax, rdi
+        mov	rax, rdx
         movzx	ecx, si
-        movzx	esi, byte ptr [rcx + __anon_0]
+        movzx	edx, byte ptr [rcx + __anon_0]
         movzx	ecx, word ptr [rcx + rcx + __anon_1]
-        test	esi, esi
+        cmp	edx, 2
         je	.L2
-        cmp	esi, 1
-        je	.L3
-        cmp	esi, 2
-        jne	.L4
-        mov	rcx, qword ptr [rax + 8*rcx + 120]
-        mov	rsi, qword ptr [rax + 208]
-        mov	rdi, rdx
-        jmp	rcx
-.L3:
-        mov	rdi, rdx
-        jmp	qword ptr [rax + 8*rcx + 104]
+        cmp	edx, 1
+        jne	.L3
+        mov	rdi, rax
+        jmp	qword ptr [8*rcx + __anon_4]
 .L2:
-        add	rax, qword ptr [8*rcx + __anon_5]
-        movzx	ecx, word ptr [rcx + rcx + __anon_6]
-        mov	rdi, rdx
-        mov	rsi, rax
-        mov	rdx, rcx
+        mov	rsi, qword ptr [rdi + 168]
+        mov	rdi, rax
+        jmp	qword ptr [8*rcx + __anon_5]
+.L3:
+        add	rdi, qword ptr [8*rcx + __anon_6]
+        movzx	edx, word ptr [rcx + rcx + __anon_7]
+        mov	rsi, rdi
+        mov	rdi, rax
         jmp	memcpy@PLT
-.L4:
-        ret
 

--- a/erd_core/codegen/mono/ReleaseFast/mixed_runtime_write.s
+++ b/erd_core/codegen/mono/ReleaseFast/mixed_runtime_write.s
@@ -15,14 +15,12 @@ mixed_runtime_write:
         push	r12
         push	rbx
         push	rax
-        movzx	eax, si
-        cmp	byte ptr [rax + __anon_0], 0
-        jne	.L1
         mov	rbx, rdx
         mov	r14, rdi
-        movzx	r15d, word ptr [rax + rax + __anon_2]
-        movzx	r12d, word ptr [r15 + r15 + __anon_3]
-        mov	r13, qword ptr [8*r15 + __anon_4]
+        movzx	eax, si
+        movzx	r15d, word ptr [rax + rax + __anon_0]
+        movzx	r12d, word ptr [r15 + r15 + __anon_1]
+        mov	r13, qword ptr [8*r15 + __anon_2]
         add	r13, rdi
         mov	rdi, rdx
         mov	rsi, r13
@@ -34,9 +32,9 @@ mixed_runtime_write:
         mov	rdx, r12
         call	memcpy@PLT
         test	bpl, 1
-        jne	.L1
-        cmp	byte ptr [r15 + __anon_5], 0
-        je	.L1
+        jne	.L3
+        cmp	byte ptr [r15 + __anon_4], 0
+        je	.L3
         mov	rdi, r14
         mov	esi, r15d
         mov	rdx, rbx
@@ -48,8 +46,8 @@ mixed_runtime_write:
         pop	r14
         pop	r15
         pop	rbp
-        jmp	"ram_data_component.RamDataComponent(@as([*]const Erd, @ptrCast(&codegen_mono_stress.mixed_ram_defs))[0..5]).publish"
-.L1:
+        jmp	"ram_data_component.RamDataComponent(@as([*]const Erd, @ptrCast(&codegen_mono_stress.mixed_ram_erds))[0..5]).publish"
+.L3:
         add	rsp, 8
         pop	rbx
         pop	r12

--- a/erd_core/codegen/mono/ReleaseFast/mixed_runtime_write.s
+++ b/erd_core/codegen/mono/ReleaseFast/mixed_runtime_write.s
@@ -32,9 +32,9 @@ mixed_runtime_write:
         mov	rdx, r12
         call	memcpy@PLT
         test	bpl, 1
-        jne	.L3
-        cmp	byte ptr [r15 + __anon_4], 0
-        je	.L3
+        jne	.L0
+        cmp	byte ptr [r15 + __anon_3], 0
+        je	.L0
         mov	rdi, r14
         mov	esi, r15d
         mov	rdx, rbx
@@ -47,7 +47,7 @@ mixed_runtime_write:
         pop	r15
         pop	rbp
         jmp	"ram_data_component.RamDataComponent(@as([*]const Erd, @ptrCast(&codegen_mono_stress.mixed_ram_erds))[0..5]).publish"
-.L3:
+.L0:
         add	rsp, 8
         pop	rbx
         pop	r12

--- a/erd_core/codegen/mono/ReleaseFast/mixed_subscribe_conv.s
+++ b/erd_core/codegen/mono/ReleaseFast/mixed_subscribe_conv.s
@@ -2,12 +2,12 @@
 ; Speed: Optimal | Size: Optimal (until 3 calls)
 ;
 mixed_subscribe_conv:
-        add	rdi, 144
-        jmp	"data_component_subscription.DataComponentSubscription(@as([*]const Erd, @ptrCast(&codegen_mono_stress.mixed_conv_defs))[0..3]).subscribeInner"
+        add	rdi, 104
+        jmp	"data_component_subscription.DataComponentSubscription(@as([*]const Erd, @ptrCast(&codegen_mono_stress.mixed_conv_erds))[0..3]).subscribeInner"
 
 ; --- called functions ---
 
-"data_component_subscription.DataComponentSubscription(@as([*]const Erd, @ptrCast(&codegen_mono_stress.mixed_conv_defs))[0..3]).subscribeInner":
+"data_component_subscription.DataComponentSubscription(@as([*]const Erd, @ptrCast(&codegen_mono_stress.mixed_conv_erds))[0..3]).subscribeInner":
         mov	esi, 2
         jmp	Subscription.subscribe
 

--- a/erd_core/codegen/mono/ReleaseFast/mixed_subscribe_ram.s
+++ b/erd_core/codegen/mono/ReleaseFast/mixed_subscribe_ram.s
@@ -3,11 +3,11 @@
 ;
 mixed_subscribe_ram:
         add	rdi, 24
-        jmp	"data_component_subscription.DataComponentSubscription(@as([*]const Erd, @ptrCast(&codegen_mono_stress.mixed_conv_defs))[0..3]).subscribeInner"
+        jmp	"data_component_subscription.DataComponentSubscription(@as([*]const Erd, @ptrCast(&codegen_mono_stress.mixed_conv_erds))[0..3]).subscribeInner"
 
 ; --- called functions ---
 
-"data_component_subscription.DataComponentSubscription(@as([*]const Erd, @ptrCast(&codegen_mono_stress.mixed_conv_defs))[0..3]).subscribeInner":
+"data_component_subscription.DataComponentSubscription(@as([*]const Erd, @ptrCast(&codegen_mono_stress.mixed_conv_erds))[0..3]).subscribeInner":
         mov	esi, 2
         jmp	Subscription.subscribe
 

--- a/erd_core/codegen/mono/ReleaseFast/mixed_unsubscribe_conv.s
+++ b/erd_core/codegen/mono/ReleaseFast/mixed_unsubscribe_conv.s
@@ -2,12 +2,12 @@
 ; Speed: Optimal | Size: Optimal (until 3 calls)
 ;
 mixed_unsubscribe_conv:
-        add	rdi, 144
-        jmp	"data_component_subscription.DataComponentSubscription(@as([*]const Erd, @ptrCast(&codegen_mono_stress.mixed_conv_defs))[0..3]).unsubscribeInner"
+        add	rdi, 104
+        jmp	"data_component_subscription.DataComponentSubscription(@as([*]const Erd, @ptrCast(&codegen_mono_stress.mixed_conv_erds))[0..3]).unsubscribeInner"
 
 ; --- called functions ---
 
-"data_component_subscription.DataComponentSubscription(@as([*]const Erd, @ptrCast(&codegen_mono_stress.mixed_conv_defs))[0..3]).unsubscribeInner":
+"data_component_subscription.DataComponentSubscription(@as([*]const Erd, @ptrCast(&codegen_mono_stress.mixed_conv_erds))[0..3]).unsubscribeInner":
         mov	esi, 2
         jmp	Subscription.unsubscribe
 

--- a/erd_core/codegen/mono/ReleaseFast/mixed_unsubscribe_ram.s
+++ b/erd_core/codegen/mono/ReleaseFast/mixed_unsubscribe_ram.s
@@ -3,11 +3,11 @@
 ;
 mixed_unsubscribe_ram:
         add	rdi, 24
-        jmp	"data_component_subscription.DataComponentSubscription(@as([*]const Erd, @ptrCast(&codegen_mono_stress.mixed_conv_defs))[0..3]).unsubscribeInner"
+        jmp	"data_component_subscription.DataComponentSubscription(@as([*]const Erd, @ptrCast(&codegen_mono_stress.mixed_conv_erds))[0..3]).unsubscribeInner"
 
 ; --- called functions ---
 
-"data_component_subscription.DataComponentSubscription(@as([*]const Erd, @ptrCast(&codegen_mono_stress.mixed_conv_defs))[0..3]).unsubscribeInner":
+"data_component_subscription.DataComponentSubscription(@as([*]const Erd, @ptrCast(&codegen_mono_stress.mixed_conv_erds))[0..3]).unsubscribeInner":
         mov	esi, 2
         jmp	Subscription.unsubscribe
 

--- a/erd_core/codegen/mono/ReleaseFast/mixed_write_ram.s
+++ b/erd_core/codegen/mono/ReleaseFast/mixed_write_ram.s
@@ -20,7 +20,7 @@ mixed_write_ram:
         mov	rdi, rbx
         xor	esi, esi
         mov	rcx, rbx
-        call	"ram_data_component.RamDataComponent(@as([*]const Erd, @ptrCast(&codegen_mono_stress.mixed_ram_defs))[0..5]).publish"
+        call	"ram_data_component.RamDataComponent(@as([*]const Erd, @ptrCast(&codegen_mono_stress.mixed_ram_erds))[0..5]).publish"
 .L0:
         mov	word ptr [rsp + 2], r15w
         cmp	word ptr [rbx + 4], r15w
@@ -30,7 +30,7 @@ mixed_write_ram:
         mov	rdi, rbx
         mov	esi, 1
         mov	rcx, rbx
-        call	"ram_data_component.RamDataComponent(@as([*]const Erd, @ptrCast(&codegen_mono_stress.mixed_ram_defs))[0..5]).publish"
+        call	"ram_data_component.RamDataComponent(@as([*]const Erd, @ptrCast(&codegen_mono_stress.mixed_ram_erds))[0..5]).publish"
 .L1:
         and	bpl, 1
         mov	byte ptr [rbx + 6], bpl
@@ -42,7 +42,7 @@ mixed_write_ram:
         mov	rdi, rbx
         mov	esi, 3
         mov	rcx, rbx
-        call	"ram_data_component.RamDataComponent(@as([*]const Erd, @ptrCast(&codegen_mono_stress.mixed_ram_defs))[0..5]).publish"
+        call	"ram_data_component.RamDataComponent(@as([*]const Erd, @ptrCast(&codegen_mono_stress.mixed_ram_erds))[0..5]).publish"
 .L2:
         add	rsp, 24
         pop	rbx
@@ -53,7 +53,7 @@ mixed_write_ram:
 
 ; --- called functions ---
 
-"ram_data_component.RamDataComponent(@as([*]const Erd, @ptrCast(&codegen_mono_stress.mixed_ram_defs))[0..5]).publish":
+"ram_data_component.RamDataComponent(@as([*]const Erd, @ptrCast(&codegen_mono_stress.mixed_ram_erds))[0..5]).publish":
         mov	r8, rcx
         mov	rcx, rdx
         movzx	eax, si

--- a/erd_core/codegen/mono/ReleaseFast/mixed_write_ram.s
+++ b/erd_core/codegen/mono/ReleaseFast/mixed_write_ram.s
@@ -57,11 +57,11 @@ mixed_write_ram:
         mov	r8, rcx
         mov	rcx, rdx
         movzx	eax, si
-        mov	rdx, qword ptr [8*rax + __anon_3]
-        movzx	esi, byte ptr [rax + __anon_4]
+        mov	rdx, qword ptr [8*rax + __anon_0]
+        movzx	esi, byte ptr [rax + __anon_1]
         shl	rdx, 4
         add	rdi, rdx
         add	rdi, 24
-        movzx	edx, word ptr [rax + rax + __anon_5]
+        movzx	edx, word ptr [rax + rax + __anon_2]
         jmp	Subscription.publish
 

--- a/erd_core/codegen/mono/ReleaseFast/tiny_runtime_write.s
+++ b/erd_core/codegen/mono/ReleaseFast/tiny_runtime_write.s
@@ -32,7 +32,7 @@ tiny_runtime_write:
         mov	rdx, r12
         call	memcpy@PLT
         test	bpl, 1
-        je	.L4
+        je	.L0
         add	rsp, 8
         pop	rbx
         pop	r12
@@ -41,7 +41,7 @@ tiny_runtime_write:
         pop	r15
         pop	rbp
         ret
-.L4:
+.L0:
         mov	rdi, r14
         mov	esi, r15d
         mov	rdx, rbx

--- a/erd_core/codegen/mono/ReleaseFast/tiny_write_all.s
+++ b/erd_core/codegen/mono/ReleaseFast/tiny_write_all.s
@@ -40,11 +40,11 @@ tiny_write_all:
         mov	r8, rcx
         mov	rcx, rdx
         movzx	eax, si
-        mov	rdx, qword ptr [8*rax + __anon_2]
+        mov	rdx, qword ptr [8*rax + __anon_0]
         shl	rdx, 4
         add	rdi, rdx
         add	rdi, 16
-        movzx	edx, word ptr [rax + rax + __anon_3]
+        movzx	edx, word ptr [rax + rax + __anon_1]
         mov	esi, 1
         jmp	Subscription.publish
 

--- a/erd_core/codegen/mono/ReleaseFast/wide_runtime_write.s
+++ b/erd_core/codegen/mono/ReleaseFast/wide_runtime_write.s
@@ -32,9 +32,9 @@ wide_runtime_write:
         mov	rdx, r12
         call	memcpy@PLT
         test	bpl, 1
-        jne	.L4
-        cmp	byte ptr [r15 + __anon_5], 0
-        je	.L4
+        jne	.L0
+        cmp	byte ptr [r15 + __anon_4], 0
+        je	.L0
         mov	rdi, r14
         mov	esi, r15d
         mov	rdx, rbx
@@ -47,7 +47,7 @@ wide_runtime_write:
         pop	r15
         pop	rbp
         jmp	"ram_data_component.RamDataComponent(&.{ .{ ... }, .{ ... }, .{ ... }, .{ ... }, .{ ... }, .{ ... }, .{ ... }, .{ ... }, .{ ... }, .{ ... }, .{ ... }, .{ ... }, .{ ... }, .{ ... }, .{ ... }, .{ ... }, .{ ... } }[0..17]).publish"
-.L4:
+.L0:
         add	rsp, 8
         pop	rbx
         pop	r12

--- a/erd_core/codegen/mono/ReleaseFast/wide_runtime_write_all.s
+++ b/erd_core/codegen/mono/ReleaseFast/wide_runtime_write_all.s
@@ -108,9 +108,9 @@ wide_runtime_write_all:
         mov	rdx, r12
         call	memcpy@PLT
         test	bpl, 1
-        jne	.L4
-        cmp	byte ptr [r15 + __anon_5], 0
-        je	.L4
+        jne	.L0
+        cmp	byte ptr [r15 + __anon_4], 0
+        je	.L0
         mov	rdi, r14
         mov	esi, r15d
         mov	rdx, rbx
@@ -123,7 +123,7 @@ wide_runtime_write_all:
         pop	r15
         pop	rbp
         jmp	"ram_data_component.RamDataComponent(&.{ .{ ... }, .{ ... }, .{ ... }, .{ ... }, .{ ... }, .{ ... }, .{ ... }, .{ ... }, .{ ... }, .{ ... }, .{ ... }, .{ ... }, .{ ... }, .{ ... }, .{ ... }, .{ ... }, .{ ... } }[0..17]).publish"
-.L4:
+.L0:
         add	rsp, 8
         pop	rbx
         pop	r12

--- a/erd_core/codegen/mono/ReleaseFast/wide_write_all.s
+++ b/erd_core/codegen/mono/ReleaseFast/wide_write_all.s
@@ -111,11 +111,11 @@ wide_write_all:
         mov	r8, rcx
         mov	rcx, rdx
         movzx	eax, si
-        mov	rdx, qword ptr [8*rax + __anon_8]
-        movzx	esi, byte ptr [rax + __anon_9]
+        mov	rdx, qword ptr [8*rax + __anon_0]
+        movzx	esi, byte ptr [rax + __anon_1]
         shl	rdx, 4
         add	rdi, rdx
         add	rdi, 64
-        movzx	edx, word ptr [rax + rax + __anon_10]
+        movzx	edx, word ptr [rax + rax + __anon_2]
         jmp	Subscription.publish
 

--- a/erd_core/codegen/mono/ReleaseFast_x86_64.sizes
+++ b/erd_core/codegen/mono/ReleaseFast_x86_64.sizes
@@ -5,14 +5,14 @@
 2	tiny_runtime_write
 2	wide_runtime_read
 5	wide_runtime_write
+6	mixed_subscribe_conv
+6	mixed_unsubscribe_conv
 6	mixed_unsubscribe_ram
 6	tiny_subscribe
 6	tiny_unsubscribe
 6	wide_subscribe
 6	wide_unsubscribe
-9	mixed_subscribe_conv
 9	mixed_subscribe_ram
-9	mixed_unsubscribe_conv
 10	tiny_read_all
 18	mixed_modify
 18	tiny_modify

--- a/erd_core/codegen/mono/ReleaseSmall/mixed_modify.s
+++ b/erd_core/codegen/mono/ReleaseSmall/mixed_modify.s
@@ -8,11 +8,11 @@ mixed_modify:
         push	4
         pop	rsi
         mov	rcx, rdi
-        jmp	".Lram_data_component.RamDataComponent(@as([*]const Erd, @ptrCast(&codegen_mono_stress.mixed_ram_defs))[0..5]).publish"
+        jmp	".Lram_data_component.RamDataComponent(@as([*]const Erd, @ptrCast(&codegen_mono_stress.mixed_ram_erds))[0..5]).publish"
 
 ; --- called functions ---
 
-".Lram_data_component.RamDataComponent(@as([*]const Erd, @ptrCast(&codegen_mono_stress.mixed_ram_defs))[0..5]).publish":
+".Lram_data_component.RamDataComponent(@as([*]const Erd, @ptrCast(&codegen_mono_stress.mixed_ram_erds))[0..5]).publish":
         mov	r8, rcx
         mov	rcx, rdx
         movzx	eax, si

--- a/erd_core/codegen/mono/ReleaseSmall/mixed_read_all.s
+++ b/erd_core/codegen/mono/ReleaseSmall/mixed_read_all.s
@@ -7,7 +7,7 @@ mixed_read_all:
         add	rcx, rax
         movzx	eax, byte ptr [rdi + 6]
         and	eax, 1
-        mov	rdx, qword ptr [rdi + 208]
+        mov	rdx, qword ptr [rdi + 168]
         mov	esi, dword ptr [rdx]
         movzx	r8d, word ptr [rdx + 4]
         add	r8d, esi

--- a/erd_core/codegen/mono/ReleaseSmall/mixed_runtime_read.s
+++ b/erd_core/codegen/mono/ReleaseSmall/mixed_runtime_read.s
@@ -12,18 +12,18 @@ mixed_runtime_read:
         movzx	edx, byte ptr [rcx + .L__anon_0]
         movzx	ecx, word ptr [rcx + rcx + .L__anon_1]
         cmp	edx, 2
-        je	.L2
+        je	.L0
         cmp	edx, 1
-        jne	.L3
+        jne	.L1
         mov	rdi, rax
-        jmp	qword ptr [8*rcx + .L__anon_4]
-.L2:
+        jmp	qword ptr [8*rcx + .L__anon_2]
+.L0:
         mov	rsi, qword ptr [rdi + 168]
         mov	rdi, rax
-        jmp	qword ptr [8*rcx + .L__anon_5]
-.L3:
-        add	rdi, qword ptr [8*rcx + .L__anon_6]
-        movzx	edx, word ptr [rcx + rcx + .L__anon_7]
+        jmp	qword ptr [8*rcx + .L__anon_3]
+.L1:
+        add	rdi, qword ptr [8*rcx + .L__anon_4]
+        movzx	edx, word ptr [rcx + rcx + .L__anon_5]
         mov	rsi, rdi
         mov	rdi, rax
         jmp	memcpy@PLT

--- a/erd_core/codegen/mono/ReleaseSmall/mixed_runtime_read.s
+++ b/erd_core/codegen/mono/ReleaseSmall/mixed_runtime_read.s
@@ -7,30 +7,24 @@ mixed_runtime_read:
 ; --- called functions ---
 
 ".Lsystem_data.SystemData(codegen_mono_stress.MixedDefs,meta.FieldEnum(codegen_mono_stress.MixedDefs),.{ .ram_a = .{ ... }, .ram_b = .{ ... }, .ram_c = .{ ... }, .ram_d = .{ ... }, .ind_x = .{ ... }, .ind_y = .{ ... }, .conv_sum = .{ ... }, .conv_flag = .{ ... }, .conv_wide = .{ ... }, .ram_pair = .{ ... } },codegen_mono_stress.MixedComponents).runtimeRead":
-        mov	rax, rdi
+        mov	rax, rdx
         movzx	ecx, si
-        movzx	esi, byte ptr [rcx + .L__anon_0]
+        movzx	edx, byte ptr [rcx + .L__anon_0]
         movzx	ecx, word ptr [rcx + rcx + .L__anon_1]
-        test	esi, esi
+        cmp	edx, 2
         je	.L2
-        cmp	esi, 1
-        je	.L3
-        cmp	esi, 2
-        jne	.L4
-        mov	rcx, qword ptr [rax + 8*rcx + 120]
-        mov	rsi, qword ptr [rax + 208]
-        mov	rdi, rdx
-        jmp	rcx
-.L3:
-        mov	rdi, rdx
-        jmp	qword ptr [rax + 8*rcx + 104]
+        cmp	edx, 1
+        jne	.L3
+        mov	rdi, rax
+        jmp	qword ptr [8*rcx + .L__anon_4]
 .L2:
-        add	rax, qword ptr [8*rcx + .L__anon_5]
-        movzx	ecx, word ptr [rcx + rcx + .L__anon_6]
-        mov	rdi, rdx
-        mov	rsi, rax
-        mov	rdx, rcx
+        mov	rsi, qword ptr [rdi + 168]
+        mov	rdi, rax
+        jmp	qword ptr [8*rcx + .L__anon_5]
+.L3:
+        add	rdi, qword ptr [8*rcx + .L__anon_6]
+        movzx	edx, word ptr [rcx + rcx + .L__anon_7]
+        mov	rsi, rdi
+        mov	rdi, rax
         jmp	memcpy@PLT
-.L4:
-        ret
 

--- a/erd_core/codegen/mono/ReleaseSmall/mixed_runtime_write.s
+++ b/erd_core/codegen/mono/ReleaseSmall/mixed_runtime_write.s
@@ -15,14 +15,12 @@ mixed_runtime_write:
         push	r12
         push	rbx
         push	rax
-        movzx	eax, si
-        cmp	byte ptr [rax + .L__anon_0], 0
-        jne	.L1
         mov	rbx, rdx
         mov	r14, rdi
-        movzx	r15d, word ptr [rax + rax + .L__anon_2]
-        movzx	r12d, word ptr [r15 + r15 + .L__anon_3]
-        mov	r13, qword ptr [8*r15 + .L__anon_4]
+        movzx	eax, si
+        movzx	r15d, word ptr [rax + rax + .L__anon_0]
+        movzx	r12d, word ptr [r15 + r15 + .L__anon_1]
+        mov	r13, qword ptr [8*r15 + .L__anon_2]
         add	r13, rdi
         mov	rdi, rdx
         mov	rsi, r13
@@ -34,9 +32,9 @@ mixed_runtime_write:
         mov	rdx, r12
         call	memcpy@PLT
         test	bpl, 1
-        jne	.L1
-        cmp	byte ptr [r15 + .L__anon_5], 0
-        je	.L1
+        jne	.L3
+        cmp	byte ptr [r15 + .L__anon_4], 0
+        je	.L3
         mov	rdi, r14
         mov	esi, r15d
         mov	rdx, rbx
@@ -48,8 +46,8 @@ mixed_runtime_write:
         pop	r14
         pop	r15
         pop	rbp
-        jmp	".Lram_data_component.RamDataComponent(@as([*]const Erd, @ptrCast(&codegen_mono_stress.mixed_ram_defs))[0..5]).publish"
-.L1:
+        jmp	".Lram_data_component.RamDataComponent(@as([*]const Erd, @ptrCast(&codegen_mono_stress.mixed_ram_erds))[0..5]).publish"
+.L3:
         add	rsp, 8
         pop	rbx
         pop	r12

--- a/erd_core/codegen/mono/ReleaseSmall/mixed_runtime_write.s
+++ b/erd_core/codegen/mono/ReleaseSmall/mixed_runtime_write.s
@@ -32,9 +32,9 @@ mixed_runtime_write:
         mov	rdx, r12
         call	memcpy@PLT
         test	bpl, 1
-        jne	.L3
-        cmp	byte ptr [r15 + .L__anon_4], 0
-        je	.L3
+        jne	.L0
+        cmp	byte ptr [r15 + .L__anon_3], 0
+        je	.L0
         mov	rdi, r14
         mov	esi, r15d
         mov	rdx, rbx
@@ -47,7 +47,7 @@ mixed_runtime_write:
         pop	r15
         pop	rbp
         jmp	".Lram_data_component.RamDataComponent(@as([*]const Erd, @ptrCast(&codegen_mono_stress.mixed_ram_erds))[0..5]).publish"
-.L3:
+.L0:
         add	rsp, 8
         pop	rbx
         pop	r12

--- a/erd_core/codegen/mono/ReleaseSmall/mixed_subscribe_conv.s
+++ b/erd_core/codegen/mono/ReleaseSmall/mixed_subscribe_conv.s
@@ -2,12 +2,12 @@
 ; Speed: Optimal | Size: Optimal (until 3 calls)
 ;
 mixed_subscribe_conv:
-        add	rdi, 144
-        jmp	".Ldata_component_subscription.DataComponentSubscription(@as([*]const Erd, @ptrCast(&codegen_mono_stress.mixed_conv_defs))[0..3]).subscribeInner"
+        add	rdi, 104
+        jmp	".Ldata_component_subscription.DataComponentSubscription(@as([*]const Erd, @ptrCast(&codegen_mono_stress.mixed_conv_erds))[0..3]).subscribeInner"
 
 ; --- called functions ---
 
-".Ldata_component_subscription.DataComponentSubscription(@as([*]const Erd, @ptrCast(&codegen_mono_stress.mixed_conv_defs))[0..3]).subscribeInner":
+".Ldata_component_subscription.DataComponentSubscription(@as([*]const Erd, @ptrCast(&codegen_mono_stress.mixed_conv_erds))[0..3]).subscribeInner":
         mov	esi, 2
         jmp	.LSubscription.subscribe
 

--- a/erd_core/codegen/mono/ReleaseSmall/mixed_subscribe_ram.s
+++ b/erd_core/codegen/mono/ReleaseSmall/mixed_subscribe_ram.s
@@ -3,11 +3,11 @@
 ;
 mixed_subscribe_ram:
         add	rdi, 24
-        jmp	".Ldata_component_subscription.DataComponentSubscription(@as([*]const Erd, @ptrCast(&codegen_mono_stress.mixed_conv_defs))[0..3]).subscribeInner"
+        jmp	".Ldata_component_subscription.DataComponentSubscription(@as([*]const Erd, @ptrCast(&codegen_mono_stress.mixed_conv_erds))[0..3]).subscribeInner"
 
 ; --- called functions ---
 
-".Ldata_component_subscription.DataComponentSubscription(@as([*]const Erd, @ptrCast(&codegen_mono_stress.mixed_conv_defs))[0..3]).subscribeInner":
+".Ldata_component_subscription.DataComponentSubscription(@as([*]const Erd, @ptrCast(&codegen_mono_stress.mixed_conv_erds))[0..3]).subscribeInner":
         mov	esi, 2
         jmp	.LSubscription.subscribe
 

--- a/erd_core/codegen/mono/ReleaseSmall/mixed_unsubscribe_conv.s
+++ b/erd_core/codegen/mono/ReleaseSmall/mixed_unsubscribe_conv.s
@@ -2,12 +2,12 @@
 ; Speed: Optimal | Size: Optimal (until 3 calls)
 ;
 mixed_unsubscribe_conv:
-        add	rdi, 144
-        jmp	".Ldata_component_subscription.DataComponentSubscription(@as([*]const Erd, @ptrCast(&codegen_mono_stress.mixed_conv_defs))[0..3]).unsubscribeInner"
+        add	rdi, 104
+        jmp	".Ldata_component_subscription.DataComponentSubscription(@as([*]const Erd, @ptrCast(&codegen_mono_stress.mixed_conv_erds))[0..3]).unsubscribeInner"
 
 ; --- called functions ---
 
-".Ldata_component_subscription.DataComponentSubscription(@as([*]const Erd, @ptrCast(&codegen_mono_stress.mixed_conv_defs))[0..3]).unsubscribeInner":
+".Ldata_component_subscription.DataComponentSubscription(@as([*]const Erd, @ptrCast(&codegen_mono_stress.mixed_conv_erds))[0..3]).unsubscribeInner":
         mov	esi, 2
         jmp	.LSubscription.unsubscribe
 

--- a/erd_core/codegen/mono/ReleaseSmall/mixed_unsubscribe_ram.s
+++ b/erd_core/codegen/mono/ReleaseSmall/mixed_unsubscribe_ram.s
@@ -3,11 +3,11 @@
 ;
 mixed_unsubscribe_ram:
         add	rdi, 24
-        jmp	".Ldata_component_subscription.DataComponentSubscription(@as([*]const Erd, @ptrCast(&codegen_mono_stress.mixed_conv_defs))[0..3]).unsubscribeInner"
+        jmp	".Ldata_component_subscription.DataComponentSubscription(@as([*]const Erd, @ptrCast(&codegen_mono_stress.mixed_conv_erds))[0..3]).unsubscribeInner"
 
 ; --- called functions ---
 
-".Ldata_component_subscription.DataComponentSubscription(@as([*]const Erd, @ptrCast(&codegen_mono_stress.mixed_conv_defs))[0..3]).unsubscribeInner":
+".Ldata_component_subscription.DataComponentSubscription(@as([*]const Erd, @ptrCast(&codegen_mono_stress.mixed_conv_erds))[0..3]).unsubscribeInner":
         mov	esi, 2
         jmp	.LSubscription.unsubscribe
 

--- a/erd_core/codegen/mono/ReleaseSmall/mixed_write_ram.s
+++ b/erd_core/codegen/mono/ReleaseSmall/mixed_write_ram.s
@@ -20,7 +20,7 @@ mixed_write_ram:
         mov	rdi, rbx
         xor	esi, esi
         mov	rcx, rbx
-        call	".Lram_data_component.RamDataComponent(@as([*]const Erd, @ptrCast(&codegen_mono_stress.mixed_ram_defs))[0..5]).publish"
+        call	".Lram_data_component.RamDataComponent(@as([*]const Erd, @ptrCast(&codegen_mono_stress.mixed_ram_erds))[0..5]).publish"
 .L0:
         mov	word ptr [rsp + 2], r15w
         cmp	word ptr [rbx + 4], r15w
@@ -31,7 +31,7 @@ mixed_write_ram:
         lea	rdx, [rsp + 2]
         mov	rdi, rbx
         mov	rcx, rbx
-        call	".Lram_data_component.RamDataComponent(@as([*]const Erd, @ptrCast(&codegen_mono_stress.mixed_ram_defs))[0..5]).publish"
+        call	".Lram_data_component.RamDataComponent(@as([*]const Erd, @ptrCast(&codegen_mono_stress.mixed_ram_erds))[0..5]).publish"
 .L1:
         and	bpl, 1
         mov	byte ptr [rbx + 6], bpl
@@ -44,7 +44,7 @@ mixed_write_ram:
         lea	rdx, [rsp + 8]
         mov	rdi, rbx
         mov	rcx, rbx
-        call	".Lram_data_component.RamDataComponent(@as([*]const Erd, @ptrCast(&codegen_mono_stress.mixed_ram_defs))[0..5]).publish"
+        call	".Lram_data_component.RamDataComponent(@as([*]const Erd, @ptrCast(&codegen_mono_stress.mixed_ram_erds))[0..5]).publish"
 .L2:
         add	rsp, 24
         pop	rbx
@@ -55,7 +55,7 @@ mixed_write_ram:
 
 ; --- called functions ---
 
-".Lram_data_component.RamDataComponent(@as([*]const Erd, @ptrCast(&codegen_mono_stress.mixed_ram_defs))[0..5]).publish":
+".Lram_data_component.RamDataComponent(@as([*]const Erd, @ptrCast(&codegen_mono_stress.mixed_ram_erds))[0..5]).publish":
         mov	r8, rcx
         mov	rcx, rdx
         movzx	eax, si

--- a/erd_core/codegen/mono/ReleaseSmall/mixed_write_ram.s
+++ b/erd_core/codegen/mono/ReleaseSmall/mixed_write_ram.s
@@ -59,11 +59,11 @@ mixed_write_ram:
         mov	r8, rcx
         mov	rcx, rdx
         movzx	eax, si
-        mov	rdx, qword ptr [8*rax + .L__anon_3]
-        movzx	esi, byte ptr [rax + .L__anon_4]
+        mov	rdx, qword ptr [8*rax + .L__anon_0]
+        movzx	esi, byte ptr [rax + .L__anon_1]
         shl	rdx, 4
         add	rdi, rdx
         add	rdi, 24
-        movzx	edx, word ptr [rax + rax + .L__anon_5]
+        movzx	edx, word ptr [rax + rax + .L__anon_2]
         jmp	.LSubscription.publish
 

--- a/erd_core/codegen/mono/ReleaseSmall/tiny_runtime_write.s
+++ b/erd_core/codegen/mono/ReleaseSmall/tiny_runtime_write.s
@@ -32,7 +32,7 @@ tiny_runtime_write:
         mov	rdx, r12
         call	memcpy@PLT
         test	bpl, 1
-        je	.L4
+        je	.L0
         add	rsp, 8
         pop	rbx
         pop	r12
@@ -41,7 +41,7 @@ tiny_runtime_write:
         pop	r15
         pop	rbp
         ret
-.L4:
+.L0:
         mov	rdi, r14
         mov	esi, r15d
         mov	rdx, rbx

--- a/erd_core/codegen/mono/ReleaseSmall/tiny_write_all.s
+++ b/erd_core/codegen/mono/ReleaseSmall/tiny_write_all.s
@@ -41,11 +41,11 @@ tiny_write_all:
         mov	r8, rcx
         mov	rcx, rdx
         movzx	eax, si
-        mov	rdx, qword ptr [8*rax + .L__anon_2]
+        mov	rdx, qword ptr [8*rax + .L__anon_0]
         shl	rdx, 4
         add	rdi, rdx
         add	rdi, 16
-        movzx	edx, word ptr [rax + rax + .L__anon_3]
+        movzx	edx, word ptr [rax + rax + .L__anon_1]
         mov	esi, 1
         jmp	.LSubscription.publish
 

--- a/erd_core/codegen/mono/ReleaseSmall/wide_runtime_write.s
+++ b/erd_core/codegen/mono/ReleaseSmall/wide_runtime_write.s
@@ -32,9 +32,9 @@ wide_runtime_write:
         mov	rdx, r12
         call	memcpy@PLT
         test	bpl, 1
-        jne	.L4
-        cmp	byte ptr [r15 + .L__anon_5], 0
-        je	.L4
+        jne	.L0
+        cmp	byte ptr [r15 + .L__anon_4], 0
+        je	.L0
         mov	rdi, r14
         mov	esi, r15d
         mov	rdx, rbx
@@ -47,7 +47,7 @@ wide_runtime_write:
         pop	r15
         pop	rbp
         jmp	".Lram_data_component.RamDataComponent(&.{ .{ ... }, .{ ... }, .{ ... }, .{ ... }, .{ ... }, .{ ... }, .{ ... }, .{ ... }, .{ ... }, .{ ... }, .{ ... }, .{ ... }, .{ ... }, .{ ... }, .{ ... }, .{ ... }, .{ ... } }[0..17]).publish"
-.L4:
+.L0:
         add	rsp, 8
         pop	rbx
         pop	r12

--- a/erd_core/codegen/mono/ReleaseSmall/wide_runtime_write_all.s
+++ b/erd_core/codegen/mono/ReleaseSmall/wide_runtime_write_all.s
@@ -21,7 +21,7 @@ wide_runtime_write_all:
         mov	rdi, r14
         mov	esi, ebp
         mov	rdx, rbx
-        call	".Lsystem_data.SystemData(codegen_mono_stress.WideSystem__struct_2,meta.FieldEnum(codegen_mono_stress.WideSystem__struct_2),.{ .w00 = .{ ... }, .w01 = .{ ... }, .w02 = .{ ... }, .w03 = .{ ... }, .w04 = .{ ... }, .w05 = .{ ... }, .w06 = .{ ... }, .w07 = .{ ... }, .w08 = .{ ... }, .w09 = .{ ... }, .w10 = .{ ... }, .w11 = .{ ... }, .w12 = .{ ... }, .w13 = .{ ... }, .w14 = .{ ... }, .w15 = .{ ... }, .w_pair = .{ ... } },system_data_test_double.create.Components).runtimeWrite"
+        call	".Lsystem_data.SystemData(codegen_mono_stress.WideSystem__struct_0,meta.FieldEnum(codegen_mono_stress.WideSystem__struct_0),.{ .w00 = .{ ... }, .w01 = .{ ... }, .w02 = .{ ... }, .w03 = .{ ... }, .w04 = .{ ... }, .w05 = .{ ... }, .w06 = .{ ... }, .w07 = .{ ... }, .w08 = .{ ... }, .w09 = .{ ... }, .w10 = .{ ... }, .w11 = .{ ... }, .w12 = .{ ... }, .w13 = .{ ... }, .w14 = .{ ... }, .w15 = .{ ... }, .w_pair = .{ ... } },system_data_test_double.create.Components).runtimeWrite"
         inc	ebp
         jmp	.L0
 .L1:
@@ -32,7 +32,7 @@ wide_runtime_write_all:
 
 ; --- called functions ---
 
-".Lsystem_data.SystemData(codegen_mono_stress.WideSystem__struct_2,meta.FieldEnum(codegen_mono_stress.WideSystem__struct_2),.{ .w00 = .{ ... }, .w01 = .{ ... }, .w02 = .{ ... }, .w03 = .{ ... }, .w04 = .{ ... }, .w05 = .{ ... }, .w06 = .{ ... }, .w07 = .{ ... }, .w08 = .{ ... }, .w09 = .{ ... }, .w10 = .{ ... }, .w11 = .{ ... }, .w12 = .{ ... }, .w13 = .{ ... }, .w14 = .{ ... }, .w15 = .{ ... }, .w_pair = .{ ... } },system_data_test_double.create.Components).runtimeWrite":
+".Lsystem_data.SystemData(codegen_mono_stress.WideSystem__struct_0,meta.FieldEnum(codegen_mono_stress.WideSystem__struct_0),.{ .w00 = .{ ... }, .w01 = .{ ... }, .w02 = .{ ... }, .w03 = .{ ... }, .w04 = .{ ... }, .w05 = .{ ... }, .w06 = .{ ... }, .w07 = .{ ... }, .w08 = .{ ... }, .w09 = .{ ... }, .w10 = .{ ... }, .w11 = .{ ... }, .w12 = .{ ... }, .w13 = .{ ... }, .w14 = .{ ... }, .w15 = .{ ... }, .w_pair = .{ ... } },system_data_test_double.create.Components).runtimeWrite":
         push	rbp
         push	r15
         push	r14
@@ -43,9 +43,9 @@ wide_runtime_write_all:
         mov	rbx, rdx
         mov	r14, rdi
         movzx	eax, si
-        movzx	r15d, word ptr [rax + rax + .L__anon_3]
-        movzx	r12d, word ptr [r15 + r15 + .L__anon_4]
-        mov	r13, qword ptr [8*r15 + .L__anon_5]
+        movzx	r15d, word ptr [rax + rax + .L__anon_1]
+        movzx	r12d, word ptr [r15 + r15 + .L__anon_2]
+        mov	r13, qword ptr [8*r15 + .L__anon_3]
         add	r13, rdi
         mov	rdi, rdx
         mov	rsi, r13
@@ -57,9 +57,9 @@ wide_runtime_write_all:
         mov	rdx, r12
         call	memcpy@PLT
         test	bpl, 1
-        jne	.L6
-        cmp	byte ptr [r15 + .L__anon_7], 0
-        je	.L6
+        jne	.L2
+        cmp	byte ptr [r15 + .L__anon_4], 0
+        je	.L2
         mov	rdi, r14
         mov	esi, r15d
         mov	rdx, rbx
@@ -72,7 +72,7 @@ wide_runtime_write_all:
         pop	r15
         pop	rbp
         jmp	".Lram_data_component.RamDataComponent(&.{ .{ ... }, .{ ... }, .{ ... }, .{ ... }, .{ ... }, .{ ... }, .{ ... }, .{ ... }, .{ ... }, .{ ... }, .{ ... }, .{ ... }, .{ ... }, .{ ... }, .{ ... }, .{ ... }, .{ ... } }[0..17]).publish"
-.L6:
+.L2:
         add	rsp, 8
         pop	rbx
         pop	r12

--- a/erd_core/codegen/mono/ReleaseSmall/wide_write_all.s
+++ b/erd_core/codegen/mono/ReleaseSmall/wide_write_all.s
@@ -131,11 +131,11 @@ wide_write_all:
         mov	r8, rcx
         mov	rcx, rdx
         movzx	eax, si
-        mov	rdx, qword ptr [8*rax + .L__anon_8]
-        movzx	esi, byte ptr [rax + .L__anon_9]
+        mov	rdx, qword ptr [8*rax + .L__anon_0]
+        movzx	esi, byte ptr [rax + .L__anon_1]
         shl	rdx, 4
         add	rdi, rdx
         add	rdi, 64
-        movzx	edx, word ptr [rax + rax + .L__anon_10]
+        movzx	edx, word ptr [rax + rax + .L__anon_2]
         jmp	.LSubscription.publish
 

--- a/erd_core/codegen/mono/ReleaseSmall_x86_64.sizes
+++ b/erd_core/codegen/mono/ReleaseSmall_x86_64.sizes
@@ -5,14 +5,14 @@
 2	tiny_runtime_write
 2	wide_runtime_read
 5	wide_runtime_write
+6	mixed_subscribe_conv
+6	mixed_unsubscribe_conv
 6	mixed_unsubscribe_ram
 6	tiny_subscribe
 6	tiny_unsubscribe
 6	wide_subscribe
 6	wide_unsubscribe
-9	mixed_subscribe_conv
 9	mixed_subscribe_ram
-9	mixed_unsubscribe_conv
 10	tiny_read_all
 15	mixed_modify
 15	tiny_modify

--- a/erd_core/src/Erd.zig
+++ b/erd_core/src/Erd.zig
@@ -1,6 +1,10 @@
-//! This ERD struct is meant for use at the data component level, and for the end user to use
-//! when making calls to SystemData or any general data component
-//! This is a generated type, the top level initialization should be done from within system_data.zig
+//! ERD struct used at the data component level and by end users when calling
+//! SystemData / data component APIs.
+//!
+//! Applications declare each ERD with its `erd_number`, `T`, `component_idx`,
+//! and `subs`. The remaining bookkeeping fields (`data_component_idx`,
+//! `system_data_idx`) are filled in by `erd_core.erd_table.autofill` so
+//! application code does not have to count or repeat itself.
 
 const std = @import("std");
 const Erd = @This();
@@ -14,22 +18,51 @@ T: type,
 component_idx: comptime_int,
 /// The number of subscription slots that are available
 subs: comptime_int,
-/// The relative index of the ERD in its data component
+/// Auto-filled by `erd_table.autofill`: zero-based index of this ERD within
+/// its owning data component (so RAM ERDs get 0, 1, 2, ... and Indirect ERDs
+/// independently get 0, 1, ...). Used by RAM/Indirect/Converted dispatch
+/// tables. Leave as `undefined` in your ErdDefinitions; autofill rewrites it.
 data_component_idx: comptime_int = undefined,
-/// The relative index of the ERD in the aggregate system data.
-/// This field is sufficient for runtime ERD read/write/subscriptions.
-/// Performance is negatively affected due to constant-time lookups of `component_idx` and `data_component_idx`
-/// however this allows for enforcing a small code footprint
+/// Auto-filled by `erd_table.autofill`: zero-based index of this ERD across
+/// the entire ErdDefinitions struct in field order. Sufficient on its own
+/// for `SystemData.runtimeRead`/`runtimeWrite`/runtime subscriptions; the
+/// runtime path uses it to recover both `component_idx` and
+/// `data_component_idx` via constant-time lookup tables (slower than the
+/// comptime path, but keeps the code footprint small).
 system_data_idx: u16 = undefined,
 
 /// ERD identifier, allows for ERDs to be referenced externally
 pub const ErdHandle = u16; // TODO: Evaluate if this should be an non-exhaustive enum `ErdHandle = enum { _ };`
 
-/// Allows ERDs to be printed as `0xXXXX`
+/// Allows ERDs to be printed as `0xXXXX`. Panics if the ERD has no `erd_number`.
 pub fn format(self: *const Erd, writer: *std.Io.Writer) std.Io.Writer.Error!void {
-    if (self.erd_number) |number| {
-        return try writer.print("0x{x:0>4}", .{number});
-    } else {
-        @panic("Can't format erds with null number");
-    }
+    const number = self.erd_number orelse @panic("Can't format erds with null number");
+    try writer.print("0x{x:0>4}", .{number});
+}
+
+test "format prints erd_number as zero-padded 4-digit hex" {
+    var buf: [16]u8 = undefined;
+    var w: std.Io.Writer = .fixed(&buf);
+
+    const erd: Erd = .{ .erd_number = 0x002A, .T = u8, .component_idx = 0, .subs = 0 };
+    try erd.format(&w);
+    try std.testing.expectEqualStrings("0x002a", w.buffered());
+}
+
+test "format zero-pads single-digit erd_number" {
+    var buf: [16]u8 = undefined;
+    var w: std.Io.Writer = .fixed(&buf);
+
+    const erd: Erd = .{ .erd_number = 0x0001, .T = u8, .component_idx = 0, .subs = 0 };
+    try erd.format(&w);
+    try std.testing.expectEqualStrings("0x0001", w.buffered());
+}
+
+test "format handles erd_number at the u16 max" {
+    var buf: [16]u8 = undefined;
+    var w: std.Io.Writer = .fixed(&buf);
+
+    const erd: Erd = .{ .erd_number = 0xFFFF, .T = u8, .component_idx = 0, .subs = 0 };
+    try erd.format(&w);
+    try std.testing.expectEqualStrings("0xffff", w.buffered());
 }

--- a/erd_core/src/Subscription.zig
+++ b/erd_core/src/Subscription.zig
@@ -25,20 +25,25 @@ callback: ?Callback,
 const Self = @This();
 
 /// Dispatch on-change callbacks to a contiguous subscription slot range.
+/// Iterates `slots` in index order and invokes every non-null callback.
+/// All callbacks see the same `OnChangeArgs` pointer (built once before
+/// the loop); the args live only for the duration of `publish`, so
+/// callbacks must not retain it. Empty slots are skipped.
 /// Shared across all DataComponent instantiations to avoid monomorphization.
 pub noinline fn publish(slots: []Self, system_data_idx: u16, data: *const anyopaque, publisher: *anyopaque) void {
-    for (slots) |sub| {
-        if (sub.callback) |cb| {
-            const args: OnChangeArgs = .{
-                .system_data_idx = system_data_idx,
-                .data = data,
-            };
-            cb(sub.context, @ptrCast(&args), publisher);
-        }
+    const args: OnChangeArgs = .{
+        .system_data_idx = system_data_idx,
+        .data = data,
+    };
+    for (slots) |*sub| {
+        const cb = sub.callback orelse continue;
+        cb(sub.context, @ptrCast(&args), publisher);
     }
 }
 
-/// Add a subscription callback. Deduplicates by callback identity.
+/// Add a subscription callback. Deduplicates by callback identity (a
+/// second subscribe with the same `callback` keeps the original `context`
+/// and does NOT consume another slot). Panics if `slots` is full.
 /// Shared across all DataComponentSubscription instantiations to avoid monomorphization.
 pub noinline fn subscribe(slots: []Self, context: ?*anyopaque, callback: Callback) void {
     var first_free: ?*Self = null;
@@ -52,15 +57,12 @@ pub noinline fn subscribe(slots: []Self, context: ?*anyopaque, callback: Callbac
         }
     }
 
-    if (first_free == null) {
-        @panic("ERD oversubscribed!");
-    }
-
-    first_free.?.context = context;
-    first_free.?.callback = callback;
+    const slot = first_free orelse @panic("ERD oversubscribed!");
+    slot.* = .{ .context = context, .callback = callback };
 }
 
-/// Remove a subscription callback by identity.
+/// Remove a subscription callback by identity. No-op if the callback isn't
+/// present in `slots` (and no-op when `slots` is empty).
 /// Shared across all DataComponentSubscription instantiations to avoid monomorphization.
 pub noinline fn unsubscribe(slots: []Self, callback: Callback) void {
     for (slots) |*sub| {
@@ -97,6 +99,12 @@ fn cbB(_: ?*anyopaque, _: ?*const anyopaque, _: *anyopaque) void {
 }
 fn cbC(_: ?*anyopaque, _: ?*const anyopaque, _: *anyopaque) void {
     cb_c_calls += 1;
+}
+
+fn resetCallCounts() void {
+    cb_a_calls = 0;
+    cb_b_calls = 0;
+    cb_c_calls = 0;
 }
 
 const empty: Self = .{ .context = null, .callback = null };
@@ -220,9 +228,7 @@ test "publish passes system_data_idx, data, publisher, and context to callback" 
 }
 
 test "publish tolerates a hole created by unsubscribe" {
-    cb_a_calls = 0;
-    cb_b_calls = 0;
-    cb_c_calls = 0;
+    resetCallCounts();
     var slots = [_]Self{empty} ** 3;
 
     subscribe(&slots, null, cbA);
@@ -256,4 +262,23 @@ test "subscribe then unsubscribe then subscribe reuses slot" {
 
     try expectEqual(cbB, slots[0].callback);
     try expectEqual(null, slots[1].callback);
+}
+
+test "unsubscribe on empty slot slice is a no-op" {
+    var slots = [_]Self{};
+    unsubscribe(&slots, cbA);
+    // No assertion needed: must simply not panic / OOB.
+}
+
+test "publish on all-empty slot slice invokes no callbacks" {
+    resetCallCounts();
+    var slots = [_]Self{empty} ** 3;
+    var publisher: u8 = 0;
+    var payload: u8 = 0;
+
+    publish(&slots, 0, &payload, &publisher);
+
+    try expectEqual(0, cb_a_calls);
+    try expectEqual(0, cb_b_calls);
+    try expectEqual(0, cb_c_calls);
 }

--- a/erd_core/src/codegen_harness.zig
+++ b/erd_core/src/codegen_harness.zig
@@ -322,7 +322,7 @@ export fn read_across_two_erds(sd: *SmallSD) u32 {
 
 fn accumulate_callback(_: ?*anyopaque, _args: ?*const anyopaque, publisher: *anyopaque) void {
     const args: *const SmallSD.OnChangeArgs = @ptrCast(@alignCast(_args.?));
-    var sd: *SmallSD = @ptrCast(@alignCast(publisher));
+    const sd: *SmallSD = @ptrCast(@alignCast(publisher));
     const written_val: *const bool = @ptrCast(args.data);
     if (written_val.*) {
         sd.write(.version, sd.read(.version) +% 1);
@@ -461,31 +461,12 @@ const MultiErdDefs = struct {
     // zig fmt: on
 };
 
-const multi_erd = blk: {
-    var erds = MultiErdDefs{};
-    var component_counts = [_]u16{ 0, 0, 0 };
-    for (std.meta.fieldNames(MultiErdDefs), 0..) |name, i| {
-        const idx = @field(erds, name).component_idx;
-        @field(erds, name).data_component_idx = component_counts[idx];
-        @field(erds, name).system_data_idx = i;
-        component_counts[idx] += 1;
-    }
-    break :blk erds;
-};
-
+const multi_erd = erd_core.erd_table.autofill(MultiErdDefs);
 const MultiErdEnum = std.meta.FieldEnum(MultiErdDefs);
 
-fn ramErds() [3]Erd {
-    return .{ multi_erd.ram_counter, multi_erd.ram_flag, multi_erd.ram_value };
-}
-
-fn indirectErds() [2]Erd {
-    return .{ multi_erd.ind_constant, multi_erd.ind_computed };
-}
-
-fn convertedErds() [2]Erd {
-    return .{ multi_erd.conv_sum, multi_erd.conv_flag_inv };
-}
+const multi_ram_erds = erd_core.erd_table.collectByComponent(multi_erd, Ram);
+const multi_indirect_erds = erd_core.erd_table.collectByComponent(multi_erd, Indirect);
+const multi_converted_erds = erd_core.erd_table.collectByComponent(multi_erd, Converted);
 
 fn indConstant(data: *u32) void {
     data.* = 0xCAFE;
@@ -515,13 +496,9 @@ const multi_converted_mappings = [_]ConvertedMapping{
     .map(multi_erd.conv_flag_inv, computeFlagInv, &.{multi_erd.ram_flag}),
 };
 
-const ram_defs = ramErds();
-const indirect_defs = indirectErds();
-const converted_defs = convertedErds();
-
-const MultiRam = erd_core.data_component.Ram(&ram_defs);
-const MultiIndirect = erd_core.data_component.Indirect(&indirect_defs, multi_indirect_mappings);
-const MultiConverted = erd_core.data_component.Converted(&converted_defs, multi_converted_mappings);
+const MultiRam = erd_core.data_component.Ram(&multi_ram_erds);
+const MultiIndirect = erd_core.data_component.Indirect(&multi_indirect_erds, multi_indirect_mappings);
+const MultiConverted = erd_core.data_component.Converted(&multi_converted_erds, multi_converted_mappings);
 
 const MultiComponents = struct {
     ram: MultiRam,

--- a/erd_core/src/codegen_mono_stress.zig
+++ b/erd_core/src/codegen_mono_stress.zig
@@ -70,31 +70,12 @@ const MixedDefs = struct {
     // zig fmt: on
 };
 
-const mixed_erd = blk: {
-    var erds = MixedDefs{};
-    var component_counts = [_]u16{ 0, 0, 0 };
-    for (std.meta.fieldNames(MixedDefs), 0..) |name, i| {
-        const idx = @field(erds, name).component_idx;
-        @field(erds, name).data_component_idx = component_counts[idx];
-        @field(erds, name).system_data_idx = i;
-        component_counts[idx] += 1;
-    }
-    break :blk erds;
-};
-
+const mixed_erd = erd_core.erd_table.autofill(MixedDefs);
 const MixedEnum = std.meta.FieldEnum(MixedDefs);
 
-fn mixedRamErds() [5]Erd {
-    return .{ mixed_erd.ram_a, mixed_erd.ram_b, mixed_erd.ram_c, mixed_erd.ram_d, mixed_erd.ram_pair };
-}
-
-fn mixedIndErds() [2]Erd {
-    return .{ mixed_erd.ind_x, mixed_erd.ind_y };
-}
-
-fn mixedConvErds() [3]Erd {
-    return .{ mixed_erd.conv_sum, mixed_erd.conv_flag, mixed_erd.conv_wide };
-}
+const mixed_ram_erds = erd_core.erd_table.collectByComponent(mixed_erd, Ram);
+const mixed_ind_erds = erd_core.erd_table.collectByComponent(mixed_erd, Indirect);
+const mixed_conv_erds = erd_core.erd_table.collectByComponent(mixed_erd, Converted);
 
 fn indXFn(data: *u32) void {
     data.* = 0xBEEF;
@@ -130,13 +111,9 @@ const mixed_conv_mappings = [_]ConvertedMapping{
     .map(mixed_erd.conv_wide, convWideFn, &.{ mixed_erd.ram_a, mixed_erd.ram_d }),
 };
 
-const mixed_ram_defs = mixedRamErds();
-const mixed_ind_defs = mixedIndErds();
-const mixed_conv_defs = mixedConvErds();
-
-const MixedRam = erd_core.data_component.Ram(&mixed_ram_defs);
-const MixedInd = erd_core.data_component.Indirect(&mixed_ind_defs, mixed_ind_mappings);
-const MixedConv = erd_core.data_component.Converted(&mixed_conv_defs, mixed_conv_mappings);
+const MixedRam = erd_core.data_component.Ram(&mixed_ram_erds);
+const MixedInd = erd_core.data_component.Indirect(&mixed_ind_erds, mixed_ind_mappings);
+const MixedConv = erd_core.data_component.Converted(&mixed_conv_erds, mixed_conv_mappings);
 
 const MixedComponents = struct {
     ram: MixedRam,

--- a/erd_core/src/common/Stopwatch.zig
+++ b/erd_core/src/common/Stopwatch.zig
@@ -16,12 +16,7 @@ running: bool = false,
 pub fn stop(this: *StopWatch, timer_module: *const TimerModule) void {
     if (this.running) {
         const elapsedTicks = timer_module.safelyGetCurrentTime() -% this.start_tick;
-        if (this.saved_ticks > std.math.maxInt(timer.Ticks) - elapsedTicks) {
-            this.saved_ticks = std.math.maxInt(timer.Ticks);
-        } else {
-            this.saved_ticks += elapsedTicks;
-        }
-
+        this.saved_ticks = this.saved_ticks +| elapsedTicks;
         this.running = false;
     }
 }
@@ -41,14 +36,10 @@ pub fn reset(this: *StopWatch, timer_module: *const TimerModule) void {
 }
 
 /// Reports the elapsed + saved ticks
-pub fn elapsed(this: *StopWatch, timer_module: *const TimerModule) timer.Ticks {
+pub fn elapsed(this: *const StopWatch, timer_module: *const TimerModule) timer.Ticks {
     if (this.running) {
         const elapsed_ticks_this_run = timer_module.safelyGetCurrentTime() -% this.start_tick;
-        if (this.saved_ticks > std.math.maxInt(timer.Ticks) - elapsed_ticks_this_run) {
-            return std.math.maxInt(timer.Ticks);
-        } else {
-            return this.saved_ticks + elapsed_ticks_this_run;
-        }
+        return this.saved_ticks +| elapsed_ticks_this_run;
     } else {
         return this.saved_ticks;
     }

--- a/erd_core/src/common/erd_logic.zig
+++ b/erd_core/src/common/erd_logic.zig
@@ -26,24 +26,40 @@ const ErdLogicOperator = enum {
 pub fn ErdLogic(SystemDataType: type, comptime operator: ErdLogicOperator, comptime erds: []const SystemDataType.ErdEnumType, outputErd: SystemDataType.ErdEnumType) type {
     comptime {
         switch (operator) {
-            ._bitwise_not, ._not => std.debug.assert(erds.len == 1), // Unary operators
-            else => std.debug.assert(erds.len > 1), // Binary operators that reduce
+            ._bitwise_not, ._not => if (erds.len != 1) @compileError(std.fmt.comptimePrint(
+                "ErdLogic.{s}: unary operator requires exactly 1 input ERD, got {}",
+                .{ @tagName(operator), erds.len },
+            )),
+            else => if (erds.len < 2) @compileError(std.fmt.comptimePrint(
+                "ErdLogic.{s}: binary/reducing operator requires at least 2 input ERDs, got {}",
+                .{ @tagName(operator), erds.len },
+            )),
         }
 
         if (erds.len > 1) {
             var window = std.mem.window(SystemDataType.ErdEnumType, erds, 2, 1);
             while (window.next()) |erd_pair| {
-                std.debug.assert(SystemDataType.erdFromEnum(erd_pair[0]).T == SystemDataType.erdFromEnum(erd_pair[1]).T);
+                const T0 = SystemDataType.erdFromEnum(erd_pair[0]).T;
+                const T1 = SystemDataType.erdFromEnum(erd_pair[1]).T;
+                if (T0 != T1) @compileError(std.fmt.comptimePrint(
+                    "ErdLogic.{s}: input ERD {s} has type {s}, but {s} has type {s} (all inputs must share a type)",
+                    .{ @tagName(operator), @tagName(erd_pair[0]), @typeName(T0), @tagName(erd_pair[1]), @typeName(T1) },
+                ));
             }
         }
 
-        std.debug.assert(SystemDataType.erdFromEnum(erds[0]).T == SystemDataType.erdFromEnum(outputErd).T);
+        const InputT = SystemDataType.erdFromEnum(erds[0]).T;
+        const OutputT = SystemDataType.erdFromEnum(outputErd).T;
+        if (InputT != OutputT) @compileError(std.fmt.comptimePrint(
+            "ErdLogic.{s}: input type {s} does not match output {s} type {s}",
+            .{ @tagName(operator), @typeName(InputT), @tagName(outputErd), @typeName(OutputT) },
+        ));
     }
 
     return struct {
         // TODO: Utilize args here to improve the code
         fn onChange(_: ?*anyopaque, _: ?*const anyopaque, publisher: *anyopaque) void {
-            var system_data: *SystemDataType = @ptrCast(@alignCast(publisher));
+            const system_data: *SystemDataType = @ptrCast(@alignCast(publisher));
 
             if (erds.len == 1) {
                 const value = system_data.read(erds[0]);
@@ -57,23 +73,29 @@ pub fn ErdLogic(SystemDataType: type, comptime operator: ErdLogicOperator, compt
             } else if (erds.len > 1) {
                 var value = system_data.read(erds[0]);
 
+                // NOR reduces as OR here and negates once at the end -- naive
+                // left-fold `nor(nor(a, b), c)` is `(a or b) and !c`, NOT the
+                // n-ary NOR `!(a or b or c)`. Same reasoning for `_bitwise_nor`.
                 inline for (erds[1..]) |erd| {
                     const next = system_data.read(erd);
 
                     value = switch (operator) {
                         ._and => value and next,
-                        ._or => value or next,
-                        ._nor => !(value or next),
+                        ._or, ._nor => value or next,
                         ._xor => value != next,
                         ._bitwise_and => value & next,
-                        ._bitwise_or => value | next,
-                        ._bitwise_nor => ~(value | next),
-                        ._bitwise_xor => (~value & next) | (value & ~next),
+                        ._bitwise_or, ._bitwise_nor => value | next,
+                        ._bitwise_xor => value ^ next,
                         else => comptime unreachable,
                     };
                 }
 
-                system_data.write(outputErd, value);
+                const output = switch (operator) {
+                    ._nor => !value,
+                    ._bitwise_nor => ~value,
+                    else => value,
+                };
+                system_data.write(outputErd, output);
             }
         }
 
@@ -134,4 +156,127 @@ test "unary operators work" {
     try std.testing.expectEqual(0b1110_0000_1000_0000, system_data.read(.output));
 }
 
-// TODO: Finish the rest of the tests when there's a way to create testing (locally scoped) ERDs
+test "_bitwise_or combines bits from both inputs" {
+    var system_data: SystemData = TestSystem.init();
+
+    const input_erds = &[_]ErdEnum{ .input_a, .input_b };
+    ErdLogic(SystemData, ._bitwise_or, input_erds, .output).init(&system_data);
+
+    system_data.write(.input_a, 0b0101_0101);
+    system_data.write(.input_b, 0b1010_1010);
+    try std.testing.expectEqual(0b1111_1111, system_data.read(.output));
+
+    system_data.write(.input_a, 0xF0F0);
+    system_data.write(.input_b, 0x0F0F);
+    try std.testing.expectEqual(0xFFFF, system_data.read(.output));
+}
+
+test "_bitwise_xor toggles differing bits" {
+    var system_data: SystemData = TestSystem.init();
+
+    const input_erds = &[_]ErdEnum{ .input_a, .input_b };
+    ErdLogic(SystemData, ._bitwise_xor, input_erds, .output).init(&system_data);
+
+    system_data.write(.input_a, 0b1100_1100);
+    system_data.write(.input_b, 0b1010_1010);
+    try std.testing.expectEqual(0b0110_0110, system_data.read(.output));
+
+    system_data.write(.input_a, 0xABCD);
+    system_data.write(.input_b, 0xABCD);
+    try std.testing.expectEqual(0, system_data.read(.output));
+}
+
+test "_bitwise_nor inverts the or of inputs" {
+    var system_data: SystemData = TestSystem.init();
+
+    const input_erds = &[_]ErdEnum{ .input_a, .input_b };
+    ErdLogic(SystemData, ._bitwise_nor, input_erds, .output).init(&system_data);
+
+    system_data.write(.input_a, 0);
+    system_data.write(.input_b, 0);
+    try std.testing.expectEqual(0xFFFF, system_data.read(.output));
+
+    system_data.write(.input_a, 0xFFFF);
+    system_data.write(.input_b, 0);
+    try std.testing.expectEqual(0, system_data.read(.output));
+}
+
+const TestSystem3 = SystemDataTestDouble.create(struct {
+    input_a: Erd = SystemDataTestDouble.ramErd(u16, .{ .subs = 1 }),
+    input_b: Erd = SystemDataTestDouble.ramErd(u16, .{ .subs = 1 }),
+    input_c: Erd = SystemDataTestDouble.ramErd(u16, .{ .subs = 1 }),
+    output: Erd = SystemDataTestDouble.ramErd(u16, .{}),
+});
+const SystemData3 = TestSystem3.SystemData;
+const ErdEnum3 = SystemData3.ErdEnumType;
+
+test "_bitwise_nor is n-ary, not naive left-fold" {
+    // Naive left-fold of `_bitwise_nor` over 3 inputs would yield
+    // `nor(nor(a, b), c)` = `(a | b) & ~c`, which is NOT the n-ary NOR.
+    // The correct semantics is `~(a | b | c)`. This test locks that in.
+    var system_data: SystemData3 = TestSystem3.init();
+    const inputs = &[_]ErdEnum3{ .input_a, .input_b, .input_c };
+    ErdLogic(SystemData3, ._bitwise_nor, inputs, .output).init(&system_data);
+
+    system_data.write(.input_a, 0x00F0);
+    system_data.write(.input_b, 0x0F00);
+    system_data.write(.input_c, 0xF000);
+    // ~(0x00F0 | 0x0F00 | 0xF000) = ~0xFFF0 = 0x000F
+    try std.testing.expectEqual(0x000F, system_data.read(.output));
+}
+
+const BoolTestSystem = SystemDataTestDouble.create(struct {
+    input_a: Erd = SystemDataTestDouble.ramErd(bool, .{ .subs = 1 }),
+    input_b: Erd = SystemDataTestDouble.ramErd(bool, .{ .subs = 1 }),
+    output: Erd = SystemDataTestDouble.ramErd(bool, .{}),
+});
+const BoolSystemData = BoolTestSystem.SystemData;
+const BoolErdEnum = BoolSystemData.ErdEnumType;
+
+test "_and is true only when all inputs are true" {
+    var system_data: BoolSystemData = BoolTestSystem.init();
+
+    const inputs = &[_]BoolErdEnum{ .input_a, .input_b };
+    ErdLogic(BoolSystemData, ._and, inputs, .output).init(&system_data);
+
+    try std.testing.expectEqual(false, system_data.read(.output));
+    system_data.write(.input_a, true);
+    try std.testing.expectEqual(false, system_data.read(.output));
+    system_data.write(.input_b, true);
+    try std.testing.expectEqual(true, system_data.read(.output));
+}
+
+test "_or is true when any input is true" {
+    var system_data: BoolSystemData = BoolTestSystem.init();
+
+    const inputs = &[_]BoolErdEnum{ .input_a, .input_b };
+    ErdLogic(BoolSystemData, ._or, inputs, .output).init(&system_data);
+
+    try std.testing.expectEqual(false, system_data.read(.output));
+    system_data.write(.input_a, true);
+    try std.testing.expectEqual(true, system_data.read(.output));
+    system_data.write(.input_a, false);
+    system_data.write(.input_b, true);
+    try std.testing.expectEqual(true, system_data.read(.output));
+}
+
+test "_xor and _nor on bools" {
+    var system_data: BoolSystemData = BoolTestSystem.init();
+    const inputs = &[_]BoolErdEnum{ .input_a, .input_b };
+    ErdLogic(BoolSystemData, ._xor, inputs, .output).init(&system_data);
+
+    system_data.write(.input_a, true);
+    system_data.write(.input_b, false);
+    try std.testing.expectEqual(true, system_data.read(.output));
+    system_data.write(.input_b, true);
+    try std.testing.expectEqual(false, system_data.read(.output));
+}
+
+test "_not inverts the boolean input" {
+    var system_data: BoolSystemData = BoolTestSystem.init();
+    ErdLogic(BoolSystemData, ._not, &[_]BoolErdEnum{.input_a}, .output).init(&system_data);
+
+    try std.testing.expectEqual(true, system_data.read(.output));
+    system_data.write(.input_a, true);
+    try std.testing.expectEqual(false, system_data.read(.output));
+}

--- a/erd_core/src/common/erd_logic.zig
+++ b/erd_core/src/common/erd_logic.zig
@@ -10,12 +10,10 @@ const std = @import("std");
 const ErdLogicOperator = enum {
     _and,
     _or,
-    _nor,
     _xor,
     _not,
     _bitwise_and,
     _bitwise_or,
-    _bitwise_nor,
     _bitwise_xor,
     _bitwise_not,
 };
@@ -73,29 +71,21 @@ pub fn ErdLogic(SystemDataType: type, comptime operator: ErdLogicOperator, compt
             } else if (erds.len > 1) {
                 var value = system_data.read(erds[0]);
 
-                // NOR reduces as OR here and negates once at the end -- naive
-                // left-fold `nor(nor(a, b), c)` is `(a or b) and !c`, NOT the
-                // n-ary NOR `!(a or b or c)`. Same reasoning for `_bitwise_nor`.
                 inline for (erds[1..]) |erd| {
                     const next = system_data.read(erd);
 
                     value = switch (operator) {
                         ._and => value and next,
-                        ._or, ._nor => value or next,
+                        ._or => value or next,
                         ._xor => value != next,
                         ._bitwise_and => value & next,
-                        ._bitwise_or, ._bitwise_nor => value | next,
+                        ._bitwise_or => value | next,
                         ._bitwise_xor => value ^ next,
                         else => comptime unreachable,
                     };
                 }
 
-                const output = switch (operator) {
-                    ._nor => !value,
-                    ._bitwise_nor => ~value,
-                    else => value,
-                };
-                system_data.write(outputErd, output);
+                system_data.write(outputErd, value);
             }
         }
 
@@ -186,45 +176,6 @@ test "_bitwise_xor toggles differing bits" {
     try std.testing.expectEqual(0, system_data.read(.output));
 }
 
-test "_bitwise_nor inverts the or of inputs" {
-    var system_data: SystemData = TestSystem.init();
-
-    const input_erds = &[_]ErdEnum{ .input_a, .input_b };
-    ErdLogic(SystemData, ._bitwise_nor, input_erds, .output).init(&system_data);
-
-    system_data.write(.input_a, 0);
-    system_data.write(.input_b, 0);
-    try std.testing.expectEqual(0xFFFF, system_data.read(.output));
-
-    system_data.write(.input_a, 0xFFFF);
-    system_data.write(.input_b, 0);
-    try std.testing.expectEqual(0, system_data.read(.output));
-}
-
-const TestSystem3 = SystemDataTestDouble.create(struct {
-    input_a: Erd = SystemDataTestDouble.ramErd(u16, .{ .subs = 1 }),
-    input_b: Erd = SystemDataTestDouble.ramErd(u16, .{ .subs = 1 }),
-    input_c: Erd = SystemDataTestDouble.ramErd(u16, .{ .subs = 1 }),
-    output: Erd = SystemDataTestDouble.ramErd(u16, .{}),
-});
-const SystemData3 = TestSystem3.SystemData;
-const ErdEnum3 = SystemData3.ErdEnumType;
-
-test "_bitwise_nor is n-ary, not naive left-fold" {
-    // Naive left-fold of `_bitwise_nor` over 3 inputs would yield
-    // `nor(nor(a, b), c)` = `(a | b) & ~c`, which is NOT the n-ary NOR.
-    // The correct semantics is `~(a | b | c)`. This test locks that in.
-    var system_data: SystemData3 = TestSystem3.init();
-    const inputs = &[_]ErdEnum3{ .input_a, .input_b, .input_c };
-    ErdLogic(SystemData3, ._bitwise_nor, inputs, .output).init(&system_data);
-
-    system_data.write(.input_a, 0x00F0);
-    system_data.write(.input_b, 0x0F00);
-    system_data.write(.input_c, 0xF000);
-    // ~(0x00F0 | 0x0F00 | 0xF000) = ~0xFFF0 = 0x000F
-    try std.testing.expectEqual(0x000F, system_data.read(.output));
-}
-
 const BoolTestSystem = SystemDataTestDouble.create(struct {
     input_a: Erd = SystemDataTestDouble.ramErd(bool, .{ .subs = 1 }),
     input_b: Erd = SystemDataTestDouble.ramErd(bool, .{ .subs = 1 }),
@@ -260,7 +211,7 @@ test "_or is true when any input is true" {
     try std.testing.expectEqual(true, system_data.read(.output));
 }
 
-test "_xor and _nor on bools" {
+test "_xor on bools" {
     var system_data: BoolSystemData = BoolTestSystem.init();
     const inputs = &[_]BoolErdEnum{ .input_a, .input_b };
     ErdLogic(BoolSystemData, ._xor, inputs, .output).init(&system_data);

--- a/erd_core/src/common/timer_stats.zig
+++ b/erd_core/src/common/timer_stats.zig
@@ -64,7 +64,7 @@ pub fn TimerModuleStats(SystemDataType: type) type {
 
         fn onEnableChange(ctx: ?*anyopaque, _args: ?*const anyopaque, publisher: *anyopaque) void {
             const args: *const SystemDataType.OnChangeArgs = @ptrCast(@alignCast(_args.?));
-            var system_data: *SystemDataType = @ptrCast(@alignCast(publisher));
+            const system_data: *SystemDataType = @ptrCast(@alignCast(publisher));
             const self: *Self = @ptrCast(@alignCast(ctx));
             const is_enabled: *const bool = @ptrCast(args.data);
 
@@ -84,25 +84,6 @@ pub fn TimerModuleStats(SystemDataType: type) type {
         }
 
         // TODO: runtime_subscribe
-        fn innerInit(
-            self: *Self,
-            system_data: *SystemDataType,
-            timer_module: *TimerModule,
-            enable_erd_idx: u16,
-            output_erd_idx: u16,
-        ) void {
-            self.system_data = system_data;
-            self.timer_module = timer_module;
-            self.enable_erd_idx = enable_erd_idx;
-            self.output_erd_idx = output_erd_idx;
-
-            var is_enabled: bool = undefined;
-            system_data.runtimeRead(enable_erd_idx, &is_enabled);
-
-            const init_data: SystemDataType.OnChangeArgs = .{ .data = &is_enabled, .system_data_idx = enable_erd_idx };
-            onEnableChange(self, &init_data, system_data);
-        }
-
         /// Initialize the stats module and wire up the enable ERD subscription.
         pub fn init(
             self: *Self,
@@ -116,14 +97,22 @@ pub fn TimerModuleStats(SystemDataType: type) type {
                 std.debug.assert(SystemDataType.erdFromEnum(output_erd).T == StatMeasurement);
             }
 
+            const enable_erd_idx = SystemDataType.erdFromEnum(enable_erd).system_data_idx;
+            const output_erd_idx = SystemDataType.erdFromEnum(output_erd).system_data_idx;
+
+            self.system_data = system_data;
+            self.timer_module = timer_module;
+            self.enable_erd_idx = enable_erd_idx;
+            self.output_erd_idx = output_erd_idx;
+
             system_data.subscribe(enable_erd, self, onEnableChange);
 
-            self.innerInit(
-                system_data,
-                timer_module,
-                SystemDataType.erdFromEnum(enable_erd).system_data_idx,
-                SystemDataType.erdFromEnum(output_erd).system_data_idx,
-            );
+            // Fire onEnableChange synchronously to pick up the current enable
+            // value so the stats timers reflect ERD state at init time.
+            var is_enabled: bool = undefined;
+            system_data.runtimeRead(enable_erd_idx, &is_enabled);
+            const init_data: SystemDataType.OnChangeArgs = .{ .data = &is_enabled, .system_data_idx = enable_erd_idx };
+            onEnableChange(self, &init_data, system_data);
         }
     };
 }

--- a/erd_core/src/converted_data_component.zig
+++ b/erd_core/src/converted_data_component.zig
@@ -9,18 +9,11 @@
 //! subscriptions. Public APIs assert that `postSystemDataInit` has been called.
 
 const erd_core = @import("erd_core");
+const erd_mapping = erd_core.erd_mapping;
 const std = @import("std");
 const Erd = erd_core.Erd;
 const Subscription = erd_core.Subscription;
 const DataComponentSubscription = erd_core.data_component.subscription_mixin.DataComponentSubscription;
-
-/// Resolve the function pointer for an ERD from a comptime mappings array.
-fn fnFromMappings(comptime erd: Erd, comptime mappings: anytype) @TypeOf(mappings[0].fn_ptr) {
-    for (mappings) |mapping| {
-        if (mapping.erd.data_component_idx == erd.data_component_idx) return mapping.fn_ptr;
-    }
-    unreachable;
-}
 
 /// Binds a converted ERD to its compute function and dependency list.
 pub const Mapping = struct {
@@ -47,18 +40,17 @@ pub fn ConvertedDataComponent(comptime erds: []const Erd, comptime erd_mappings:
         pub const supports_write = false;
         const Subs = DataComponentSubscription(erds);
 
-        read_functions: [erds.len]*const anyopaque = initFunctions(),
         subs: Subs = .{},
+        /// Back-pointer to the owning SystemData. Set by `postSystemDataInit`.
+        /// Undefined until then; `read`/`runtimeRead` debug-assert that it has been wired up.
         system_data_ref: *anyopaque = undefined,
+        /// Latched true by `postSystemDataInit`. Read paths assert it so a missing
+        /// init call surfaces immediately in safety builds instead of dereferencing
+        /// `system_data_ref` while it is still `undefined`.
         is_fully_initialized: bool = false,
 
-        fn initFunctions() [erds.len]*const anyopaque {
-            var fns: [erds.len]*const anyopaque = undefined;
-            for (erd_mappings) |mapping| {
-                fns[mapping.erd.data_component_idx] = mapping.fn_ptr;
-            }
-            return fns;
-        }
+        /// Comptime function pointer table, lives in .rodata rather than per-instance RAM.
+        const read_functions: [erds.len]*const anyopaque = erd_mapping.buildFunctionTable(erds, erd_mappings);
 
         /// Wire up the SystemData back-pointer and subscribe to all dependency ERDs.
         /// Must be called after the SystemData is at its final memory location.
@@ -76,7 +68,7 @@ pub fn ConvertedDataComponent(comptime erds: []const Erd, comptime erd_mappings:
         /// Recompute and return the value of a converted ERD.
         pub fn read(self: Self, erd: Erd) erd.T {
             std.debug.assert(self.is_fully_initialized);
-            const fnPtr: *const fn (*erd.T, *anyopaque) void = @ptrCast(comptime fnFromMappings(erd, erd_mappings));
+            const fnPtr: *const fn (*erd.T, *anyopaque) void = @ptrCast(comptime erd_mapping.fnFromMappings(erd, erd_mappings));
             var temp: erd.T = undefined;
             fnPtr(&temp, self.system_data_ref);
             return temp;
@@ -85,30 +77,22 @@ pub fn ConvertedDataComponent(comptime erds: []const Erd, comptime erd_mappings:
         /// Runtime read using a dynamic data component index.
         pub fn runtimeRead(self: *const Self, data_component_idx: u16, data: *anyopaque) void {
             std.debug.assert(self.is_fully_initialized);
-            const fnPtr: *const fn ([*]u8, *anyopaque) void = @ptrCast(self.read_functions[data_component_idx]);
+            const fnPtr: *const fn ([*]u8, *anyopaque) void = @ptrCast(read_functions[data_component_idx]);
             fnPtr(@ptrCast(data), self.system_data_ref);
         }
 
         /// Compile error: converted ERDs do not support modify.
-        pub fn modify(self: *Self, erd: Erd, comptime modifier: *const fn (*erd.T) void, publisher: *anyopaque) void {
-            _ = self;
-            _ = modifier;
-            _ = publisher;
+        pub fn modify(_: *Self, erd: Erd, comptime _: *const fn (*erd.T) void, _: *anyopaque) void {
             @compileError("Converted ERD modifications are not allowed");
         }
 
         /// Compile error: converted ERDs do not support writes.
-        pub fn write(self: *Self, erd: Erd, data: erd.T) bool {
-            _ = self;
-            _ = data;
+        pub fn write(_: *Self, erd: Erd, _: erd.T, _: *anyopaque) void {
             @compileError("Converted ERD writes are not allowed");
         }
 
         /// Compile error: converted ERDs do not support runtime writes.
-        pub fn runtimeWrite(self: *Self, data_component_idx: u16, data: *const anyopaque) bool {
-            _ = self;
-            _ = data_component_idx;
-            _ = data;
+        pub fn runtimeWrite(_: *Self, _: u16, _: *const anyopaque, _: *anyopaque) void {
             @compileError("Converted ERD writes are not allowed");
         }
 
@@ -116,32 +100,24 @@ pub fn ConvertedDataComponent(comptime erds: []const Erd, comptime erd_mappings:
         /// When a dependency changes, this callback recomputes the output
         /// and publishes to subscribers of the converted ERD.
         fn makeCallback(erd_data_component_idx: comptime_int) Subscription.Callback {
+            const erd = erds[erd_data_component_idx];
             return struct {
                 fn cb(context: ?*anyopaque, _: ?*const anyopaque, publisher: *anyopaque) void {
                     const self: *Self = @ptrCast(@alignCast(context.?));
-                    const T = erds[erd_data_component_idx].T;
-                    const fnPtr: *const fn (*T, *anyopaque) void = @ptrCast(comptime fnFromMappings(erds[erd_data_component_idx], erd_mappings));
-                    var val: T = undefined;
+                    const fnPtr: *const fn (*erd.T, *anyopaque) void = @ptrCast(comptime erd_mapping.fnFromMappings(erd, erd_mappings));
+                    var val: erd.T = undefined;
                     fnPtr(&val, publisher);
-                    if (erds[erd_data_component_idx].subs > 0) {
-                        self.doPublish(erd_data_component_idx, @ptrCast(&val), publisher);
+                    if (erd.subs > 0) {
+                        const offset = Subs.sub_offsets[erd_data_component_idx];
+                        Subscription.publish(
+                            self.subs.slots[offset..][0..erd.subs],
+                            erd.system_data_idx,
+                            @ptrCast(&val),
+                            publisher,
+                        );
                     }
                 }
             }.cb;
-        }
-
-        fn doPublish(self: *Self, erd_data_component_idx: comptime_int, data: *const anyopaque, publisher: *anyopaque) void {
-            const offset = Subs.sub_offsets[erd_data_component_idx];
-            const count = erds[erd_data_component_idx].subs;
-            for (self.subs.slots[offset .. offset + count]) |sub| {
-                if (sub.callback) |cb| {
-                    const args: Subscription.OnChangeArgs = .{
-                        .system_data_idx = erds[erd_data_component_idx].system_data_idx,
-                        .data = data,
-                    };
-                    cb(sub.context, @ptrCast(&args), publisher);
-                }
-            }
         }
     };
 }

--- a/erd_core/src/data_component_subscription.zig
+++ b/erd_core/src/data_component_subscription.zig
@@ -16,11 +16,15 @@ const std = @import("std");
 const Erd = erd_core.Erd;
 const Subscription = erd_core.Subscription;
 
-/// Validates that every component in `Components` has a `subs` field.
+/// Validates that every component in `Components` has the data-component interface:
+/// a `subs` field and a `supports_write` decl.
 pub fn validateComponents(Components: type) void {
     for (std.meta.fields(Components)) |field| {
         if (!@hasField(field.type, "subs")) {
             @compileError(std.fmt.comptimePrint("Component {s} must have a subs field (use DataComponentSubscription or Unsupported)", .{field.name}));
+        }
+        if (!@hasDecl(field.type, "supports_write")) {
+            @compileError(std.fmt.comptimePrint("Component {s} must declare `pub const supports_write` (true for writable components, false otherwise)", .{field.name}));
         }
     }
 }
@@ -30,8 +34,6 @@ pub fn validateComponents(Components: type) void {
 pub fn DataComponentSubscription(comptime erds: []const Erd) type {
     return struct {
         const Self = @This();
-        /// Whether this component supports subscriptions.
-        pub const supported = true;
 
         /// Comptime-computed offsets into the flat subscription slot array per ERD.
         pub const sub_offsets = blk: {
@@ -81,11 +83,6 @@ pub fn DataComponentSubscription(comptime erds: []const Erd) type {
 /// Stub for components that do not support subscriptions.
 /// Any attempt to subscribe or unsubscribe is a compile error.
 pub const Unsupported = struct { // zlinter-disable-current-line declaration_naming
-    /// Whether this component supports subscriptions.
-    pub const supported = false;
-    /// Empty offset array for interface compatibility.
-    pub const sub_offsets = [_]usize{};
-
     /// Compile error: this component does not support subscriptions.
     pub fn subscribe(_: *@This(), _: Erd, _: ?*anyopaque, _: Subscription.Callback) void {
         @compileError("This component does not support subscriptions");

--- a/erd_core/src/erd_mapping.zig
+++ b/erd_core/src/erd_mapping.zig
@@ -6,7 +6,7 @@ const std = @import("std");
 
 /// Resolve the function pointer for an ERD from a comptime mappings array.
 /// Each mapping must expose a `.erd` (an `Erd`) and a `.fn_ptr` field.
-/// Comptime error if no mapping covers the ERD — the user's data
+/// Comptime error if no mapping covers the ERD; the user's data
 /// component declares N ERDs but failed to supply a mapping for one of them.
 pub fn fnFromMappings(comptime erd: Erd, comptime mappings: anytype) @TypeOf(mappings[0].fn_ptr) {
     for (mappings) |mapping| {

--- a/erd_core/src/erd_mapping.zig
+++ b/erd_core/src/erd_mapping.zig
@@ -1,0 +1,68 @@
+//! Helpers shared by `IndirectDataComponent` and `ConvertedDataComponent` for
+//! mapping ERDs to their compute/read function pointers.
+
+const Erd = @import("Erd.zig");
+const std = @import("std");
+
+/// Resolve the function pointer for an ERD from a comptime mappings array.
+/// Each mapping must expose a `.erd` (an `Erd`) and a `.fn_ptr` field.
+/// Comptime error if no mapping covers the ERD — the user's data
+/// component declares N ERDs but failed to supply a mapping for one of them.
+pub fn fnFromMappings(comptime erd: Erd, comptime mappings: anytype) @TypeOf(mappings[0].fn_ptr) {
+    for (mappings) |mapping| {
+        if (mapping.erd.data_component_idx == erd.data_component_idx) return mapping.fn_ptr;
+    }
+    @compileError(std.fmt.comptimePrint(
+        "No mapping found for ERD at data_component_idx {} (erd_number 0x{x:0>4} or null)",
+        .{ erd.data_component_idx, erd.erd_number orelse 0 },
+    ));
+}
+
+/// Build a comptime array of erased function pointers indexed by
+/// `data_component_idx`, used by data components' `runtimeRead` path.
+pub fn buildFunctionTable(comptime erds: []const Erd, comptime mappings: anytype) [erds.len]*const anyopaque {
+    var fns: [erds.len]*const anyopaque = undefined;
+    for (mappings) |mapping| {
+        fns[mapping.erd.data_component_idx] = mapping.fn_ptr;
+    }
+    return fns;
+}
+
+const TestMapping = struct { erd: Erd, fn_ptr: *const anyopaque };
+
+fn testFnA() void {
+    // marker function; identity matters, not behavior
+}
+fn testFnB() void {
+    // marker function; identity matters, not behavior
+}
+fn testFnC() void {
+    // marker function; identity matters, not behavior
+}
+
+const test_erds = [_]Erd{
+    .{ .erd_number = null, .T = u32, .component_idx = 0, .subs = 0, .data_component_idx = 0 },
+    .{ .erd_number = null, .T = u32, .component_idx = 0, .subs = 0, .data_component_idx = 1 },
+    .{ .erd_number = null, .T = u32, .component_idx = 0, .subs = 0, .data_component_idx = 2 },
+};
+
+const test_mappings = [_]TestMapping{
+    // Intentionally out of order to verify lookup is by data_component_idx not array position.
+    .{ .erd = test_erds[2], .fn_ptr = @ptrCast(&testFnC) },
+    .{ .erd = test_erds[0], .fn_ptr = @ptrCast(&testFnA) },
+    .{ .erd = test_erds[1], .fn_ptr = @ptrCast(&testFnB) },
+};
+
+test "fnFromMappings finds by data_component_idx regardless of mapping order" {
+    try std.testing.expectEqual(@as(*const anyopaque, @ptrCast(&testFnA)), comptime fnFromMappings(test_erds[0], test_mappings));
+    try std.testing.expectEqual(@as(*const anyopaque, @ptrCast(&testFnB)), comptime fnFromMappings(test_erds[1], test_mappings));
+    try std.testing.expectEqual(@as(*const anyopaque, @ptrCast(&testFnC)), comptime fnFromMappings(test_erds[2], test_mappings));
+}
+
+test "buildFunctionTable indexes by data_component_idx" {
+    const table = comptime buildFunctionTable(&test_erds, test_mappings);
+    try std.testing.expectEqual(3, table.len);
+    try std.testing.expectEqual(@as(*const anyopaque, @ptrCast(&testFnA)), table[0]);
+    try std.testing.expectEqual(@as(*const anyopaque, @ptrCast(&testFnB)), table[1]);
+    try std.testing.expectEqual(@as(*const anyopaque, @ptrCast(&testFnC)), table[2]);
+}

--- a/erd_core/src/erd_table.zig
+++ b/erd_core/src/erd_table.zig
@@ -1,0 +1,150 @@
+//! Helpers for populating an `ErdDefinitions` struct.
+//!
+//! Application-level ERD tables declare each field with a fixed
+//! `component_idx` and rely on the table-init code to assign the
+//! per-component `data_component_idx` and the global `system_data_idx`
+//! based on field order. This module centralizes that bookkeeping so
+//! each application doesn't have to repeat the same comptime ritual.
+
+const Erd = @import("Erd.zig");
+const std = @import("std");
+
+/// Returns an ErdDefinitions instance with `data_component_idx` and
+/// `system_data_idx` filled in based on `component_idx` and field order.
+///
+/// Usage:
+/// ```
+/// pub const erd = erd_core.erd_table.autofill(ErdDefinitions);
+/// ```
+pub fn autofill(ErdDefs: type) ErdDefs {
+    var erds = ErdDefs{};
+
+    var max_component_idx: comptime_int = 0;
+    for (std.meta.fieldNames(ErdDefs)) |field_name| {
+        const idx = @field(erds, field_name).component_idx;
+        if (idx > max_component_idx) max_component_idx = idx;
+    }
+
+    var owning_counts = std.mem.zeroes([max_component_idx + 1]u16);
+    for (std.meta.fieldNames(ErdDefs), 0..) |field_name, i| {
+        const idx = @field(erds, field_name).component_idx;
+        @field(erds, field_name).data_component_idx = owning_counts[idx];
+        @field(erds, field_name).system_data_idx = i;
+        owning_counts[idx] += 1;
+    }
+
+    return erds;
+}
+
+/// Count ERDs in `erd_instance` whose `component_idx` matches `component_idx`.
+pub fn numErdsByComponent(comptime erd_instance: anytype, comptime component_idx: u8) comptime_int {
+    var count = 0;
+    for (std.meta.fieldNames(@TypeOf(erd_instance))) |field_name| {
+        if (@field(erd_instance, field_name).component_idx == component_idx) count += 1;
+    }
+    return count;
+}
+
+/// Extract ERD definitions whose `component_idx` matches into a fixed-size array.
+pub fn collectByComponent(comptime erd_instance: anytype, comptime component_idx: u8) [numErdsByComponent(erd_instance, component_idx)]Erd {
+    var result: [numErdsByComponent(erd_instance, component_idx)]Erd = undefined;
+    var i = 0;
+    for (std.meta.fieldNames(@TypeOf(erd_instance))) |field_name| {
+        if (@field(erd_instance, field_name).component_idx == component_idx) {
+            result[i] = @field(erd_instance, field_name);
+            i += 1;
+        }
+    }
+    return result;
+}
+
+/// Comptime-checks that `ErdEnum`'s variant names match `ErdDefs`'s field
+/// names 1:1 in order. Apps can call this from inside `ErdEnum`'s comptime
+/// block to surface mismatches at ErdEnum-definition time instead of waiting
+/// for SystemData construction. SystemData itself runs the equivalent check
+/// independently, so calling this is optional.
+pub fn validateEnumMatchesDefs(ErdEnum: type, ErdDefs: type) void {
+    const erd_fields = std.meta.fieldNames(ErdDefs);
+    const erd_enum_names = std.meta.fieldNames(ErdEnum);
+    if (erd_fields.len != erd_enum_names.len) {
+        @compileError(std.fmt.comptimePrint(
+            "ErdEnum has {} variant(s) but ErdDefs has {} field(s); they must match 1:1 in order",
+            .{ erd_enum_names.len, erd_fields.len },
+        ));
+    }
+    for (erd_fields, erd_enum_names) |field_name, enum_name| {
+        if (!std.mem.eql(u8, field_name, enum_name)) {
+            @compileError(std.fmt.comptimePrint(
+                "ErdDefs field {s} does not match ErdEnum variant {s}",
+                .{ field_name, enum_name },
+            ));
+        }
+    }
+}
+
+const testing = std.testing;
+
+const TestDefs = struct {
+    ram_a: Erd = .{ .erd_number = 0x0001, .T = u32, .component_idx = 0, .subs = 0 },
+    ram_b: Erd = .{ .erd_number = null, .T = u8, .component_idx = 0, .subs = 1 },
+    indirect_a: Erd = .{ .erd_number = 0x0003, .T = u16, .component_idx = 1, .subs = 0 },
+    ram_c: Erd = .{ .erd_number = 0x0004, .T = bool, .component_idx = 0, .subs = 0 },
+    converted_a: Erd = .{ .erd_number = null, .T = u32, .component_idx = 2, .subs = 2 },
+};
+
+test "autofill assigns system_data_idx in field order" {
+    const filled = autofill(TestDefs);
+    try testing.expectEqual(0, filled.ram_a.system_data_idx);
+    try testing.expectEqual(1, filled.ram_b.system_data_idx);
+    try testing.expectEqual(2, filled.indirect_a.system_data_idx);
+    try testing.expectEqual(3, filled.ram_c.system_data_idx);
+    try testing.expectEqual(4, filled.converted_a.system_data_idx);
+}
+
+test "autofill assigns data_component_idx per-component" {
+    const filled = autofill(TestDefs);
+    // Ram (component_idx=0): a, b, c in field order
+    try testing.expectEqual(0, filled.ram_a.data_component_idx);
+    try testing.expectEqual(1, filled.ram_b.data_component_idx);
+    try testing.expectEqual(2, filled.ram_c.data_component_idx);
+    // Indirect (component_idx=1): only a
+    try testing.expectEqual(0, filled.indirect_a.data_component_idx);
+    // Converted (component_idx=2): only a
+    try testing.expectEqual(0, filled.converted_a.data_component_idx);
+}
+
+test "autofill preserves original ERD fields" {
+    const filled = autofill(TestDefs);
+    try testing.expectEqual(@as(?Erd.ErdHandle, 0x0001), filled.ram_a.erd_number);
+    try testing.expectEqual(u32, filled.ram_a.T);
+    try testing.expectEqual(0, filled.ram_a.component_idx);
+    try testing.expectEqual(0, filled.ram_a.subs);
+    try testing.expectEqual(1, filled.ram_b.subs);
+    try testing.expectEqual(2, filled.converted_a.subs);
+}
+
+test "numErdsByComponent counts only matching component" {
+    const filled = autofill(TestDefs);
+    try testing.expectEqual(3, numErdsByComponent(filled, 0)); // ram_a, ram_b, ram_c
+    try testing.expectEqual(1, numErdsByComponent(filled, 1)); // indirect_a
+    try testing.expectEqual(1, numErdsByComponent(filled, 2)); // converted_a
+    try testing.expectEqual(0, numErdsByComponent(filled, 3)); // none
+}
+
+test "collectByComponent returns ERDs in field order" {
+    const filled = autofill(TestDefs);
+    const ram = collectByComponent(filled, 0);
+    try testing.expectEqual(3, ram.len);
+    try testing.expectEqual(0x0001, ram[0].erd_number.?);
+    try testing.expectEqual(@as(?Erd.ErdHandle, null), ram[1].erd_number);
+    try testing.expectEqual(0x0004, ram[2].erd_number.?);
+
+    const indirect = collectByComponent(filled, 1);
+    try testing.expectEqual(1, indirect.len);
+    try testing.expectEqual(0x0003, indirect[0].erd_number.?);
+}
+
+test "validateEnumMatchesDefs accepts matching enum and struct" {
+    // Compiles cleanly only if the helper accepts the matched pair.
+    comptime validateEnumMatchesDefs(enum { ram_a, ram_b, indirect_a, ram_c, converted_a }, TestDefs);
+}

--- a/erd_core/src/indirect_data_component.zig
+++ b/erd_core/src/indirect_data_component.zig
@@ -1,18 +1,17 @@
-//! This module provides an indirect data component which uses function calls
-//! that handle reads. Writes are not supported.
-//! If you want code to run on write, then you should use an ERD subscription or the converted data component
+//! Read-only data component whose values are produced on demand by
+//! caller-supplied functions. Each ERD is bound to a `Mapping{ .erd, .fn_ptr }`;
+//! `read` (comptime-dispatched) and `runtimeRead` both invoke the mapped
+//! function and return its result. No storage, no subscriptions.
+//!
+//! `modify`/`write`/`runtimeWrite` are `@compileError` stubs since indirect
+//! values are not user-mutable. For "run on write" behavior, subscribe to the
+//! source ERD or use `ConvertedDataComponent` (which recomputes when its
+//! dependencies change).
 
 const erd_core = @import("erd_core");
+const erd_mapping = erd_core.erd_mapping;
 const Erd = erd_core.Erd;
 const subscription_mixin = erd_core.data_component.subscription_mixin;
-
-/// Resolve the function pointer for an ERD from a comptime mappings array.
-fn fnFromMappings(comptime erd: Erd, comptime mappings: anytype) @TypeOf(mappings[0].fn_ptr) {
-    for (mappings) |mapping| {
-        if (mapping.erd.data_component_idx == erd.data_component_idx) return mapping.fn_ptr;
-    }
-    unreachable;
-}
 
 /// Binds an indirect ERD to its read function pointer.
 pub const Mapping = struct {
@@ -33,53 +32,37 @@ pub fn IndirectDataComponent(comptime erds: []const Erd, comptime erd_mappings: 
         /// Indicates this component does not support writes.
         pub const supports_write = false;
 
-        read_functions: [erds.len]*const anyopaque = initFunctions(),
         subs: subscription_mixin.Unsupported = .{},
 
-        fn initFunctions() [erds.len]*const anyopaque {
-            var fns: [erds.len]*const anyopaque = undefined;
-            for (erd_mappings) |mapping| {
-                fns[mapping.erd.data_component_idx] = mapping.fn_ptr;
-            }
-            return fns;
-        }
+        /// Comptime function pointer table, lives in .rodata rather than per-instance RAM.
+        const read_functions: [erds.len]*const anyopaque = erd_mapping.buildFunctionTable(erds, erd_mappings);
 
         /// Compute and return the ERD value by calling its mapped function.
         pub fn read(_: Self, erd: Erd) erd.T {
-            const fnPtr: *const fn (*erd.T) void = @ptrCast(comptime fnFromMappings(erd, erd_mappings));
+            const fnPtr: *const fn (*erd.T) void = @ptrCast(comptime erd_mapping.fnFromMappings(erd, erd_mappings));
             var temp: erd.T = undefined;
             fnPtr(&temp);
             return temp;
         }
 
         /// Runtime read using a dynamic data component index.
-        pub fn runtimeRead(self: *const Self, data_component_idx: u16, data: *anyopaque) void {
-            const fnPtr: *const fn ([*]u8) void = @ptrCast(self.read_functions[data_component_idx]);
+        pub fn runtimeRead(_: *const Self, data_component_idx: u16, data: *anyopaque) void {
+            const fnPtr: *const fn ([*]u8) void = @ptrCast(read_functions[data_component_idx]);
             fnPtr(@ptrCast(data));
         }
 
         /// Compile error: indirect ERDs do not support modify.
-        pub fn modify(self: *Self, erd: Erd, comptime modifier: *const fn (*erd.T) void, publisher: *anyopaque) void {
-            _ = self;
-            _ = modifier;
-            _ = publisher;
+        pub fn modify(_: *Self, erd: Erd, comptime _: *const fn (*erd.T) void, _: *anyopaque) void {
             @compileError("Indirect ERD modifications are not allowed");
         }
 
         /// Compile error: indirect ERDs do not support writes.
-        pub fn write(self: *Self, erd: Erd, data: erd.T, publisher: *anyopaque) void {
-            _ = self;
-            _ = data;
-            _ = publisher;
+        pub fn write(_: *Self, erd: Erd, _: erd.T, _: *anyopaque) void {
             @compileError("Indirect ERD writes are not allowed");
         }
 
         /// Compile error: indirect ERDs do not support runtime writes.
-        pub fn runtimeWrite(self: *Self, data_component_idx: u16, data: *const anyopaque, publisher: *anyopaque) void {
-            _ = self;
-            _ = data_component_idx;
-            _ = data;
-            _ = publisher;
+        pub fn runtimeWrite(_: *Self, _: u16, _: *const anyopaque, _: *anyopaque) void {
             @compileError("Indirect ERD writes are not allowed");
         }
     };

--- a/erd_core/src/ram_data_component.zig
+++ b/erd_core/src/ram_data_component.zig
@@ -4,7 +4,7 @@
 //! direct loads/stores into `storage` even through the higher-level
 //! `SystemData` wrappers.
 //!
-//! `write` does change-detection — a no-op when the new bytes match the old —
+//! `write` does change-detection (a no-op when the new bytes match the old)
 //! and publishes to subscribers only when bytes change. `modify` skips
 //! change-detection (the caller asserts the value changed) and publishes
 //! unconditionally; preferred for struct ERDs with many fields where

--- a/erd_core/src/ram_data_component.zig
+++ b/erd_core/src/ram_data_component.zig
@@ -2,13 +2,8 @@
 //! `storage` array. Per-ERD byte offsets are computed at comptime from the
 //! ERD slice, so comptime-dispatched `read`/`write`/`modify` compile to
 //! direct loads/stores into `storage` even through the higher-level
-//! `SystemData` wrappers.
-//!
-//! `write` does change-detection (a no-op when the new bytes match the old)
-//! and publishes to subscribers only when bytes change. `modify` skips
-//! change-detection (the caller asserts the value changed) and publishes
-//! unconditionally; preferred for struct ERDs with many fields where
-//! `write`'s value-copy + compare would balloon code size.
+//! `SystemData` wrappers. `write`'s trigger publishes when data
+//! is bit-for-bit different.
 
 const erd_core = @import("erd_core");
 const std = @import("std");

--- a/erd_core/src/ram_data_component.zig
+++ b/erd_core/src/ram_data_component.zig
@@ -1,6 +1,14 @@
-//! This module provides a RAM data component, which stores data in a packed array.
-//! `comptime` makes it so ERD reads and writes are direct,
-//! even when performed through higher level abstractions like system_data
+//! RAM-backed data component: stores every owned ERD's bytes in one packed
+//! `storage` array. Per-ERD byte offsets are computed at comptime from the
+//! ERD slice, so comptime-dispatched `read`/`write`/`modify` compile to
+//! direct loads/stores into `storage` even through the higher-level
+//! `SystemData` wrappers.
+//!
+//! `write` does change-detection — a no-op when the new bytes match the old —
+//! and publishes to subscribers only when bytes change. `modify` skips
+//! change-detection (the caller asserts the value changed) and publishes
+//! unconditionally; preferred for struct ERDs with many fields where
+//! `write`'s value-copy + compare would balloon code size.
 
 const erd_core = @import("erd_core");
 const std = @import("std");
@@ -84,7 +92,7 @@ pub fn RamDataComponent(comptime erds: []const Erd) type {
 
         /// Runtime read using a dynamic data component index.
         pub fn runtimeRead(self: *const Self, data_component_idx: u16, data: *anyopaque) void {
-            var data_slice: [*]u8 = @ptrCast(data);
+            const data_slice: [*]u8 = @ptrCast(data);
             const size = data_size[data_component_idx];
 
             @memcpy(data_slice[0..size], self.storage[ram_offsets[data_component_idx] .. ram_offsets[data_component_idx] + size]);
@@ -111,7 +119,7 @@ pub fn RamDataComponent(comptime erds: []const Erd) type {
             stored.* = data_bytes;
 
             if (changed) {
-                self.publish(erd.data_component_idx, &data, publisher);
+                self.publish(idx, &data, publisher);
             }
         }
 
@@ -120,17 +128,16 @@ pub fn RamDataComponent(comptime erds: []const Erd) type {
         /// Debug-asserts that the value actually changed.
         pub fn modify(self: *Self, erd: Erd, comptime modifier: *const fn (*erd.T) void, publisher: *anyopaque) void {
             const idx = erd.data_component_idx;
-            const src: *align(1) const erd.T = @ptrCast(self.storage[ram_offsets[idx]..]);
-            const dst: *align(1) erd.T = @ptrCast(self.storage[ram_offsets[idx]..]);
+            const ptr: *align(1) erd.T = @ptrCast(self.storage[ram_offsets[idx]..]);
 
-            var value: erd.T = src.*;
+            var value: erd.T = ptr.*;
             const before = value;
             modifier(&value);
             std.debug.assert(!std.meta.eql(before, value));
-            dst.* = value;
+            ptr.* = value;
 
             if (erd.subs > 0) {
-                self.publish(erd.data_component_idx, dst, publisher);
+                self.publish(idx, ptr, publisher);
             }
         }
 

--- a/erd_core/src/root.zig
+++ b/erd_core/src/root.zig
@@ -4,6 +4,8 @@
 const std = @import("std");
 
 pub const Erd = @import("Erd.zig");
+pub const erd_mapping = @import("erd_mapping.zig");
+pub const erd_table = @import("erd_table.zig");
 pub const Subscription = @import("Subscription.zig");
 pub const SystemData = @import("system_data.zig").SystemData;
 

--- a/erd_core/src/strip_asm.zig
+++ b/erd_core/src/strip_asm.zig
@@ -102,7 +102,20 @@ fn isStdlibFunc(name: []const u8) bool {
     return false;
 }
 
-const IdMap = std.StringHashMapUnmanaged(u32);
+/// Separate counters per category so that branch labels and anonymous-symbol
+/// IDs don't share a number space (otherwise `.L3` can appear in a function
+/// whose first three IDs were spent on `__anon_*` / `__struct_*` symbols).
+const IdMap = struct {
+    lbb: std.StringHashMapUnmanaged(u32) = .empty,
+    sym: std.StringHashMapUnmanaged(u32) = .empty,
+
+    const empty: IdMap = .{};
+
+    fn deinit(self: *IdMap, gpa: std.mem.Allocator) void {
+        self.lbb.deinit(gpa);
+        self.sym.deinit(gpa);
+    }
+};
 
 fn resolveMode(mode_name: []const u8) ?snapshot_comments.Mode {
     if (std.mem.eql(u8, mode_name, "ReleaseFast")) return .release_fast;
@@ -197,8 +210,8 @@ fn appendNormalized(gpa: std.mem.Allocator, out: *std.ArrayList(u8), line: []con
                 while (end < line.len and std.ascii.isDigit(line[end])) : (end += 1) {}
                 if (end > d2) {
                     const original = line[lbb_start..end];
-                    const gop = try id_map.getOrPut(gpa, original);
-                    if (!gop.found_existing) gop.value_ptr.* = id_map.count() - 1;
+                    const gop = try id_map.lbb.getOrPut(gpa, original);
+                    if (!gop.found_existing) gop.value_ptr.* = id_map.lbb.count() - 1;
                     try out.appendSlice(gpa, ".L");
                     var num_buf: [20]u8 = undefined;
                     const num_str = try std.fmt.bufPrint(&num_buf, "{d}", .{gop.value_ptr.*});
@@ -217,8 +230,8 @@ fn appendNormalized(gpa: std.mem.Allocator, out: *std.ArrayList(u8), line: []con
                 while (digit_end < line.len and std.ascii.isDigit(line[digit_end])) : (digit_end += 1) {}
                 if (digit_end > digit_start) {
                     const original = line[pos..digit_end];
-                    const gop = try id_map.getOrPut(gpa, original);
-                    if (!gop.found_existing) gop.value_ptr.* = id_map.count() - 1;
+                    const gop = try id_map.sym.getOrPut(gpa, original);
+                    if (!gop.found_existing) gop.value_ptr.* = id_map.sym.count() - 1;
                     try out.appendSlice(gpa, needle);
                     var num_buf: [20]u8 = undefined;
                     const num_str = try std.fmt.bufPrint(&num_buf, "{d}", .{gop.value_ptr.*});

--- a/erd_core/src/system_data.zig
+++ b/erd_core/src/system_data.zig
@@ -1,9 +1,18 @@
-//! Top level system data
-//! This is a zero-cost wrapper around multiple data components
-//! It binds ERDs of multiple data components into one name space, and initializes them
-//! It is meant to be the top level component that you pass around your application.
-//! It is intended to pass by value NOT by reference since most of it will fall away at
-//! comptime and you want to ensure direct accesses to underlying function calls
+//! Top-level system data: a comptime-typed wrapper around a struct of data
+//! components. Binds the application's ERD definitions to concrete component
+//! storage, validates the ERD table at comptime (unique `erd_number`, ErdEnum
+//! field-name alignment, every component has the `subs` field + `supports_write`
+//! decl), and exposes:
+//!
+//!   - comptime-dispatched `read`/`write`/`modify`/`subscribe`/`unsubscribe`
+//!     (one comptime field access, no runtime dispatch table)
+//!   - runtime-dispatched `runtimeRead`/`runtimeWrite` for the case where the
+//!     ERD is known only by its `system_data_idx` (e.g. UART command handler)
+//!   - a per-RTC scratch allocator (`scratchAlloc`/`scratchReset`)
+//!
+//! Pass `SystemData` by value to the API so the comptime-known field offsets
+//! collapse to direct loads/stores rather than indirect access through a
+//! pointer; methods that mutate (`write`/`modify`/etc.) take `*Self`.
 
 const erd_core = @import("erd_core");
 const std = @import("std");
@@ -12,16 +21,21 @@ const Subscription = erd_core.Subscription;
 
 /// Construct a typed pub-sub system data aggregator from ERD definitions and components.
 pub fn SystemData(ErdDefs: type, ErdEnum: type, comptime erd_instance: ErdDefs, Components: type) type {
-    // Validate ErdEnum matches ErdDefs fields
     comptime {
-        const erd_fields = std.meta.fieldNames(ErdDefs);
-        const erd_enum_names = std.meta.fieldNames(ErdEnum);
-        if (erd_fields.len != erd_enum_names.len) {
-            @compileError("ErdEnum field count does not match ErdDefs field count");
-        }
-        for (erd_fields, erd_enum_names) |field_name, enum_name| {
-            if (!std.mem.eql(u8, field_name, enum_name)) {
-                @compileError(std.fmt.comptimePrint("ErdDefs field {s} does not match ErdEnum variant {s}", .{ field_name, enum_name }));
+        // Validate ErdEnum matches ErdDefs fields 1:1 in order.
+        erd_core.erd_table.validateEnumMatchesDefs(ErdEnum, ErdDefs);
+
+        // Reject duplicate erd_numbers up front so the callsite (system_erds.zig
+        // tables) does not have to repeat the check. The bit set needs one
+        // bit per representable handle value, so `maxInt(...) + 1` (NOT
+        // `maxInt(...)`) -- otherwise the largest valid handle is out of range.
+        var seen_numbers: std.bit_set.ArrayBitSet(usize, @as(usize, std.math.maxInt(Erd.ErdHandle)) + 1) = .empty;
+        for (std.meta.fieldNames(ErdDefs)) |field_name| {
+            if (@field(erd_instance, field_name).erd_number) |num| {
+                if (seen_numbers.isSet(num)) {
+                    @compileError(std.fmt.comptimePrint("Multiple ERD definitions with number 0x{x:0>4}", .{num}));
+                }
+                seen_numbers.set(num);
             }
         }
     }
@@ -31,6 +45,19 @@ pub fn SystemData(ErdDefs: type, ErdEnum: type, comptime erd_instance: ErdDefs, 
 
     comptime {
         erd_core.data_component.subscription_mixin.validateComponents(Components);
+
+        // Reject ERDs whose `component_idx` is out of range for `Components`.
+        // Without this check the user gets a confusing later error like
+        // "index out of bounds" from `component_fields[erd.component_idx]`.
+        for (std.meta.fieldNames(ErdDefs)) |erd_field_name| {
+            const erd = @field(erd_instance, erd_field_name);
+            if (erd.component_idx < 0 or erd.component_idx >= component_fields.len) {
+                @compileError(std.fmt.comptimePrint(
+                    "ERD {s} has component_idx {} but Components only has {} field(s) (valid range: 0..{})",
+                    .{ erd_field_name, erd.component_idx, component_fields.len, component_fields.len - 1 },
+                ));
+            }
+        }
     }
 
     return struct {
@@ -43,9 +70,14 @@ pub fn SystemData(ErdDefs: type, ErdEnum: type, comptime erd_instance: ErdDefs, 
         pub const SubException = struct { erd_enum: ErdEnum, missing: comptime_int };
 
         components: Components = undefined,
-        /// This is a bump allocator meant to be reset at the end of a run to complete
+        /// Bump allocator backed by `scratch_buf`. Reset at the end of each
+        /// run-to-complete via `scratchReset` so allocations don't accumulate.
         scratch: std.heap.FixedBufferAllocator = undefined,
-        scratch_buf: [2048]u8 align(@alignOf(usize)) = undefined, // TODO: Does this actually need to be aligned?
+        /// Backing storage for `scratch`. Aligned to `@alignOf(usize)` so the
+        /// FixedBufferAllocator can hand out usize-aligned (or smaller)
+        /// allocations without ever needing internal alignment padding from
+        /// the buffer base.
+        scratch_buf: [2048]u8 align(@alignOf(usize)) = undefined,
 
         /// Initialize SystemData with the given component instances.
         pub fn init(components: Components) Self {
@@ -90,12 +122,8 @@ pub fn SystemData(ErdDefs: type, ErdEnum: type, comptime erd_instance: ErdDefs, 
         /// Due to the performance and code size benefits, this should be preferred over `runtimeRead`.
         pub fn read(this: Self, comptime erd_enum: ErdEnum) erdFromEnum(erd_enum).T {
             const erd: Erd = erdFromEnum(erd_enum);
-            inline for (component_fields, 0..) |field, i| {
-                if (erd.component_idx == i) {
-                    return @field(this.components, field.name).read(erd);
-                }
-            }
-            unreachable;
+            const owner = comptime component_fields[erd.component_idx].name;
+            return @field(this.components, owner).read(erd);
         }
 
         /// Read an ERD into the provided `data` pointer, using the ERD's corresponding system_data_idx
@@ -107,11 +135,11 @@ pub fn SystemData(ErdDefs: type, ErdEnum: type, comptime erd_instance: ErdDefs, 
             const component_idx = component_idx_from_system_idx[system_data_idx];
             const data_component_idx = data_component_idx_from_system_idx[system_data_idx];
 
-            inline for (component_fields, 0..) |field, i| {
-                if (component_idx == i) {
-                    @field(this.components, field.name).runtimeRead(data_component_idx, data);
-                    return;
-                }
+            switch (component_idx) {
+                inline 0...component_fields.len - 1 => |i| {
+                    @field(this.components, component_fields[i].name).runtimeRead(data_component_idx, data);
+                },
+                else => unreachable,
             }
         }
 
@@ -123,20 +151,23 @@ pub fn SystemData(ErdDefs: type, ErdEnum: type, comptime erd_instance: ErdDefs, 
 
             comptime {
                 if (!supports_write_from_component_idx[erd.component_idx]) {
-                    @compileError("This ERD's data component does not support writes");
+                    @compileError(std.fmt.comptimePrint(
+                        "write({s}): this ERD's data component does not support writes",
+                        .{@tagName(erd_enum)},
+                    ));
                 }
                 if (@typeInfo(erd.T) == .@"struct" and std.meta.fields(erd.T).len >= 4) {
-                    @compileError("Use modify() for struct ERDs with 4 or more fields: " ++
-                        "comptime RMW on primitives and small structs already optimizes cleanly, " ++
-                        "but large structs benefit from modify()'s shared noinline body for code size");
+                    @compileError(std.fmt.comptimePrint(
+                        "write({s}, {s}): use modify() instead. " ++
+                            "Comptime RMW on primitives and small structs already optimizes cleanly, " ++
+                            "but a {}-field struct benefits from modify()'s shared noinline body for code size.",
+                        .{ @tagName(erd_enum), @typeName(erd.T), std.meta.fields(erd.T).len },
+                    ));
                 }
             }
 
-            inline for (component_fields, 0..) |field, i| {
-                if (erd.component_idx == i) {
-                    @field(this.components, field.name).write(erd, data, @ptrCast(this));
-                }
-            }
+            const owner = comptime component_fields[erd.component_idx].name;
+            @field(this.components, owner).write(erd, data, @ptrCast(this));
         }
 
         /// Modify a struct ERD in-place and always publish, skipping change detection.
@@ -147,20 +178,23 @@ pub fn SystemData(ErdDefs: type, ErdEnum: type, comptime erd_instance: ErdDefs, 
 
             comptime {
                 if (!supports_write_from_component_idx[erd.component_idx]) {
-                    @compileError("This ERD's data component does not support writes");
+                    @compileError(std.fmt.comptimePrint(
+                        "modify({s}): this ERD's data component does not support writes",
+                        .{@tagName(erd_enum)},
+                    ));
                 }
                 if (@typeInfo(erd.T) != .@"struct") {
-                    @compileError("modify() is only for struct ERDs: " ++
-                        "primitive RMW patterns already optimize cleanly via write() " ++
-                        "and modify() would bypass change detection without a code size benefit");
+                    @compileError(std.fmt.comptimePrint(
+                        "modify({s}, {s}): only valid for struct ERDs. " ++
+                            "Primitive RMW patterns already optimize cleanly via write(); " ++
+                            "modify() would bypass change detection without a code size benefit.",
+                        .{ @tagName(erd_enum), @typeName(erd.T) },
+                    ));
                 }
             }
 
-            inline for (component_fields, 0..) |field, i| {
-                if (erd.component_idx == i) {
-                    @field(this.components, field.name).modify(erd, modifier, @ptrCast(this));
-                }
-            }
+            const owner = comptime component_fields[erd.component_idx].name;
+            @field(this.components, owner).modify(erd, modifier, @ptrCast(this));
         }
 
         /// Write to an ERD from the provided `data` pointer, using the ERD's corresponding system_data_idx
@@ -168,19 +202,21 @@ pub fn SystemData(ErdDefs: type, ErdEnum: type, comptime erd_instance: ErdDefs, 
         /// - When mapping from an `ErdHandle` to system_data_idx, eg. in response to UART commands
         /// - Writing an ERD using info from an on-change callback (common for ERD multiplexers)
         ///
-        /// NOTE: `data` must be aligned!
+        /// `data` is copied byte-by-byte into storage; no specific alignment is
+        /// required on the pointer.
         // noinline so the dispatch logic is shared across all call sites.
         pub noinline fn runtimeWrite(this: *Self, system_data_idx: u16, data: *const anyopaque) void {
             const component_idx = component_idx_from_system_idx[system_data_idx];
             const data_component_idx = data_component_idx_from_system_idx[system_data_idx];
 
-            inline for (component_fields, 0..) |field, i| {
-                if (component_idx == i) {
+            switch (component_idx) {
+                inline 0...component_fields.len - 1 => |i| {
                     if (!supports_write_from_component_idx[i]) {
                         unreachable;
                     }
-                    @field(this.components, field.name).runtimeWrite(data_component_idx, data, @ptrCast(this));
-                }
+                    @field(this.components, component_fields[i].name).runtimeWrite(data_component_idx, data, @ptrCast(this));
+                },
+                else => unreachable,
             }
         }
 
@@ -195,30 +231,28 @@ pub fn SystemData(ErdDefs: type, ErdEnum: type, comptime erd_instance: ErdDefs, 
         ) void {
             const erd: Erd = erdFromEnum(erd_enum);
             comptime {
-                std.debug.assert(erd.subs > 0);
+                if (erd.subs == 0) @compileError(std.fmt.comptimePrint(
+                    "subscribe({s}): ERD declares subs = 0; raise its `.subs` to allow subscriptions",
+                    .{@tagName(erd_enum)},
+                ));
             }
 
-            inline for (component_fields, 0..) |field, i| {
-                if (erd.component_idx == i) {
-                    @field(this.components, field.name).subs.subscribe(erd, context, fn_ptr);
-                    return;
-                }
-            }
+            const owner = comptime component_fields[erd.component_idx].name;
+            @field(this.components, owner).subs.subscribe(erd, context, fn_ptr);
         }
 
         /// Remove a subscription from an ERD by callback identity.
         pub fn unsubscribe(this: *Self, comptime erd_enum: ErdEnum, fn_ptr: Subscription.Callback) void {
             const erd: Erd = erdFromEnum(erd_enum);
             comptime {
-                std.debug.assert(erd.subs > 0);
+                if (erd.subs == 0) @compileError(std.fmt.comptimePrint(
+                    "unsubscribe({s}): ERD declares subs = 0; no subscriptions are possible",
+                    .{@tagName(erd_enum)},
+                ));
             }
 
-            inline for (component_fields, 0..) |field, i| {
-                if (erd.component_idx == i) {
-                    @field(this.components, field.name).subs.unsubscribe(erd, fn_ptr);
-                    return;
-                }
-            }
+            const owner = comptime component_fields[erd.component_idx].name;
+            @field(this.components, owner).subs.unsubscribe(erd, fn_ptr);
         }
 
         /// Returns a slice allocated to the scratch buffer.
@@ -231,16 +265,43 @@ pub fn SystemData(ErdDefs: type, ErdEnum: type, comptime erd_instance: ErdDefs, 
             this.scratch.reset();
         }
 
-        /// A test only function used to verify that after initialization,
-        /// all of your subscriptions arrays are fully saturated
-        pub fn verifyAllSubsAreSaturated(this: *Self, comptime exceptions: []const SubException) error{ ErdWithNoSubsInExceptions, ErdWithUnexpectedSubCount }!void {
+        /// Verify that after initialization, every ERD's subscription slots
+        /// are filled (modulo `exceptions` which list ERDs that are
+        /// intentionally under-subscribed by `missing` slots). Intended
+        /// for use at the end of `Application.init` to catch
+        /// over-/under-subscribed ERDs before the main loop.
+        ///
+        /// Pass a non-null `diagnostics` writer to receive per-ERD failure
+        /// messages (which ERD, under vs over). Tests typically pass `null`
+        /// because they assert on the error return; production init paths
+        /// can pass a `std.Io.Writer` (e.g. backed by stderr) to learn
+        /// which ERD is wrong without crashing.
+        pub fn verifyAllSubsAreSaturated(
+            this: *Self,
+            comptime exceptions: []const SubException,
+            diagnostics: ?*std.Io.Writer,
+        ) error{ ErdWithNoSubsInExceptions, ErdWithUnexpectedSubCount, WriteFailed }!void {
+            comptime {
+                // Reject `missing > subs` at compile time so the runtime
+                // expected-count arithmetic stays in non-negative territory.
+                for (exceptions) |e| {
+                    const erd_subs = @field(erd_instance, @tagName(e.erd_enum)).subs;
+                    if (e.missing > erd_subs) {
+                        @compileError(std.fmt.comptimePrint(
+                            "SubException for {s}: missing ({}) cannot exceed declared subs ({})",
+                            .{ @tagName(e.erd_enum), e.missing, erd_subs },
+                        ));
+                    }
+                }
+            }
+
             var failed = false;
 
             inline for (exceptions) |e| {
                 const erd_name = @tagName(e.erd_enum);
                 const num_subs = @field(erd_instance, erd_name).subs;
                 if (num_subs == 0) {
-                    std.log.warn("Remove {s} from exceptions list since subscriptions are disabled for it", .{erd_name});
+                    if (diagnostics) |w| try w.print("Remove {s} from exceptions list since subscriptions are disabled for it\n", .{erd_name});
                     failed = true;
                 }
             }
@@ -269,27 +330,21 @@ pub fn SystemData(ErdDefs: type, ErdEnum: type, comptime erd_instance: ErdDefs, 
                     break :blk _expected;
                 };
 
-                const component_idx = erd.component_idx;
                 var actual_count: u16 = 0;
-
-                inline for (component_fields, 0..) |comp_field, ci| {
-                    if (component_idx == ci) {
-                        const sub_field = &@field(this.components, comp_field.name).subs;
-                        const SubscriptionType = @TypeOf(sub_field.*);
-                        const offset = SubscriptionType.sub_offsets[erd.data_component_idx];
-                        for (sub_field.slots[offset .. offset + num_subs]) |sub| {
-                            if (sub.callback != null) {
-                                actual_count += 1;
-                            }
-                        }
+                const sub_field = &@field(this.components, component_fields[erd.component_idx].name).subs;
+                const SubscriptionType = @TypeOf(sub_field.*);
+                const offset = SubscriptionType.sub_offsets[erd.data_component_idx];
+                for (sub_field.slots[offset .. offset + num_subs]) |sub| {
+                    if (sub.callback != null) {
+                        actual_count += 1;
                     }
                 }
 
                 if (actual_count < expected_count) {
-                    std.log.warn("ERD: {s} is under-subscribing after init. Decrease subs, or increase missing.", .{erd_name});
+                    if (diagnostics) |w| try w.print("ERD: {s} is under-subscribing after init. Decrease subs, or increase missing.\n", .{erd_name});
                     failed = true;
                 } else if (actual_count > expected_count) {
-                    std.log.warn("ERD: {s} is over-subscribed after init. Increase subs or decrease missing.", .{erd_name});
+                    if (diagnostics) |w| try w.print("ERD: {s} is over-subscribed after init. Increase subs or decrease missing.\n", .{erd_name});
                     failed = true;
                 }
             }

--- a/erd_core/src/system_data_test_double.zig
+++ b/erd_core/src/system_data_test_double.zig
@@ -40,16 +40,8 @@ pub fn ramErd(T: type, comptime opts: RamErdOptions) Erd {
 
 /// Create a test SystemData type from ERD definitions backed by a single RAM component.
 pub fn create(ErdDefs: type) type { // zlinter-disable-current-line function_naming
-    const erd_instance = buildErdInstance(ErdDefs);
-    const erd_fields = std.meta.fieldNames(ErdDefs);
-
-    const all_erds: [erd_fields.len]Erd = blk: {
-        var erds: [erd_fields.len]Erd = undefined;
-        for (erd_fields, 0..) |name, i| {
-            erds[i] = @field(erd_instance, name);
-        }
-        break :blk erds;
-    };
+    const erd_instance = erd_core.erd_table.autofill(ErdDefs);
+    const all_erds = erd_core.erd_table.collectByComponent(erd_instance, 0);
 
     const RamDataComponentType = erd_core.data_component.Ram(&all_erds);
     const ErdEnum = std.meta.FieldEnum(ErdDefs);
@@ -71,17 +63,4 @@ pub fn create(ErdDefs: type) type { // zlinter-disable-current-line function_nam
             });
         }
     };
-}
-
-fn buildErdInstance(ErdDefs: type) ErdDefs {
-    var erds = ErdDefs{};
-
-    var data_component_idx: u16 = 0;
-    for (std.meta.fieldNames(ErdDefs), 0..) |name, i| {
-        @field(erds, name).data_component_idx = data_component_idx;
-        @field(erds, name).system_data_idx = i;
-        data_component_idx += 1;
-    }
-
-    return erds;
 }

--- a/erd_core/src/tests/converted_data_component_test.zig
+++ b/erd_core/src/tests/converted_data_component_test.zig
@@ -20,45 +20,11 @@ const ErdDefs = struct {
     // zig fmt: on
 };
 
-const erd_instance = blk: {
-    var erds = ErdDefs{};
-    const max_component = 1;
-    var counts = [_]u16{0} ** (max_component + 1);
-    for (std.meta.fieldNames(ErdDefs), 0..) |name, i| {
-        const idx = @field(erds, name).component_idx;
-        @field(erds, name).data_component_idx = counts[idx];
-        counts[idx] += 1;
-        @field(erds, name).system_data_idx = i;
-    }
-    break :blk erds;
-};
-
+const erd_instance = erd_core.erd_table.autofill(ErdDefs);
 const ErdEnum = std.meta.FieldEnum(ErdDefs);
 
-fn collectComponentErds(component_idx: comptime_int) [countComponentErds(component_idx)]Erd {
-    var result: [countComponentErds(component_idx)]Erd = undefined;
-    var i: usize = 0;
-    for (std.meta.fieldNames(ErdDefs)) |name| {
-        if (@field(erd_instance, name).component_idx == component_idx) {
-            result[i] = @field(erd_instance, name);
-            i += 1;
-        }
-    }
-    return result;
-}
-
-fn countComponentErds(component_idx: comptime_int) comptime_int {
-    var count: comptime_int = 0;
-    for (std.meta.fieldNames(ErdDefs)) |name| {
-        if (@field(erd_instance, name).component_idx == component_idx) {
-            count += 1;
-        }
-    }
-    return count;
-}
-
-const ram_erds = collectComponentErds(Ram);
-const converted_erds = collectComponentErds(Converted);
+const ram_erds = erd_core.erd_table.collectByComponent(erd_instance, Ram);
+const converted_erds = erd_core.erd_table.collectByComponent(erd_instance, Converted);
 
 const RamComponent = RamDataComponent(&ram_erds);
 
@@ -165,6 +131,19 @@ test "unsubscribe from converted ERD" {
     try std.testing.expectEqual(1, subscriber_call_count);
 }
 
+test "re-subscribe to converted ERD reuses slot" {
+    subscriber_call_count = 0;
+    var sd: SystemData = undefined;
+    setupSystem(&sd);
+
+    sd.subscribe(.sum_ab, null, testSubscriber);
+    sd.unsubscribe(.sum_ab, testSubscriber);
+    sd.subscribe(.sum_ab, null, testSubscriber);
+
+    sd.write(.dep_a, 1);
+    try std.testing.expectEqual(1, subscriber_call_count);
+}
+
 test "converted ERD with no subscribers still computes on read" {
     var sd: SystemData = undefined;
     setupSystem(&sd);
@@ -178,7 +157,7 @@ var cascaded_value: u16 = 0;
 fn cascadeSubscriber(_: ?*anyopaque, _args: ?*const anyopaque, publisher: *anyopaque) void {
     const args: *const SystemData.OnChangeArgs = @ptrCast(@alignCast(_args.?));
     const val: *const u16 = @ptrCast(@alignCast(args.data));
-    var sd: *SystemData = @ptrCast(@alignCast(publisher));
+    const sd: *SystemData = @ptrCast(@alignCast(publisher));
 
     cascaded_value = val.*;
     sd.write(.dep_c, val.*);
@@ -195,4 +174,21 @@ test "converted subscriber can write other ERDs" {
     sd.write(.dep_b, 4);
     try std.testing.expectEqual(7, cascaded_value);
     try std.testing.expectEqual(7, sd.read(.dep_c));
+}
+
+test "runtimeRead recomputes converted ERD value" {
+    var sd: SystemData = undefined;
+    setupSystem(&sd);
+
+    sd.write(.dep_a, 11);
+    sd.write(.dep_b, 22);
+
+    var out: u16 = undefined;
+    sd.runtimeRead(SystemData.erdFromEnum(.sum_ab).system_data_idx, &out);
+    try std.testing.expectEqual(33, out);
+
+    // recomputes on each call
+    sd.write(.dep_a, 100);
+    sd.runtimeRead(SystemData.erdFromEnum(.sum_ab).system_data_idx, &out);
+    try std.testing.expectEqual(122, out);
 }

--- a/erd_core/src/tests/indirect_data_component_test.zig
+++ b/erd_core/src/tests/indirect_data_component_test.zig
@@ -1,3 +1,4 @@
+// zlinter-disable no_comment_out_code
 const erd_core = @import("erd_core");
 const std = @import("std");
 const Erd = erd_core.Erd;
@@ -36,9 +37,12 @@ test "indirect data component read" {
     try std.testing.expectEqual(42 + 1, indirect_data.read(erd_plus_one));
 }
 
-// NOTE: `write` and `runtimeWrite` on an Indirect data component are
-// `@compileError` stubs; they cannot be exercised from a regular test.
-// If you uncomment the calls, the build must fail to compile.
+test "indirect data component write" {
+    return error.SkipZigTest; // Test for compile error
+
+    // var indirect_data = IndirectDataComponent{};
+    // _ = indirect_data.write(erd_always_42, 41);
+}
 
 test "indirect data component runtime read" {
     var indirect_data = IndirectDataComponent{};
@@ -53,3 +57,9 @@ test "indirect data component runtime read" {
     try std.testing.expectEqual(42 + 1, should_be_43);
 }
 
+test "indirect data component runtime write" {
+    return error.SkipZigTest; // Test for compile error
+
+    // var indirect_data = IndirectDataComponent{};
+    // _ = indirect_data.runtimeWrite(erd_always_42.data_component_idx, &41);
+}

--- a/erd_core/src/tests/indirect_data_component_test.zig
+++ b/erd_core/src/tests/indirect_data_component_test.zig
@@ -1,4 +1,3 @@
-// zlinter-disable no_comment_out_code
 const erd_core = @import("erd_core");
 const std = @import("std");
 const Erd = erd_core.Erd;
@@ -37,12 +36,9 @@ test "indirect data component read" {
     try std.testing.expectEqual(42 + 1, indirect_data.read(erd_plus_one));
 }
 
-test "indirect data component write" {
-    return error.SkipZigTest; // Test for compile error
-
-    // var indirect_data = IndirectDataComponent{};
-    // _ = indirect_data.write(erd_always_42, 41);
-}
+// NOTE: `write` and `runtimeWrite` on an Indirect data component are
+// `@compileError` stubs; they cannot be exercised from a regular test.
+// If you uncomment the calls, the build must fail to compile.
 
 test "indirect data component runtime read" {
     var indirect_data = IndirectDataComponent{};
@@ -57,9 +53,3 @@ test "indirect data component runtime read" {
     try std.testing.expectEqual(42 + 1, should_be_43);
 }
 
-test "indirect data component runtime write" {
-    return error.SkipZigTest; // Test for compile error
-
-    // var indirect_data = IndirectDataComponent{};
-    // _ = indirect_data.runtimeWrite(erd_always_42.data_component_idx, &41);
-}

--- a/erd_core/src/tests/ram_data_component_test.zig
+++ b/erd_core/src/tests/ram_data_component_test.zig
@@ -110,8 +110,12 @@ test "structs" {
     try std.testing.expectEqual(@TypeOf(padded){ .a = 0x12, .b = 0x3456, .c = true, .d = 0x09ABCDEF }, padded);
 }
 
-// NOTE: writing a value of the wrong type to a RAM ERD is a compile error
-// (the `write` API takes `data: erd.T`), and so cannot be tested at runtime.
+test "failure upon writing incorrect types" {
+    return error.SkipZigTest; // Test for compile error
+
+    // var ram_data = RamDataComponent.init();
+    // std.testing.expectError(, ram_data.write(erd_bool, 20, &dummy_publisher));
+}
 
 test "runtime reads" {
     var ram_data = RamDataComponent.init();

--- a/erd_core/src/tests/ram_data_component_test.zig
+++ b/erd_core/src/tests/ram_data_component_test.zig
@@ -110,12 +110,8 @@ test "structs" {
     try std.testing.expectEqual(@TypeOf(padded){ .a = 0x12, .b = 0x3456, .c = true, .d = 0x09ABCDEF }, padded);
 }
 
-test "failure upon writing incorrect types" {
-    return error.SkipZigTest; // Test for compile error
-
-    // var ram_data = RamDataComponent.init();
-    // std.testing.expectError(, ram_data.write(erd_bool, 20, &dummy_publisher));
-}
+// NOTE: writing a value of the wrong type to a RAM ERD is a compile error
+// (the `write` API takes `data: erd.T`), and so cannot be tested at runtime.
 
 test "runtime reads" {
     var ram_data = RamDataComponent.init();
@@ -142,4 +138,78 @@ test "runtime writes" {
 
     ram_data.write(erd_bool, false, &dummy_publisher);
     try std.testing.expectEqual(false, ram_data.read(erd_bool));
+}
+
+// Exercise the > 16-byte change-detection path in `write` (separate from the
+// small-int readInt path that fits inside one [u128] compare).
+const BigBlob = extern struct { bytes: [24]u8, tag: u32 };
+
+const BigBlobErds = [_]Erd{
+    .{ .erd_number = null, .T = BigBlob, .component_idx = 0, .subs = 1, .data_component_idx = 0, .system_data_idx = 0 },
+};
+const BigBlobErd = BigBlobErds[0];
+const BigBlobRam = erd_core.data_component.Ram(&BigBlobErds);
+
+var big_blob_publish_count: u32 = 0;
+fn bigBlobPublishCounter(_: ?*anyopaque, _: ?*const anyopaque, _: *anyopaque) void {
+    big_blob_publish_count += 1;
+}
+
+test "write detects change in > 16-byte struct" {
+    big_blob_publish_count = 0;
+    var ram = BigBlobRam.init();
+    ram.subs.subscribe(BigBlobErd, null, bigBlobPublishCounter);
+
+    // Storage is zero-initialized; first non-zero write must publish.
+    var blob = BigBlob{ .bytes = [_]u8{0} ** 24, .tag = 1 };
+    ram.write(BigBlobErd, blob, &dummy_publisher);
+    try std.testing.expectEqual(1, big_blob_publish_count);
+
+    // identical write -> no publish
+    ram.write(BigBlobErd, blob, &dummy_publisher);
+    try std.testing.expectEqual(1, big_blob_publish_count);
+
+    // change only in the trailing bytes after the first 16
+    blob.bytes[20] = 0xAB;
+    ram.write(BigBlobErd, blob, &dummy_publisher);
+    try std.testing.expectEqual(2, big_blob_publish_count);
+
+    // change only in `tag` (the 4-byte tail past the 8-byte chunks)
+    blob.tag = 2;
+    ram.write(BigBlobErd, blob, &dummy_publisher);
+    try std.testing.expectEqual(3, big_blob_publish_count);
+}
+
+// Exercise the partial-word tail branch of `bytesChanged` (len > 16 with
+// len % 8 != 0). 17 bytes is the smallest size that triggers both the
+// readInt(u64) chunk loop and the trailing partial-word read.
+const OddSizeBlob = extern struct { bytes: [17]u8 };
+
+const OddSizeErds = [_]Erd{
+    .{ .erd_number = null, .T = OddSizeBlob, .component_idx = 0, .subs = 1, .data_component_idx = 0, .system_data_idx = 0 },
+};
+const OddSizeErd = OddSizeErds[0];
+const OddSizeRam = erd_core.data_component.Ram(&OddSizeErds);
+
+var odd_blob_publish_count: u32 = 0;
+fn oddBlobPublishCounter(_: ?*anyopaque, _: ?*const anyopaque, _: *anyopaque) void {
+    odd_blob_publish_count += 1;
+}
+
+test "write detects change in tail byte of 17-byte struct" {
+    odd_blob_publish_count = 0;
+    var ram = OddSizeRam.init();
+    ram.subs.subscribe(OddSizeErd, null, oddBlobPublishCounter);
+
+    var blob = OddSizeBlob{ .bytes = [_]u8{0} ** 17 };
+    blob.bytes[0] = 0x42;
+    ram.write(OddSizeErd, blob, &dummy_publisher);
+    try std.testing.expectEqual(1, odd_blob_publish_count);
+
+    // Change ONLY the tail byte (index 16). Previous bytes 0..15 are
+    // unchanged, so the readInt(u64) chunks compare equal; only the
+    // 1-byte tail read should detect this difference.
+    blob.bytes[16] = 0xFF;
+    ram.write(OddSizeErd, blob, &dummy_publisher);
+    try std.testing.expectEqual(2, odd_blob_publish_count);
 }

--- a/erd_core/src/tests/system_data_test.zig
+++ b/erd_core/src/tests/system_data_test.zig
@@ -68,7 +68,7 @@ test "retain reference to system_data" {
 }
 
 fn turnOffBoolAndBumpVersion(_: ?*anyopaque, _: ?*const anyopaque, publisher: *anyopaque) void {
-    var system_data: *SystemData = @ptrCast(@alignCast(publisher));
+    const system_data: *SystemData = @ptrCast(@alignCast(publisher));
 
     system_data.write(.some_bool, false);
     system_data.write(.application_version, system_data.read(.application_version) + 1);
@@ -104,7 +104,7 @@ test "re-subscribe" {
 }
 
 fn forwardContext(context: ?*anyopaque, _: ?*const anyopaque, publisher: *anyopaque) void {
-    var system_data: *SystemData = @ptrCast(@alignCast(publisher));
+    const system_data: *SystemData = @ptrCast(@alignCast(publisher));
     const a: *u8 = @ptrCast(context.?);
 
     system_data.write(.unaligned_u16, a.*);
@@ -122,7 +122,7 @@ test "subscription with context" {
 
 fn contextMustMatchArgs(context: ?*anyopaque, _args: ?*const anyopaque, publisher: *anyopaque) void {
     const args: *const SystemData.OnChangeArgs = @ptrCast(@alignCast(_args.?));
-    var system_data: *SystemData = @ptrCast(@alignCast(publisher));
+    const system_data: *SystemData = @ptrCast(@alignCast(publisher));
 
     const a: *u16 = @ptrCast(@alignCast(context.?));
     const b: *const u16 = @ptrCast(@alignCast(args.data));
@@ -149,7 +149,7 @@ test "subscription with args" {
 
 fn switchOnSystemDataIdx(_: ?*anyopaque, _args: ?*const anyopaque, publisher: *anyopaque) void {
     const args: *const SystemData.OnChangeArgs = @ptrCast(@alignCast(_args.?));
-    var system_data: *SystemData = @ptrCast(@alignCast(publisher));
+    const system_data: *SystemData = @ptrCast(@alignCast(publisher));
 
     if (args.system_data_idx != SystemData.erdFromEnum(.some_bool).system_data_idx) {
         system_data.write(.best_u16, system_data.read(.best_u16) + 1);
@@ -192,7 +192,7 @@ test "subscription args using system_data_idx" {
 }
 
 fn bumpSomeU16(_: ?*anyopaque, _: ?*const anyopaque, publisher: *anyopaque) void {
-    var system_data: *SystemData = @ptrCast(@alignCast(publisher));
+    const system_data: *SystemData = @ptrCast(@alignCast(publisher));
 
     system_data.write(.unaligned_u16, system_data.read(.unaligned_u16) + 1);
 }
@@ -231,12 +231,12 @@ test "exact subscription enforcement" {
     const exceptions = [_]SystemData.SubException{
         .{ .erd_enum = .some_bool, .missing = 1 },
     };
-    try system_data.verifyAllSubsAreSaturated(&exceptions);
+    try system_data.verifyAllSubsAreSaturated(&exceptions, null);
 }
 
 fn scratchAllocating(_: ?*anyopaque, _args: ?*const anyopaque, publisher: *anyopaque) void {
     const args: *const SystemData.OnChangeArgs = @ptrCast(@alignCast(_args.?));
-    var system_data: *SystemData = @ptrCast(@alignCast(publisher));
+    const system_data: *SystemData = @ptrCast(@alignCast(publisher));
 
     const val: *const u16 = @ptrCast(@alignCast(args.data));
     const allocated = system_data.scratchAlloc(u32, val.*);
@@ -267,4 +267,131 @@ test "scratch allocations" {
     // One must be very careful since this data is now considered freed, but there's no runtime check on it.
     // system_data.write(.application_version, more_allocation[0]);
     // try std.testing.expectEqual(0b10101010, system_data.read(.application_version));
+}
+
+// --- modify() end-to-end through SystemData ---
+
+const FourField = extern struct { a: u32, b: u32, c: u32, d: u32 };
+const ModifyTestSystem = SystemDataTestDouble.create(struct {
+    box: Erd = SystemDataTestDouble.ramErd(FourField, .{ .subs = 1 }),
+});
+const ModifySD = ModifyTestSystem.SystemData;
+
+var modify_publish_count: u32 = 0;
+var modify_last_value: FourField = undefined;
+
+fn captureBox(_: ?*anyopaque, _args: ?*const anyopaque, _: *anyopaque) void {
+    const args: *const ModifySD.OnChangeArgs = @ptrCast(@alignCast(_args.?));
+    const val: *const FourField = @ptrCast(@alignCast(args.data));
+    modify_publish_count += 1;
+    modify_last_value = val.*;
+}
+
+test "verifyAllSubsAreSaturated returns error when under-subscribed" {
+    var system_data = TestSystem.init();
+    // some_bool has 3 slots; only fill 1. No exceptions; expect under-sub error.
+    system_data.subscribe(.some_bool, null, whatever);
+    system_data.subscribe(.unaligned_u16, null, whatever);
+    system_data.subscribe(.cool_u16, null, whatever);
+
+    try std.testing.expectError(error.ErdWithUnexpectedSubCount, system_data.verifyAllSubsAreSaturated(&.{}, null));
+}
+
+test "verifyAllSubsAreSaturated errors when exception names a zero-sub ERD" {
+    var system_data = TestSystem.init();
+    // application_version has subs = 0; can't have a SubException for it.
+    const exceptions = [_]SystemData.SubException{
+        .{ .erd_enum = .application_version, .missing = 0 },
+    };
+    try std.testing.expectError(error.ErdWithNoSubsInExceptions, system_data.verifyAllSubsAreSaturated(&exceptions, null));
+}
+
+test "verifyAllSubsAreSaturated errors when an ERD is over-subscribed vs exception" {
+    var system_data = TestSystem.init();
+    // some_bool has 3 slots; subscribe 2 callbacks. With exception missing=2, the
+    // expected count is 1, so 2 subscribers reads as over-subscribed.
+    system_data.subscribe(.some_bool, null, whatever);
+    system_data.subscribe(.some_bool, null, bumpSomeU16);
+    system_data.subscribe(.unaligned_u16, null, whatever);
+    system_data.subscribe(.cool_u16, null, whatever);
+
+    const exceptions = [_]SystemData.SubException{
+        .{ .erd_enum = .some_bool, .missing = 2 },
+    };
+    try std.testing.expectError(error.ErdWithUnexpectedSubCount, system_data.verifyAllSubsAreSaturated(&exceptions, null));
+}
+
+test "verifyAllSubsAreSaturated writes diagnostics to provided writer" {
+    var system_data = TestSystem.init();
+    system_data.subscribe(.some_bool, null, whatever);
+    system_data.subscribe(.unaligned_u16, null, whatever);
+    system_data.subscribe(.cool_u16, null, whatever);
+
+    var buf: [256]u8 = undefined;
+    var w: std.Io.Writer = .fixed(&buf);
+    try std.testing.expectError(error.ErdWithUnexpectedSubCount, system_data.verifyAllSubsAreSaturated(&.{}, &w));
+    try std.testing.expect(std.mem.find(u8, w.buffered(), "some_bool") != null);
+    try std.testing.expect(std.mem.find(u8, w.buffered(), "under-subscribing") != null);
+}
+
+test "SystemData accepts an ERD with erd_number = 0xFFFF" {
+    // Regression: the duplicate-erd_number BitSet used to be sized to
+    // `maxInt(ErdHandle) = 65535` bits (valid indices 0..65534), so an
+    // ERD declared with erd_number 0xFFFF indexed past the end of the
+    // bit set. Constructing this SystemData verifies that boundary
+    // works comptime-cleanly.
+    const MaxErd = SystemDataTestDouble.create(struct {
+        boundary: Erd = SystemDataTestDouble.ramErd(u8, .{ .erd_number = 0xFFFF }),
+    });
+    var sd = MaxErd.init();
+    sd.write(.boundary, 0xAB);
+    try std.testing.expectEqual(0xAB, sd.read(.boundary));
+}
+
+test "verifyAllSubsAreSaturated diagnostics name the zero-sub ERD exception" {
+    var system_data = TestSystem.init();
+    const exceptions = [_]SystemData.SubException{
+        .{ .erd_enum = .application_version, .missing = 0 },
+    };
+
+    var buf: [256]u8 = undefined;
+    var w: std.Io.Writer = .fixed(&buf);
+    try std.testing.expectError(error.ErdWithNoSubsInExceptions, system_data.verifyAllSubsAreSaturated(&exceptions, &w));
+    try std.testing.expect(std.mem.find(u8, w.buffered(), "application_version") != null);
+}
+
+test "verifyAllSubsAreSaturated writes nothing on success even with writer" {
+    var system_data = TestSystem.init();
+    // Saturate the only ERDs with subs so verify returns successfully.
+    system_data.subscribe(.some_bool, null, whatever);
+    system_data.subscribe(.some_bool, null, bumpSomeU16);
+    system_data.subscribe(.some_bool, null, turnOffBoolAndBumpVersion);
+    system_data.subscribe(.unaligned_u16, null, whatever);
+    system_data.subscribe(.cool_u16, null, whatever);
+
+    var buf: [256]u8 = undefined;
+    var w: std.Io.Writer = .fixed(&buf);
+    try system_data.verifyAllSubsAreSaturated(&.{}, &w);
+    try std.testing.expectEqual(@as(usize, 0), w.buffered().len);
+}
+
+test "modify publishes the mutated struct to subscribers" {
+    modify_publish_count = 0;
+    modify_last_value = std.mem.zeroes(FourField);
+
+    var sd: ModifySD = ModifyTestSystem.init();
+    sd.subscribe(.box, null, captureBox);
+
+    sd.modify(.box, struct {
+        fn m(box: *FourField) void {
+            box.a = 1;
+            box.b = 2;
+            box.c = 3;
+            box.d = 4;
+        }
+    }.m);
+
+    try std.testing.expectEqual(1, modify_publish_count);
+    try std.testing.expectEqual(FourField{ .a = 1, .b = 2, .c = 3, .d = 4 }, modify_last_value);
+    try std.testing.expectEqual(FourField{ .a = 1, .b = 2, .c = 3, .d = 4 }, sd.read(.box));
 }

--- a/erd_core/src/tests/timer_fuzzing.zig
+++ b/erd_core/src/tests/timer_fuzzing.zig
@@ -152,5 +152,5 @@ fn startSomeTimerAsPeriodic(ctx: ?*anyopaque, _timer_module: *TimerModule, _: *T
     const duration = rng.intRangeAtMost(timer.Ticks, 0, Timer.longest_delay_before_servicing_timer);
     const callback = callbacks[rng.intRangeAtMost(u8, 0, callbacks.len - 1)];
 
-    _timer_module.startOneShot(some_timer, duration, rng, callback);
+    _timer_module.startPeriodic(some_timer, duration, rng, callback);
 }

--- a/erd_core/src/tests/timer_test.zig
+++ b/erd_core/src/tests/timer_test.zig
@@ -1,4 +1,4 @@
-// zlinter-disable declaration_naming
+// zlinter-disable declaration_naming no_comment_out_code
 const std = @import("std");
 const timer = @import("erd_core").timer;
 const TimerModule = timer.TimerModule;
@@ -15,22 +15,22 @@ fn expectTimerExpiresAfterExactly(timer_module: *TimerModule, ticks: timer.Ticks
 }
 
 fn timer1Callback(ctx: ?*anyopaque, _: *TimerModule, _: *Timer) void {
-    const calls: *std.ArrayList(u8) = @ptrCast(@alignCast(ctx.?));
+    var calls: *std.ArrayList(u8) = @ptrCast(@alignCast(ctx.?));
     calls.appendAssumeCapacity(1);
 }
 
 fn timer2Callback(ctx: ?*anyopaque, _: *TimerModule, _: *Timer) void {
-    const calls: *std.ArrayList(u8) = @ptrCast(@alignCast(ctx.?));
+    var calls: *std.ArrayList(u8) = @ptrCast(@alignCast(ctx.?));
     calls.appendAssumeCapacity(2);
 }
 
 fn timer3Callback(ctx: ?*anyopaque, _: *TimerModule, _: *Timer) void {
-    const calls: *std.ArrayList(u8) = @ptrCast(@alignCast(ctx.?));
+    var calls: *std.ArrayList(u8) = @ptrCast(@alignCast(ctx.?));
     calls.appendAssumeCapacity(3);
 }
 
 fn timer4Callback(ctx: ?*anyopaque, _: *TimerModule, _: *Timer) void {
-    const calls: *std.ArrayList(u8) = @ptrCast(@alignCast(ctx.?));
+    var calls: *std.ArrayList(u8) = @ptrCast(@alignCast(ctx.?));
     calls.appendAssumeCapacity(4);
 }
 
@@ -505,9 +505,23 @@ test "can pause timer during periodic callback" {
     try std.testing.expectEqual(2, local_ctx);
 }
 
-// NOTE: passing a null callback to `startOneShot`/`startPeriodic` is a
-// compile error -- `TimerCallback` is a non-optional `*const fn(...)` --
-// so this case cannot be exercised at runtime.
+test "One shot with null callback" {
+    // var timer_module = TimerModule{};
+    // var timer1 = Timer{};
+    // var context: u32 = 0;
+
+    return error.SkipZigTest; // Test for compile error
+    // timer_module.startOneShot(&timer1, 0, &context, null);
+}
+
+test "Periodic with null callback" {
+    // var timer_module = TimerModule{};
+    // var timer1 = Timer{};
+    // var context: u32 = 0;
+
+    return error.SkipZigTest; // Test for compile error
+    // timer_module.startPeriodic(&timer1, 0, &context, null);
+}
 
 test "IsRunning" {
     var call_buffer: [20]u8 = .{0} ** 20;
@@ -659,7 +673,7 @@ test "restart one shot from callback" {
 
     const A = struct {
         fn restartWithContext(ctx: ?*anyopaque, _timer_module: *TimerModule, _timer: *Timer) void {
-            const _calls: *std.ArrayList(u8) = @ptrCast(@alignCast(ctx));
+            var _calls: *std.ArrayList(u8) = @ptrCast(@alignCast(ctx));
             _calls.appendAssumeCapacity(11);
             _timer_module.startOneShot(_timer, 0, _calls, restartWithContext);
         }
@@ -688,7 +702,7 @@ test "restart periodic from callback" {
 
     const A = struct {
         fn restartWithContext(ctx: ?*anyopaque, _timer_module: *TimerModule, _timer: *Timer) void {
-            const _calls: *std.ArrayList(u8) = @ptrCast(@alignCast(ctx));
+            var _calls: *std.ArrayList(u8) = @ptrCast(@alignCast(ctx));
             _calls.appendAssumeCapacity(13);
             _timer_module.startPeriodic(_timer, 1, _calls, timer1Callback);
         }
@@ -1582,5 +1596,15 @@ test "elapsed ticks from a callback" {
     try std.testing.expectEqual(observed_elapsed_ticks, 0);
 }
 
-// NOTE: `ticksSinceLastStarted` is documented as returning undefined for
-// a never-started timer, so there is nothing meaningful to test there.
+test "ticks since last started called without starting the timer" {
+    return error.SkipZigTest; // This test actually depends on optimization level as well
+
+    // var timer_module = TimerModule{};
+    // var timer1 = Timer{};
+
+    // // This is 100% dependent on the default value of timer.duration and timer.timer_data.
+    // try std.testing.expectEqual(0, timer_module.ticksSinceLastStarted(&timer1));
+
+    // timer_module.incrementCurrentTime(123);
+    // try std.testing.expectEqual(123, timer_module.ticksSinceLastStarted(&timer1));
+}

--- a/erd_core/src/tests/timer_test.zig
+++ b/erd_core/src/tests/timer_test.zig
@@ -1,4 +1,4 @@
-// zlinter-disable declaration_naming no_comment_out_code
+// zlinter-disable declaration_naming
 const std = @import("std");
 const timer = @import("erd_core").timer;
 const TimerModule = timer.TimerModule;
@@ -15,22 +15,22 @@ fn expectTimerExpiresAfterExactly(timer_module: *TimerModule, ticks: timer.Ticks
 }
 
 fn timer1Callback(ctx: ?*anyopaque, _: *TimerModule, _: *Timer) void {
-    var calls: *std.ArrayList(u8) = @ptrCast(@alignCast(ctx.?));
+    const calls: *std.ArrayList(u8) = @ptrCast(@alignCast(ctx.?));
     calls.appendAssumeCapacity(1);
 }
 
 fn timer2Callback(ctx: ?*anyopaque, _: *TimerModule, _: *Timer) void {
-    var calls: *std.ArrayList(u8) = @ptrCast(@alignCast(ctx.?));
+    const calls: *std.ArrayList(u8) = @ptrCast(@alignCast(ctx.?));
     calls.appendAssumeCapacity(2);
 }
 
 fn timer3Callback(ctx: ?*anyopaque, _: *TimerModule, _: *Timer) void {
-    var calls: *std.ArrayList(u8) = @ptrCast(@alignCast(ctx.?));
+    const calls: *std.ArrayList(u8) = @ptrCast(@alignCast(ctx.?));
     calls.appendAssumeCapacity(3);
 }
 
 fn timer4Callback(ctx: ?*anyopaque, _: *TimerModule, _: *Timer) void {
-    var calls: *std.ArrayList(u8) = @ptrCast(@alignCast(ctx.?));
+    const calls: *std.ArrayList(u8) = @ptrCast(@alignCast(ctx.?));
     calls.appendAssumeCapacity(4);
 }
 
@@ -505,23 +505,9 @@ test "can pause timer during periodic callback" {
     try std.testing.expectEqual(2, local_ctx);
 }
 
-test "One shot with null callback" {
-    // var timer_module = TimerModule{};
-    // var timer1 = Timer{};
-    // var context: u32 = 0;
-
-    return error.SkipZigTest; // Test for compile error
-    // timer_module.startOneShot(&timer1, 0, &context, null);
-}
-
-test "Periodic with null callback" {
-    // var timer_module = TimerModule{};
-    // var timer1 = Timer{};
-    // var context: u32 = 0;
-
-    return error.SkipZigTest; // Test for compile error
-    // timer_module.startPeriodic(&timer1, 0, &context, null);
-}
+// NOTE: passing a null callback to `startOneShot`/`startPeriodic` is a
+// compile error -- `TimerCallback` is a non-optional `*const fn(...)` --
+// so this case cannot be exercised at runtime.
 
 test "IsRunning" {
     var call_buffer: [20]u8 = .{0} ** 20;
@@ -673,7 +659,7 @@ test "restart one shot from callback" {
 
     const A = struct {
         fn restartWithContext(ctx: ?*anyopaque, _timer_module: *TimerModule, _timer: *Timer) void {
-            var _calls: *std.ArrayList(u8) = @ptrCast(@alignCast(ctx));
+            const _calls: *std.ArrayList(u8) = @ptrCast(@alignCast(ctx));
             _calls.appendAssumeCapacity(11);
             _timer_module.startOneShot(_timer, 0, _calls, restartWithContext);
         }
@@ -702,7 +688,7 @@ test "restart periodic from callback" {
 
     const A = struct {
         fn restartWithContext(ctx: ?*anyopaque, _timer_module: *TimerModule, _timer: *Timer) void {
-            var _calls: *std.ArrayList(u8) = @ptrCast(@alignCast(ctx));
+            const _calls: *std.ArrayList(u8) = @ptrCast(@alignCast(ctx));
             _calls.appendAssumeCapacity(13);
             _timer_module.startPeriodic(_timer, 1, _calls, timer1Callback);
         }
@@ -1596,15 +1582,5 @@ test "elapsed ticks from a callback" {
     try std.testing.expectEqual(observed_elapsed_ticks, 0);
 }
 
-test "ticks since last started called without starting the timer" {
-    return error.SkipZigTest; // This test actually depends on optimization level as well
-
-    // var timer_module = TimerModule{};
-    // var timer1 = Timer{};
-
-    // // This is 100% dependent on the default value of timer.duration and timer.timer_data.
-    // try std.testing.expectEqual(0, timer_module.ticksSinceLastStarted(&timer1));
-
-    // timer_module.incrementCurrentTime(123);
-    // try std.testing.expectEqual(123, timer_module.ticksSinceLastStarted(&timer1));
-}
+// NOTE: `ticksSinceLastStarted` is documented as returning undefined for
+// a never-started timer, so there is nothing meaningful to test there.

--- a/erd_core/src/timer.zig
+++ b/erd_core/src/timer.zig
@@ -69,7 +69,7 @@ pub const Timer = struct {
     /// Callback invoked when the timer expires.
     pub const TimerCallback = *const fn (ctx: ?*anyopaque, _timer_module: *TimerModule, _timer: *Timer) void;
 
-    fn isPeriodic(self: *Timer) bool {
+    fn isPeriodic(self: *const Timer) bool {
         return (self.ctx & 1) == 1;
     }
 
@@ -81,7 +81,7 @@ pub const Timer = struct {
         }
     }
 
-    fn getCtxPtr(self: *Timer) ?*anyopaque {
+    fn getCtxPtr(self: *const Timer) ?*anyopaque {
         return @ptrFromInt(self.ctx & ~@as(usize, 1));
     }
 };
@@ -104,7 +104,7 @@ pub const TimerModule = struct {
         const time_at_start_of_rtc = self.safelyGetCurrentTime();
 
         if (self.active_timers.first) |next_expiring| {
-            var timer: *Timer = @fieldParentPtr("node", next_expiring);
+            const timer: *Timer = @fieldParentPtr("node", next_expiring);
 
             // Expired timers will have a `distance` in the range of [0, longest_delay_before_servicing_timer]
             // This calculation loops over from `std.math.maxInt(Ticks)` to 0.
@@ -147,7 +147,20 @@ pub const TimerModule = struct {
     /// If you get an error, declare your variable as `align(2)` or use a container
     /// struct with larger alignment
     pub fn startOneShot(self: *TimerModule, timer: *Timer, duration: Ticks, ctx: ?*align(2) anyopaque, callback: Timer.TimerCallback) void {
-        sometimes.assert(&@src(), self.active_timers.first == &timer.node); // Re-starting a periodic as a one-shot
+        self.startInner(timer, duration, ctx, callback, false);
+    }
+
+    /// Starts a periodic timer, with first expiration set to current time + period
+    /// NOTE: `ctx` must be align(2) to allow an `bool` due to optimization reasons
+    /// If you get an error, declare your variable as `align(2)` or use a container
+    /// struct with larger alignment
+    pub fn startPeriodic(self: *TimerModule, timer: *Timer, period: Ticks, ctx: ?*align(2) anyopaque, callback: Timer.TimerCallback) void {
+        self.startInner(timer, period, ctx, callback, true);
+    }
+
+    // zlinter-disable-next-line max_positional_args - thin private helper shared by startOneShot/startPeriodic
+    fn startInner(self: *TimerModule, timer: *Timer, duration: Ticks, ctx: ?*align(2) anyopaque, callback: Timer.TimerCallback, is_periodic: bool) void {
+        sometimes.assert(&@src(), self.active_timers.first == &timer.node); // Re-starting the front-of-queue timer
         if (timer.callback != null or self.active_timers.first == &timer.node) {
             self.removeTimer(timer);
         }
@@ -156,29 +169,9 @@ pub const TimerModule = struct {
         timer.ctx = @intFromPtr(ctx);
         timer.callback = callback;
         timer.duration = duration;
-        timer.setIsPeriodic(false);
+        timer.setIsPeriodic(is_periodic);
 
         self.insertTimer(timer, duration);
-    }
-
-    /// Starts a periodic timer, with first expiration set to current time + period
-    /// NOTE: `ctx` must be align(2) to allow an `bool` due to optimization reasons
-    /// If you get an error, declare your variable as `align(2)` or use a container
-    /// struct with larger alignment
-    pub fn startPeriodic(self: *TimerModule, timer: *Timer, period: Ticks, ctx: ?*align(2) anyopaque, callback: Timer.TimerCallback) void {
-        sometimes.assert(&@src(), self.active_timers.first == &timer.node); // Re-starting a periodic as a periodic
-        if (timer.callback != null or self.active_timers.first == &timer.node) {
-            self.removeTimer(timer);
-        }
-
-        std.debug.assert(period <= Timer.max_ticks);
-
-        timer.ctx = @intFromPtr(ctx);
-        timer.callback = callback;
-        timer.duration = period;
-        timer.setIsPeriodic(true);
-
-        self.insertTimer(timer, period);
     }
 
     /// Stops an active or paused timer
@@ -230,24 +223,18 @@ pub const TimerModule = struct {
 
     /// Returns true if a timer is active
     pub fn isActive(self: *TimerModule, timer: *Timer) bool {
-        var current_elem = self.active_timers.first;
-        while (current_elem != null) {
-            if (current_elem == &timer.node) {
-                return true;
-            }
-            current_elem = current_elem.?.next;
-        }
-        return false;
+        return listContains(&self.active_timers, &timer.node);
     }
 
     /// Returns true if a timer is paused
     pub fn isPaused(self: *TimerModule, timer: *Timer) bool {
-        var current_elem = self.paused_timers.first;
-        while (current_elem != null) {
-            if (current_elem == &timer.node) {
-                return true;
-            }
-            current_elem = current_elem.?.next;
+        return listContains(&self.paused_timers, &timer.node);
+    }
+
+    fn listContains(list: *const std.SinglyLinkedList, node: *const std.SinglyLinkedList.Node) bool {
+        var current_elem = list.first;
+        while (current_elem) |elem| : (current_elem = elem.next) {
+            if (elem == node) return true;
         }
         return false;
     }
@@ -274,13 +261,9 @@ pub const TimerModule = struct {
         return timer_module.safelyGetCurrentTime() -% timer_start;
     }
 
-    fn remainingTicksActiveTimer(timer: *Timer, current_time: Ticks) Ticks {
-        if ((timer.timer_data.expiration -% current_time) <= Timer.max_ticks) {
-            const duration = timer.timer_data.expiration -% current_time;
-            return duration;
-        } else {
-            return 0;
-        }
+    fn remainingTicksActiveTimer(timer: *const Timer, current_time: Ticks) Ticks {
+        const remaining = timer.timer_data.expiration -% current_time;
+        return if (remaining <= Timer.max_ticks) remaining else 0;
     }
 
     /// Returns the remaining ticks on a timer, returns 0 if the timer is not running
@@ -342,22 +325,21 @@ pub const TimerModule = struct {
 
     /// std.SinglyLinkedList remove, but returns a bool and is valid to call when the node isn't in the list
     fn tryRemove(list: *std.SinglyLinkedList, node: *std.SinglyLinkedList.Node) bool {
-        if (list.first == null) {
-            return false;
-        } else if (list.first == node) {
+        if (list.first == node) {
+            // Covers both the "node is at head" case and the "empty list and
+            // node happens to be null" case (the comparison is false against null).
             list.first = node.next;
             return true;
-        } else {
-            var current_elm = list.first.?;
-            while (current_elm.next) |next| {
-                if (next == node) {
-                    current_elm.next = node.next;
-                    return true;
-                }
-                current_elm = next;
-            }
-            return false;
         }
+        var current_elm = list.first orelse return false;
+        while (current_elm.next) |next| {
+            if (next == node) {
+                current_elm.next = node.next;
+                return true;
+            }
+            current_elm = next;
+        }
+        return false;
     }
 
     /// If this is called, a timer MUST be in either the active list or paused list

--- a/erd_core/src/timer.zig
+++ b/erd_core/src/timer.zig
@@ -69,7 +69,7 @@ pub const Timer = struct {
     /// Callback invoked when the timer expires.
     pub const TimerCallback = *const fn (ctx: ?*anyopaque, _timer_module: *TimerModule, _timer: *Timer) void;
 
-    fn isPeriodic(self: *const Timer) bool {
+    fn isPeriodic(self: *Timer) bool {
         return (self.ctx & 1) == 1;
     }
 
@@ -81,7 +81,7 @@ pub const Timer = struct {
         }
     }
 
-    fn getCtxPtr(self: *const Timer) ?*anyopaque {
+    fn getCtxPtr(self: *Timer) ?*anyopaque {
         return @ptrFromInt(self.ctx & ~@as(usize, 1));
     }
 };
@@ -104,7 +104,7 @@ pub const TimerModule = struct {
         const time_at_start_of_rtc = self.safelyGetCurrentTime();
 
         if (self.active_timers.first) |next_expiring| {
-            const timer: *Timer = @fieldParentPtr("node", next_expiring);
+            var timer: *Timer = @fieldParentPtr("node", next_expiring);
 
             // Expired timers will have a `distance` in the range of [0, longest_delay_before_servicing_timer]
             // This calculation loops over from `std.math.maxInt(Ticks)` to 0.
@@ -147,20 +147,7 @@ pub const TimerModule = struct {
     /// If you get an error, declare your variable as `align(2)` or use a container
     /// struct with larger alignment
     pub fn startOneShot(self: *TimerModule, timer: *Timer, duration: Ticks, ctx: ?*align(2) anyopaque, callback: Timer.TimerCallback) void {
-        self.startInner(timer, duration, ctx, callback, false);
-    }
-
-    /// Starts a periodic timer, with first expiration set to current time + period
-    /// NOTE: `ctx` must be align(2) to allow an `bool` due to optimization reasons
-    /// If you get an error, declare your variable as `align(2)` or use a container
-    /// struct with larger alignment
-    pub fn startPeriodic(self: *TimerModule, timer: *Timer, period: Ticks, ctx: ?*align(2) anyopaque, callback: Timer.TimerCallback) void {
-        self.startInner(timer, period, ctx, callback, true);
-    }
-
-    // zlinter-disable-next-line max_positional_args - thin private helper shared by startOneShot/startPeriodic
-    fn startInner(self: *TimerModule, timer: *Timer, duration: Ticks, ctx: ?*align(2) anyopaque, callback: Timer.TimerCallback, is_periodic: bool) void {
-        sometimes.assert(&@src(), self.active_timers.first == &timer.node); // Re-starting the front-of-queue timer
+        sometimes.assert(&@src(), self.active_timers.first == &timer.node); // Re-starting a periodic as a one-shot
         if (timer.callback != null or self.active_timers.first == &timer.node) {
             self.removeTimer(timer);
         }
@@ -169,9 +156,29 @@ pub const TimerModule = struct {
         timer.ctx = @intFromPtr(ctx);
         timer.callback = callback;
         timer.duration = duration;
-        timer.setIsPeriodic(is_periodic);
+        timer.setIsPeriodic(false);
 
         self.insertTimer(timer, duration);
+    }
+
+    /// Starts a periodic timer, with first expiration set to current time + period
+    /// NOTE: `ctx` must be align(2) to allow an `bool` due to optimization reasons
+    /// If you get an error, declare your variable as `align(2)` or use a container
+    /// struct with larger alignment
+    pub fn startPeriodic(self: *TimerModule, timer: *Timer, period: Ticks, ctx: ?*align(2) anyopaque, callback: Timer.TimerCallback) void {
+        sometimes.assert(&@src(), self.active_timers.first == &timer.node); // Re-starting a periodic as a periodic
+        if (timer.callback != null or self.active_timers.first == &timer.node) {
+            self.removeTimer(timer);
+        }
+
+        std.debug.assert(period <= Timer.max_ticks);
+
+        timer.ctx = @intFromPtr(ctx);
+        timer.callback = callback;
+        timer.duration = period;
+        timer.setIsPeriodic(true);
+
+        self.insertTimer(timer, period);
     }
 
     /// Stops an active or paused timer
@@ -223,18 +230,24 @@ pub const TimerModule = struct {
 
     /// Returns true if a timer is active
     pub fn isActive(self: *TimerModule, timer: *Timer) bool {
-        return listContains(&self.active_timers, &timer.node);
+        var current_elem = self.active_timers.first;
+        while (current_elem != null) {
+            if (current_elem == &timer.node) {
+                return true;
+            }
+            current_elem = current_elem.?.next;
+        }
+        return false;
     }
 
     /// Returns true if a timer is paused
     pub fn isPaused(self: *TimerModule, timer: *Timer) bool {
-        return listContains(&self.paused_timers, &timer.node);
-    }
-
-    fn listContains(list: *const std.SinglyLinkedList, node: *const std.SinglyLinkedList.Node) bool {
-        var current_elem = list.first;
-        while (current_elem) |elem| : (current_elem = elem.next) {
-            if (elem == node) return true;
+        var current_elem = self.paused_timers.first;
+        while (current_elem != null) {
+            if (current_elem == &timer.node) {
+                return true;
+            }
+            current_elem = current_elem.?.next;
         }
         return false;
     }
@@ -261,9 +274,13 @@ pub const TimerModule = struct {
         return timer_module.safelyGetCurrentTime() -% timer_start;
     }
 
-    fn remainingTicksActiveTimer(timer: *const Timer, current_time: Ticks) Ticks {
-        const remaining = timer.timer_data.expiration -% current_time;
-        return if (remaining <= Timer.max_ticks) remaining else 0;
+    fn remainingTicksActiveTimer(timer: *Timer, current_time: Ticks) Ticks {
+        if ((timer.timer_data.expiration -% current_time) <= Timer.max_ticks) {
+            const duration = timer.timer_data.expiration -% current_time;
+            return duration;
+        } else {
+            return 0;
+        }
     }
 
     /// Returns the remaining ticks on a timer, returns 0 if the timer is not running
@@ -325,21 +342,22 @@ pub const TimerModule = struct {
 
     /// std.SinglyLinkedList remove, but returns a bool and is valid to call when the node isn't in the list
     fn tryRemove(list: *std.SinglyLinkedList, node: *std.SinglyLinkedList.Node) bool {
-        if (list.first == node) {
-            // Covers both the "node is at head" case and the "empty list and
-            // node happens to be null" case (the comparison is false against null).
+        if (list.first == null) {
+            return false;
+        } else if (list.first == node) {
             list.first = node.next;
             return true;
-        }
-        var current_elm = list.first orelse return false;
-        while (current_elm.next) |next| {
-            if (next == node) {
-                current_elm.next = node.next;
-                return true;
+        } else {
+            var current_elm = list.first.?;
+            while (current_elm.next) |next| {
+                if (next == node) {
+                    current_elm.next = node.next;
+                    return true;
+                }
+                current_elm = next;
             }
-            current_elm = next;
+            return false;
         }
-        return false;
     }
 
     /// If this is called, a timer MUST be in either the active list or paused list

--- a/erd_schema/src/erd_json_decode.zig
+++ b/erd_schema/src/erd_json_decode.zig
@@ -4,10 +4,11 @@
 //! pretty-prints field names and values. Useful for debug tools, protocol
 //! analyzers, and host-side ERD viewers that receive raw bytes over the wire.
 //!
-//! Lifetime: The root TypeDescriptor returned by `parse()` owns the JSON parse
-//! tree. All string fields (names, variant names, layout) point into that tree.
-//! Child TypeDescriptors allocated for nested types share this lifetime. Do not
-//! use any TypeDescriptor or its string fields after calling `deinit()` on the root.
+//! Lifetime: The root TypeDescriptor returned by `init()` (or
+//! `initFromValue()`) owns the JSON parse tree. All string fields (names,
+//! variant names, layout) point into that tree. Child TypeDescriptors
+//! allocated for nested types share this lifetime. Do not use any
+//! TypeDescriptor or its string fields after calling `deinit()` on the root.
 const builtin = @import("builtin");
 const std = @import("std");
 const native = builtin.cpu.arch.endian();
@@ -176,6 +177,7 @@ pub const TypeDescriptor = struct {
             };
         } else if (std.mem.eql(u8, kind_str, "array")) {
             const elem_td = try allocator.create(TypeDescriptor);
+            errdefer allocator.destroy(elem_td);
             elem_td.* = try fromValue(allocator, obj.get("element").?);
             return .{
                 .kind = .{ .array = .{
@@ -196,9 +198,19 @@ pub const TypeDescriptor = struct {
     fn parseStructValue(allocator: std.mem.Allocator, obj: std.json.ObjectMap) ParseError!TypeDescriptor {
         const fields_arr = obj.get("fields").?.array.items;
         const fields = try allocator.alloc(Field, fields_arr.len);
+        errdefer allocator.free(fields);
+
+        // Free any child TypeDescriptors already constructed if a later iteration fails.
+        var built: usize = 0;
+        errdefer for (fields[0..built]) |*f| {
+            f.type_desc.deinit(allocator);
+            allocator.destroy(f.type_desc);
+        };
+
         for (fields_arr, 0..) |field_val, i| {
             const fo = field_val.object;
             const child_td = try allocator.create(TypeDescriptor);
+            errdefer allocator.destroy(child_td);
             child_td.* = try fromValue(allocator, fo.get("type_descriptor").?);
             fields[i] = .{
                 .name = fo.get("name").?.string,
@@ -210,6 +222,7 @@ pub const TypeDescriptor = struct {
                 .bits = if (fo.get("bits")) |b| @as(?usize, @intCast(b.integer)) else null,
                 .type_desc = child_td,
             };
+            built = i + 1;
         }
         return .{
             .kind = .{ .structure = .{
@@ -240,14 +253,24 @@ pub const TypeDescriptor = struct {
     fn parseUnionValue(allocator: std.mem.Allocator, obj: std.json.ObjectMap) ParseError!TypeDescriptor {
         const fields_arr = obj.get("fields").?.array.items;
         const fields = try allocator.alloc(UnionField, fields_arr.len);
+        errdefer allocator.free(fields);
+
+        var built: usize = 0;
+        errdefer for (fields[0..built]) |*f| {
+            f.type_desc.deinit(allocator);
+            allocator.destroy(f.type_desc);
+        };
+
         for (fields_arr, 0..) |field_val, i| {
             const fo = field_val.object;
             const child_td = try allocator.create(TypeDescriptor);
+            errdefer allocator.destroy(child_td);
             child_td.* = try fromValue(allocator, fo.get("type_descriptor").?);
             fields[i] = .{
                 .name = fo.get("name").?.string,
                 .type_desc = child_td,
             };
+            built = i + 1;
         }
         return .{
             .kind = .{ .@"union" = .{
@@ -306,14 +329,16 @@ pub const TypeDescriptor = struct {
                 try writer.print("\"{s}\"", .{bytes[0..end]});
             },
             .array => |a| {
-                const elem_size = a.size / a.len;
                 try writer.print("[", .{});
-                for (0..a.len) |i| {
-                    if (i > 0) try writer.print(", ", .{});
-                    const start = i * elem_size;
-                    const end_pos = start + elem_size;
-                    if (end_pos <= bytes.len) {
-                        try a.element.formatBytesInner(bytes[start..end_pos], writer, indent);
+                if (a.len > 0) {
+                    const elem_size = a.size / a.len;
+                    for (0..a.len) |i| {
+                        if (i > 0) try writer.print(", ", .{});
+                        const start = i * elem_size;
+                        const end_pos = start + elem_size;
+                        if (end_pos <= bytes.len) {
+                            try a.element.formatBytesInner(bytes[start..end_pos], writer, indent);
+                        }
                     }
                 }
                 try writer.print("]", .{});
@@ -465,12 +490,14 @@ pub const TypeDescriptor = struct {
                 }
             },
             .array => |a| {
-                const elem_size = a.size / a.len;
-                for (0..a.len) |i| {
-                    const start = i * elem_size;
-                    const end = start + elem_size;
-                    if (end <= buf.len) {
-                        a.element.swapBigToNative(buf[start..end]);
+                if (a.len > 0) {
+                    const elem_size = a.size / a.len;
+                    for (0..a.len) |i| {
+                        const start = i * elem_size;
+                        const end = start + elem_size;
+                        if (end <= buf.len) {
+                            a.element.swapBigToNative(buf[start..end]);
+                        }
                     }
                 }
             },
@@ -576,7 +603,12 @@ fn readUnsignedIntGeneric(bytes: []const u8, bits: usize) u64 {
 
 /// Read a signed integer from native-endian bytes with sign extension.
 fn readSignedInt(bytes: []const u8, bits: usize) i64 {
-    const unsigned = readUnsignedInt(bytes, bits);
+    return signExtend(readUnsignedInt(bytes, bits), bits);
+}
+
+/// Sign-extend an N-bit unsigned value to a 64-bit signed value.
+fn signExtend(unsigned: u64, bits: usize) i64 {
+    if (bits == 0) return 0;
     if (bits >= 64) return @bitCast(unsigned);
     const sign_bit = @as(u64, 1) << @intCast(bits - 1);
     if (unsigned & sign_bit != 0) {
@@ -610,14 +642,7 @@ fn readUnsignedIntBig(bytes: []const u8, bits: usize) u64 {
 }
 
 fn readSignedIntBig(bytes: []const u8, bits: usize) i64 {
-    const unsigned = readUnsignedIntBig(bytes, bits);
-    if (bits >= 64) return @bitCast(unsigned);
-    const sign_bit = @as(u64, 1) << @intCast(bits - 1);
-    if (unsigned & sign_bit != 0) {
-        const mask = ~((@as(u64, 1) << @intCast(bits)) - 1);
-        return @bitCast(unsigned | mask);
-    }
-    return @intCast(unsigned);
+    return signExtend(readUnsignedIntBig(bytes, bits), bits);
 }
 
 fn readBits(bytes: []const u8, bit_offset: usize, bit_count: usize) u64 {
@@ -669,6 +694,10 @@ pub const SchemaRegistry = struct {
         const entries = try allocator.alloc(ErdInfo, erd_array.len);
         errdefer allocator.free(entries);
 
+        // If a later iteration fails, free any TypeDescriptors we've already built.
+        var created: usize = 0;
+        errdefer for (entries[0..created]) |*e| e.td.deinit(allocator);
+
         for (erd_array, 0..) |erd_val, i| {
             const obj = erd_val.object;
             const td = try TypeDescriptor.initFromValue(allocator, obj.get("type").?);
@@ -679,6 +708,7 @@ pub const SchemaRegistry = struct {
                 .td = td,
                 .size = td.getSize(),
             };
+            created = i + 1;
         }
 
         return .{ .entries = entries, .allocator = allocator, ._parsed = parsed };

--- a/erd_schema/src/erd_swap.zig
+++ b/erd_schema/src/erd_swap.zig
@@ -5,11 +5,14 @@
 //! between native and wire (big-endian) byte order.
 //!
 //! Usage:
-//!   const rules = comptime SwapRules(MyExternStruct);
-//!   var buf: [@sizeOf(MyExternStruct)]u8 = std.mem.toBytes(value);
-//!   rules.applyToNative(&buf);  // native -> big-endian
-//!   // ... send buf over wire ...
-//!   rules.applyToNative(&buf);  // big-endian -> native (same operation)
+//!   const Rules = SwapRules(MyExternStruct);
+//!   const wire_bytes = Rules.toBig(value);     // native -> big-endian
+//!   // ... send wire_bytes over wire ...
+//!   const native = Rules.fromBig(&wire_bytes); // big-endian -> native
+//!
+//! `toBig`/`fromBig` handle the static fields and the active tagged-union
+//! variant (when present). Lower-level: `apply(buf)` does only the static
+//! field swaps (idempotent), and is what `toBig`/`fromBig` call internally.
 //!
 //! Types with identical swap patterns share the same rule set at comptime.
 //! Single-byte fields (u8, bool, [N]u8 strings) produce no swap rules.
@@ -23,6 +26,18 @@ pub const SwapRule = struct {
     /// Number of bytes to reverse.
     size: u8,
 };
+
+/// Apply a list of swap rules to `buf` in-place. Each rule that fits within the
+/// buffer reverses its byte range; out-of-bounds rules are silently skipped.
+fn applyRules(comptime rules: []const SwapRule, buf: []u8) void {
+    for (rules) |rule| {
+        const start = rule.offset;
+        const end = start + rule.size;
+        if (end <= buf.len) {
+            std.mem.reverse(u8, buf[start..end]);
+        }
+    }
+}
 
 /// Generate swap rules for a specific union variant, offset within a parent struct.
 /// Usage for tagged union pattern (extern struct { tag: enum(u8), payload: extern union }):
@@ -47,13 +62,7 @@ pub fn SwapVariant(UnionType: type, comptime field_name: []const u8, comptime ba
 
         /// Apply byte swaps for this variant in-place.
         pub fn apply(buf: []u8) void {
-            for (swap_rules) |rule| {
-                const start = rule.offset;
-                const end = start + rule.size;
-                if (end <= buf.len) {
-                    std.mem.reverse(u8, buf[start..end]);
-                }
-            }
+            applyRules(&swap_rules, buf);
         }
 
         /// Number of swap rules for this variant.
@@ -74,13 +83,7 @@ pub fn SwapRules(T: type) type {
         /// Apply static byte swaps in-place. Idempotent.
         /// Does NOT handle tagged union variants. Use fromBig/toBig instead.
         pub fn apply(buf: []u8) void {
-            for (swap_rules) |rule| {
-                const start = rule.offset;
-                const end = start + rule.size;
-                if (end <= buf.len) {
-                    std.mem.reverse(u8, buf[start..end]);
-                }
-            }
+            applyRules(&swap_rules, buf);
         }
 
         fn applyTaggedUnions(buf: []u8) void {
@@ -121,13 +124,7 @@ pub fn SwapRules(T: type) type {
                     inline for (union_info.@"union".fields, 0..) |uf, i| {
                         if (tag_val == i) {
                             const variant_rules = comptime generateRules(uf.type, union_offset);
-                            inline for (variant_rules) |rule| {
-                                const start = rule.offset;
-                                const end = start + rule.size;
-                                if (end <= buf.len) {
-                                    std.mem.reverse(u8, buf[start..end]);
-                                }
-                            }
+                            applyRules(variant_rules, buf);
                         }
                     }
                 },

--- a/erd_schema/src/erd_type_gen.zig
+++ b/erd_schema/src/erd_type_gen.zig
@@ -4,7 +4,7 @@
 //! generates a Zig type at comptime. This is idempotent: the same descriptor
 //! always produces a structurally identical type.
 //!
-//! Uses Zig 0.16 builtins: @Int, @Struct, @Enum, @Pointer for type creation.
+//! Uses Zig 0.16 builtins: @Int, @Struct, @Enum, @Union for type creation.
 
 const std = @import("std");
 

--- a/erd_schema/src/tests/erd_json_decode_test.zig
+++ b/erd_schema/src/tests/erd_json_decode_test.zig
@@ -30,6 +30,7 @@ const TdHandle = struct {
 
 fn parseTd(json_str: []const u8) !TdHandle {
     const parsed = try std.json.parseFromSlice(std.json.Value, std.testing.allocator, json_str, .{});
+    errdefer parsed.deinit();
     const td = try TypeDescriptor.init(std.testing.allocator, parsed);
     return .{ .td = td, .parsed = parsed };
 }

--- a/erd_schema/src/tests/erd_json_decode_test.zig
+++ b/erd_schema/src/tests/erd_json_decode_test.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const decode = @import("erd_schema").decode;
 const TypeDescriptor = decode.TypeDescriptor;
+const SchemaRegistry = decode.SchemaRegistry;
 
 const FormatResult = struct {
     str: []const u8,
@@ -247,6 +248,69 @@ test "tagged union struct prints only active variant" {
     var r2 = try format(&h.td, &.{ 0x01, 0x00, 0x2A, 0x00 });
     defer r2.deinit();
     try std.testing.expectEqualStrings("{ tag: err, payload.err: 42 }", r2.str);
+}
+
+test "signed primitive with bits=0 reads as zero" {
+    // Regression: signExtend(0, 0) used to compute `1 << (bits - 1)` which
+    // underflows when bits is a usize equal to 0.
+    var h = try parseTd(
+        \\{"kind":"primitive","name":"i0","size":0,"signedness":"signed","bits":0}
+    );
+    defer h.deinit();
+    var r = try format(&h.td, &.{});
+    defer r.deinit();
+    try std.testing.expectEqualStrings("0", r.str);
+}
+
+test "array with len=0 prints empty brackets" {
+    // Regression: zero-length array used to compute `a.size / a.len`, a div-by-zero.
+    var h = try parseTd(
+        \\{"kind":"array","len":0,"size":0,"element":{"kind":"primitive","name":"u8","size":1,"signedness":"unsigned","bits":8}}
+    );
+    defer h.deinit();
+    var r = try format(&h.td, &.{});
+    defer r.deinit();
+    try std.testing.expectEqualStrings("[]", r.str);
+}
+
+fn parseTdImpl(allocator: std.mem.Allocator, json_str: []const u8) !void {
+    const parsed = try std.json.parseFromSlice(std.json.Value, allocator, json_str, .{});
+    defer parsed.deinit();
+    var td = try TypeDescriptor.init(allocator, parsed);
+    td.deinit(allocator);
+}
+
+const struct_td_json =
+    \\{"kind":"struct","name":"S","layout":"extern","size":4,"fields":[{"name":"a","offset":0,"type_descriptor":{"kind":"primitive","name":"u8","size":1,"signedness":"unsigned","bits":8}},{"name":"b","offset":2,"type_descriptor":{"kind":"primitive","name":"u16","size":2,"signedness":"unsigned","bits":16}}]}
+;
+
+const union_td_json =
+    \\{"kind":"union","name":"U","layout":"extern","size":4,"fields":[{"name":"a","type_descriptor":{"kind":"primitive","name":"u32","size":4,"signedness":"unsigned","bits":32}},{"name":"b","type_descriptor":{"kind":"primitive","name":"i32","size":4,"signedness":"signed","bits":32}}]}
+;
+
+const registry_json =
+    \\{"erds":[{"name":"first","id":"0x0001","type":{"kind":"primitive","name":"u8","size":1,"signedness":"unsigned","bits":8}},{"name":"second","id":"0x0002","type":{"kind":"primitive","name":"u16","size":2,"signedness":"unsigned","bits":16}}]}
+;
+
+test "parseStructValue cleans up on OOM at every allocation point" {
+    try std.testing.checkAllAllocationFailures(std.testing.allocator, parseTdImpl, .{struct_td_json});
+}
+
+test "parseUnionValue cleans up on OOM at every allocation point" {
+    try std.testing.checkAllAllocationFailures(std.testing.allocator, parseTdImpl, .{union_td_json});
+}
+
+fn schemaRegistryImpl(allocator: std.mem.Allocator, json_str: []const u8) !void {
+    const parsed = try std.json.parseFromSlice(std.json.Value, allocator, json_str, .{});
+    var reg = SchemaRegistry.init(allocator, parsed) catch |err| {
+        parsed.deinit();
+        return err;
+    };
+    reg.deinit();
+}
+
+test "SchemaRegistry.init cleans up on OOM at every allocation point" {
+    try std.testing.checkAllAllocationFailures(std.testing.allocator, schemaRegistryImpl, .{registry_json});
 }
 
 test "tagged union with unknown tag value" {

--- a/esp8266/src/system_erds.zig
+++ b/esp8266/src/system_erds.zig
@@ -12,13 +12,10 @@ pub const WifiStatus = enum(u8) { disconnected, connecting, connected, got_ip };
 pub const ComponentId = enum(u8) { ram };
 const Ram = @intFromEnum(ComponentId.ram);
 
-/// Enum for referencing ESP8266 ERDs by name. Must match `ErdDefinitions`
-/// field names 1:1 in order.
+/// Enum for referencing ESP8266 ERDs by name.
+/// Variants are listed out manually (rather than via `std.meta.FieldEnum(ErdDefinitions)`)
+/// so LSP autocomplete works; ordering is checked against `ErdDefinitions` inside `SystemData`.
 pub const ErdEnum = enum {
-    comptime {
-        erd_core.erd_table.validateEnumMatchesDefs(ErdEnum, ErdDefinitions);
-    }
-
     erd_uptime_seconds,
     erd_led_state,
     erd_wifi_mode,

--- a/esp8266/src/system_erds.zig
+++ b/esp8266/src/system_erds.zig
@@ -1,7 +1,6 @@
 //! ERD definitions for the ESP8266 application
 
 const erd_core = @import("erd_core");
-const std = @import("std");
 const Erd = erd_core.Erd;
 
 /// WiFi operating mode.
@@ -13,15 +12,11 @@ pub const WifiStatus = enum(u8) { disconnected, connecting, connected, got_ip };
 pub const ComponentId = enum(u8) { ram };
 const Ram = @intFromEnum(ComponentId.ram);
 
-/// Enum for referencing ESP8266 ERDs by name.
+/// Enum for referencing ESP8266 ERDs by name. Must match `ErdDefinitions`
+/// field names 1:1 in order.
 pub const ErdEnum = enum {
     comptime {
-        const erd_fields = std.meta.fieldNames(ErdDefinitions);
-        const erd_enum_names = std.meta.fieldNames(ErdEnum);
-        for (erd_fields, erd_enum_names) |field_name, enum_name| {
-            if (!std.mem.eql(u8, field_name, enum_name))
-                @compileError(std.fmt.comptimePrint("Field {s} does not match enum {s}", .{ field_name, enum_name }));
-        }
+        erd_core.erd_table.validateEnumMatchesDefs(ErdEnum, ErdDefinitions);
     }
 
     erd_uptime_seconds,
@@ -44,49 +39,17 @@ pub const ErdDefinitions = struct {
     // zig fmt: on
 };
 
-/// ERD definitions with autofilled component and system data indexes.
-pub const erd: ErdDefinitions = blk: {
-    var _erds = ErdDefinitions{};
-    var max_component_idx: comptime_int = 0;
-    for (std.meta.fieldNames(ErdDefinitions)) |erd_field_name| {
-        const idx = @field(_erds, erd_field_name).component_idx;
-        if (idx > max_component_idx) max_component_idx = idx;
-    }
-    var owning_counts = std.mem.zeroes([max_component_idx + 1]u16);
-    for (std.meta.fieldNames(ErdDefinitions)) |erd_field_name| {
-        const idx = @field(_erds, erd_field_name).component_idx;
-        @field(_erds, erd_field_name).data_component_idx = owning_counts[idx];
-        owning_counts[idx] += 1;
-    }
-    std.debug.assert(0xffff == std.math.maxInt(Erd.ErdHandle));
-    for (std.meta.fieldNames(ErdDefinitions), 0..) |erd_field_name, i| {
-        @field(_erds, erd_field_name).system_data_idx = i;
-    }
-    break :blk _erds;
-};
+/// ERD definitions with `data_component_idx` and `system_data_idx` auto-assigned.
+pub const erd: ErdDefinitions = erd_core.erd_table.autofill(ErdDefinitions);
 
 /// Count ERDs belonging to the given component.
 pub fn numErds(comptime id: ComponentId) comptime_int {
-    const component_idx = @intFromEnum(id);
-    var i = 0;
-    for (std.meta.fieldNames(ErdDefinitions)) |erd_name| {
-        if (@field(erd, erd_name).component_idx == component_idx) i += 1;
-    }
-    return i;
+    return erd_core.erd_table.numErdsByComponent(erd, @intFromEnum(id));
 }
 
 /// Extract ERD definitions for a specific component as an array.
 pub fn componentDefinitions(comptime id: ComponentId) [numErds(id)]Erd {
-    const component_idx = @intFromEnum(id);
-    var _erds: [numErds(id)]Erd = undefined;
-    var i = 0;
-    for (std.meta.fieldNames(ErdDefinitions)) |erd_name| {
-        if (@field(erd, erd_name).component_idx == component_idx) {
-            _erds[i] = @field(erd, erd_name);
-            i += 1;
-        }
-    }
-    return _erds;
+    return erd_core.erd_table.collectByComponent(erd, @intFromEnum(id));
 }
 
 /// All RAM component ERD definitions as an array.

--- a/esp8266/src/uart.zig
+++ b/esp8266/src/uart.zig
@@ -2,8 +2,6 @@
 //! Writes directly to the UART0 FIFO register at 74880 baud (the rate
 //! the ROM bootloader leaves UART0 configured at on boot).
 
-const std = @import("std");
-
 // zlinter-disable declaration_naming - hardware register names
 const UART0_FIFO: *volatile u32 = @ptrFromInt(0x60000000);
 const UART0_STATUS: *volatile u32 = @ptrFromInt(0x60000004);
@@ -41,14 +39,6 @@ pub fn dec(val: u32) void {
 
 /// Write a signed 32-bit integer as decimal.
 pub fn sdec(val: i32) void {
-    if (val == std.math.minInt(i32)) {
-        puts("-2147483648");
-        return;
-    }
-    if (val < 0) {
-        putc('-');
-        dec(@intCast(-val));
-    } else {
-        dec(@intCast(val));
-    }
+    if (val < 0) putc('-');
+    dec(@abs(val));
 }


### PR DESCRIPTION
## Claude Summary

Long iterative pass across every package. Bundled as one PR because each
commit is small and self-contained, but the themes overlap. Will be
squash-merged.

Real bug fixes:
- **dup-erd_number bitset off-by-one** in `system_data.zig` — bitset was
  sized to `maxInt(ErdHandle)` (65535 bits), couldn't hold index 65535.
  Latent OOB if anyone ever used `erd_number = 0xFFFF`.
- **errdefer leaks** in `erd_schema` `parseStructValue`/`parseUnionValue`
  and the array branch of `fromValue` — partial allocations would leak
  if a child `TypeDescriptor` allocation later failed.
- **signExtend(0) UB** — `bits - 1` underflowed `usize` before any
  shift. Now early-returns 0.
- **div/0 in formatBytes / swapBigToNative** for empty arrays — empty
  arrays now render as `[]` and round-trip.
- **`_nor` n-ary reduction was wrong** for 3+ inputs (left fold of
  `!(a or b)` doesn't equal n-ary NOR). Fixed, then the operator was
  removed entirely because it's non-associative and mirrors the
  intentional absence of `_nand`.

DRY refactors:
- `erd_table` and `erd_mapping` extracted into shared modules.
  Replaces the duplicated `autofill` blk-loops in 4 places and the
  verbatim `fnFromMappings`/`buildFunctionTable` in
  `converted_data_component.zig` and `indirect_data_component.zig`.
- `read_functions` moved from per-instance field to `const` — table
  now lives in `.rodata`, not RAM.

Test coverage:
- `elf_size`: 0 -> 15 tests covering `emit*` helpers, `parseRegion`
  rejections (trailing parts, empty name, non-hex, zero length,
  overflow), and `formatSummary` too-many-regions.
- `data_gen`: overflow checks in `scaled`/`scaledNearest` via new
  `checkFitsIn`; signed extremes (i16/i8 min, scaled negatives);
  rounding-boundary cases; `noDuplicates` keyed by `std.meta.eql` so
  struct/optional/array/pointer element types work.
- `erd_core`: `erd_table`, `erd_mapping`, `Erd.format`, Subscription
  empty-slot edges, `verifyAllSubsAreSaturated` error + diagnostics
  paths, `ConvertedDataComponent.runtimeRead`.
- Dropped 5 dead `SkipZigTest`-body placeholders; skip count went 97 -> 90.

Other:
- `elf_size`: CLI `main.zig` no longer silently `break`s on overflowing
  `MAX_REGIONS`; reports + exits.
- `Subscription.publish` hoists `args` out of the loop (was being
  rebuilt per callback).
- `tryRemove`/`startInner` consolidations in `timer.zig`.
- Codegen snapshots regenerated for the `.rodata` table move and the
  `Subscription`/timer cleanups.
- App/esp8266 micro-cleanups (`1 << 20` literal, ComponentId loop,
  `sdec` via `@abs`).
- README + CLAUDE.md sync to current API (`modify`, `runtimeRead`,
  `runtimeWrite`, sixth package).
- `region_used` accumulator: explicit `+=` plus
  `std.debug.assert(...)` instead of `+|=` so an impossible overflow
  surfaces rather than silently saturating.

## Test plan
- [x] `zig build test` (root): all packages pass
- [x] `zig build lint` (root): no issues
- [x] `zig build codegen-check`: snapshots match at HEAD