### PR TITLE
Move OnChangeArgs ownership from Subscription to publishers

### DIFF
--- a/erd_core/codegen/ReleaseFast/cross_erd_compute.s
+++ b/erd_core/codegen/ReleaseFast/cross_erd_compute.s
@@ -30,5 +30,5 @@ cross_erd_compute:
         add	rdi, rdx
         add	rdi, 16
         movzx	edx, word ptr [rax + rax + __anon_2]
-        jmp	Subscription.publish
+        jmp	system_data.publishOnChange
 

--- a/erd_core/codegen/ReleaseFast/cross_system_swap.s
+++ b/erd_core/codegen/ReleaseFast/cross_system_swap.s
@@ -27,5 +27,5 @@ cross_system_swap:
         add	rdi, 16
         mov	esi, 1
         xor	edx, edx
-        jmp	Subscription.publish
+        jmp	system_data.publishOnChange
 

--- a/erd_core/codegen/ReleaseFast/double_modify_struct.s
+++ b/erd_core/codegen/ReleaseFast/double_modify_struct.s
@@ -29,5 +29,5 @@ double_modify_struct:
         add	rdi, 312
         mov	esi, 1
         mov	edx, 1
-        jmp	Subscription.publish
+        jmp	system_data.publishOnChange
 

--- a/erd_core/codegen/ReleaseFast/double_write_diff_values.s
+++ b/erd_core/codegen/ReleaseFast/double_write_diff_values.s
@@ -53,5 +53,5 @@ double_write_diff_values:
         add	rdi, rdx
         add	rdi, 16
         movzx	edx, word ptr [rax + rax + __anon_2]
-        jmp	Subscription.publish
+        jmp	system_data.publishOnChange
 

--- a/erd_core/codegen/ReleaseFast/double_write_same_value.s
+++ b/erd_core/codegen/ReleaseFast/double_write_same_value.s
@@ -55,5 +55,5 @@ double_write_same_value:
         add	rdi, rdx
         add	rdi, 16
         movzx	edx, word ptr [rax + rax + __anon_2]
-        jmp	Subscription.publish
+        jmp	system_data.publishOnChange
 

--- a/erd_core/codegen/ReleaseFast/many_write_last_with_subs.s
+++ b/erd_core/codegen/ReleaseFast/many_write_last_with_subs.s
@@ -23,5 +23,5 @@ many_write_last_with_subs:
         add	rdi, 136
         mov	esi, 3
         mov	edx, 31
-        jmp	Subscription.publish
+        jmp	system_data.publishOnChange
 

--- a/erd_core/codegen/ReleaseFast/modify_medium_single_field.s
+++ b/erd_core/codegen/ReleaseFast/modify_medium_single_field.s
@@ -16,5 +16,5 @@ modify_medium_single_field:
         add	rdi, 312
         mov	esi, 1
         mov	edx, 1
-        jmp	Subscription.publish
+        jmp	system_data.publishOnChange
 

--- a/erd_core/codegen/ReleaseFast/modify_medium_two_fields.s
+++ b/erd_core/codegen/ReleaseFast/modify_medium_two_fields.s
@@ -17,5 +17,5 @@ modify_medium_two_fields:
         add	rdi, 312
         mov	esi, 1
         mov	edx, 1
-        jmp	Subscription.publish
+        jmp	system_data.publishOnChange
 

--- a/erd_core/codegen/ReleaseFast/read_write_other_read.s
+++ b/erd_core/codegen/ReleaseFast/read_write_other_read.s
@@ -38,5 +38,5 @@ read_write_other_read:
         add	rdi, rdx
         add	rdi, 16
         movzx	edx, word ptr [rax + rax + __anon_2]
-        jmp	Subscription.publish
+        jmp	system_data.publishOnChange
 

--- a/erd_core/codegen/ReleaseFast/triple_write_increment.s
+++ b/erd_core/codegen/ReleaseFast/triple_write_increment.s
@@ -61,5 +61,5 @@ triple_write_increment:
         add	rdi, rdx
         add	rdi, 16
         movzx	edx, word ptr [rax + rax + __anon_2]
-        jmp	Subscription.publish
+        jmp	system_data.publishOnChange
 

--- a/erd_core/codegen/ReleaseFast/write_bool_with_subs.s
+++ b/erd_core/codegen/ReleaseFast/write_bool_with_subs.s
@@ -29,5 +29,5 @@ write_bool_with_subs:
         add	rdi, rdx
         add	rdi, 16
         movzx	edx, word ptr [rax + rax + __anon_2]
-        jmp	Subscription.publish
+        jmp	system_data.publishOnChange
 

--- a/erd_core/codegen/ReleaseFast/write_junk_read_write.s
+++ b/erd_core/codegen/ReleaseFast/write_junk_read_write.s
@@ -47,5 +47,5 @@ write_junk_read_write:
         add	rdi, rdx
         add	rdi, 16
         movzx	edx, word ptr [rax + rax + __anon_2]
-        jmp	Subscription.publish
+        jmp	system_data.publishOnChange
 

--- a/erd_core/codegen/ReleaseFast/write_ram_flag_with_converted_dep.s
+++ b/erd_core/codegen/ReleaseFast/write_ram_flag_with_converted_dep.s
@@ -29,5 +29,5 @@ write_ram_flag_with_converted_dep:
         add	rdi, rdx
         add	rdi, 8
         movzx	edx, word ptr [rax + rax + __anon_2]
-        jmp	Subscription.publish
+        jmp	system_data.publishOnChange
 

--- a/erd_core/codegen/ReleaseFast/write_ram_with_converted_deps.s
+++ b/erd_core/codegen/ReleaseFast/write_ram_with_converted_deps.s
@@ -28,5 +28,5 @@ write_ram_with_converted_deps:
         add	rdi, rdx
         add	rdi, 8
         movzx	edx, word ptr [rax + rax + __anon_2]
-        jmp	Subscription.publish
+        jmp	system_data.publishOnChange
 

--- a/erd_core/codegen/ReleaseFast/write_then_read_converted.s
+++ b/erd_core/codegen/ReleaseFast/write_then_read_converted.s
@@ -35,5 +35,5 @@ write_then_read_converted:
         add	rdi, rdx
         add	rdi, 8
         movzx	edx, word ptr [rax + rax + __anon_2]
-        jmp	Subscription.publish
+        jmp	system_data.publishOnChange
 

--- a/erd_core/codegen/ReleaseFast/write_triggering_callback.s
+++ b/erd_core/codegen/ReleaseFast/write_triggering_callback.s
@@ -28,5 +28,5 @@ write_triggering_callback:
         add	rdi, rdx
         add	rdi, 16
         movzx	edx, word ptr [rax + rax + __anon_2]
-        jmp	Subscription.publish
+        jmp	system_data.publishOnChange
 

--- a/erd_core/codegen/ReleaseFast/write_u16_with_subs.s
+++ b/erd_core/codegen/ReleaseFast/write_u16_with_subs.s
@@ -28,5 +28,5 @@ write_u16_with_subs:
         add	rdi, rdx
         add	rdi, 16
         movzx	edx, word ptr [rax + rax + __anon_2]
-        jmp	Subscription.publish
+        jmp	system_data.publishOnChange
 

--- a/erd_core/codegen/ReleaseSmall/cross_system_swap.s
+++ b/erd_core/codegen/ReleaseSmall/cross_system_swap.s
@@ -27,5 +27,5 @@ cross_system_swap:
         add	rdi, 16
         mov	esi, 1
         xor	edx, edx
-        jmp	.LSubscription.publish
+        jmp	.Lsystem_data.publishOnChange
 

--- a/erd_core/codegen/ReleaseSmall/double_modify_struct.s
+++ b/erd_core/codegen/ReleaseSmall/double_modify_struct.s
@@ -29,5 +29,5 @@ double_modify_struct:
         add	rdi, 312
         mov	esi, 1
         mov	edx, 1
-        jmp	.LSubscription.publish
+        jmp	.Lsystem_data.publishOnChange
 

--- a/erd_core/codegen/ReleaseSmall/many_write_last_with_subs.s
+++ b/erd_core/codegen/ReleaseSmall/many_write_last_with_subs.s
@@ -23,5 +23,5 @@ many_write_last_with_subs:
         add	rdi, 136
         mov	esi, 3
         mov	edx, 31
-        jmp	.LSubscription.publish
+        jmp	.Lsystem_data.publishOnChange
 

--- a/erd_core/codegen/ReleaseSmall/modify_medium_single_field.s
+++ b/erd_core/codegen/ReleaseSmall/modify_medium_single_field.s
@@ -16,5 +16,5 @@ modify_medium_single_field:
         add	rdi, 312
         mov	esi, 1
         mov	edx, 1
-        jmp	.LSubscription.publish
+        jmp	.Lsystem_data.publishOnChange
 

--- a/erd_core/codegen/ReleaseSmall/modify_medium_two_fields.s
+++ b/erd_core/codegen/ReleaseSmall/modify_medium_two_fields.s
@@ -17,5 +17,5 @@ modify_medium_two_fields:
         add	rdi, 312
         mov	esi, 1
         mov	edx, 1
-        jmp	.LSubscription.publish
+        jmp	.Lsystem_data.publishOnChange
 

--- a/erd_core/codegen/ReleaseSmall/write_ram_flag_with_converted_dep.s
+++ b/erd_core/codegen/ReleaseSmall/write_ram_flag_with_converted_dep.s
@@ -29,5 +29,5 @@ write_ram_flag_with_converted_dep:
         add	rdi, rdx
         add	rdi, 8
         movzx	edx, word ptr [rax + rax + .L__anon_2]
-        jmp	.LSubscription.publish
+        jmp	.Lsystem_data.publishOnChange
 

--- a/erd_core/codegen/mono/ReleaseFast/mixed_modify.s
+++ b/erd_core/codegen/mono/ReleaseFast/mixed_modify.s
@@ -21,5 +21,5 @@ mixed_modify:
         add	rdi, rdx
         add	rdi, 24
         movzx	edx, word ptr [rax + rax + __anon_2]
-        jmp	Subscription.publish
+        jmp	system_data.publishOnChange
 

--- a/erd_core/codegen/mono/ReleaseFast/mixed_write_ram.s
+++ b/erd_core/codegen/mono/ReleaseFast/mixed_write_ram.s
@@ -63,5 +63,5 @@ mixed_write_ram:
         add	rdi, rdx
         add	rdi, 24
         movzx	edx, word ptr [rax + rax + __anon_2]
-        jmp	Subscription.publish
+        jmp	system_data.publishOnChange
 

--- a/erd_core/codegen/mono/ReleaseFast/tiny_modify.s
+++ b/erd_core/codegen/mono/ReleaseFast/tiny_modify.s
@@ -21,5 +21,5 @@ tiny_modify:
         add	rdi, 16
         movzx	edx, word ptr [rax + rax + __anon_1]
         mov	esi, 1
-        jmp	Subscription.publish
+        jmp	system_data.publishOnChange
 

--- a/erd_core/codegen/mono/ReleaseFast/tiny_write_all.s
+++ b/erd_core/codegen/mono/ReleaseFast/tiny_write_all.s
@@ -46,5 +46,5 @@ tiny_write_all:
         add	rdi, 16
         movzx	edx, word ptr [rax + rax + __anon_1]
         mov	esi, 1
-        jmp	Subscription.publish
+        jmp	system_data.publishOnChange
 

--- a/erd_core/codegen/mono/ReleaseFast/wide_modify.s
+++ b/erd_core/codegen/mono/ReleaseFast/wide_modify.s
@@ -21,5 +21,5 @@ wide_modify:
         add	rdi, rdx
         add	rdi, 64
         movzx	edx, word ptr [rax + rax + __anon_2]
-        jmp	Subscription.publish
+        jmp	system_data.publishOnChange
 

--- a/erd_core/codegen/mono/ReleaseFast/wide_write_all.s
+++ b/erd_core/codegen/mono/ReleaseFast/wide_write_all.s
@@ -117,5 +117,5 @@ wide_write_all:
         add	rdi, rdx
         add	rdi, 64
         movzx	edx, word ptr [rax + rax + __anon_2]
-        jmp	Subscription.publish
+        jmp	system_data.publishOnChange
 

--- a/erd_core/codegen/mono/ReleaseSmall/mixed_modify.s
+++ b/erd_core/codegen/mono/ReleaseSmall/mixed_modify.s
@@ -22,5 +22,5 @@ mixed_modify:
         add	rdi, rdx
         add	rdi, 24
         movzx	edx, word ptr [rax + rax + .L__anon_2]
-        jmp	.LSubscription.publish
+        jmp	.Lsystem_data.publishOnChange
 

--- a/erd_core/codegen/mono/ReleaseSmall/mixed_write_ram.s
+++ b/erd_core/codegen/mono/ReleaseSmall/mixed_write_ram.s
@@ -65,5 +65,5 @@ mixed_write_ram:
         add	rdi, rdx
         add	rdi, 24
         movzx	edx, word ptr [rax + rax + .L__anon_2]
-        jmp	.LSubscription.publish
+        jmp	.Lsystem_data.publishOnChange
 

--- a/erd_core/codegen/mono/ReleaseSmall/tiny_modify.s
+++ b/erd_core/codegen/mono/ReleaseSmall/tiny_modify.s
@@ -22,5 +22,5 @@ tiny_modify:
         add	rdi, 16
         movzx	edx, word ptr [rax + rax + .L__anon_1]
         mov	esi, 1
-        jmp	.LSubscription.publish
+        jmp	.Lsystem_data.publishOnChange
 

--- a/erd_core/codegen/mono/ReleaseSmall/tiny_write_all.s
+++ b/erd_core/codegen/mono/ReleaseSmall/tiny_write_all.s
@@ -47,5 +47,5 @@ tiny_write_all:
         add	rdi, 16
         movzx	edx, word ptr [rax + rax + .L__anon_1]
         mov	esi, 1
-        jmp	.LSubscription.publish
+        jmp	.Lsystem_data.publishOnChange
 

--- a/erd_core/codegen/mono/ReleaseSmall/wide_modify.s
+++ b/erd_core/codegen/mono/ReleaseSmall/wide_modify.s
@@ -22,5 +22,5 @@ wide_modify:
         add	rdi, rdx
         add	rdi, 64
         movzx	edx, word ptr [rax + rax + .L__anon_2]
-        jmp	.LSubscription.publish
+        jmp	.Lsystem_data.publishOnChange
 

--- a/erd_core/codegen/mono/ReleaseSmall/wide_write_all.s
+++ b/erd_core/codegen/mono/ReleaseSmall/wide_write_all.s
@@ -137,5 +137,5 @@ wide_write_all:
         add	rdi, rdx
         add	rdi, 64
         movzx	edx, word ptr [rax + rax + .L__anon_2]
-        jmp	.LSubscription.publish
+        jmp	.Lsystem_data.publishOnChange
 

--- a/erd_core/src/Subscription.zig
+++ b/erd_core/src/Subscription.zig
@@ -1,10 +1,19 @@
-//! `Subscription` allows publishers to send events to multiple subscribers.
-//! On publish, each client's callback will receive user provided context (optional), args associated with the publication, and a pointer to the publisher.
-//! `Subscription`s are owned by the publisher, typically in a `comptime` sized array or slice.
+//! `Subscription` provides slot storage and subscribe/unsubscribe machinery
+//! for publishers that want to deliver events to multiple subscribers.
+//! `Subscription`s are owned by the publisher, typically in a `comptime` sized
+//! array or slice.
+//!
+//! Each publisher owns its own args type and its own dispatch helper (see
+//! e.g. `system_data.publishOnChange` and the wire-publisher equivalent),
+//! both of which call subscribers through `Subscription.Callback`. The args
+//! pointer delivered to each subscriber is opaque from `Subscription`'s
+//! perspective: subscribers cast based on the publisher they subscribed to.
+//! Args live only for the duration of dispatch; callbacks must not retain
+//! the pointer.
 //!
 //! The identity of a `Subscription` is solely based on its callback pointer.
 //! `Subscription`s with the same identity cannot be known to the same publisher.
-//! However `Subscription`s with the same identity may subscribe to several source.
+//! However `Subscription`s with the same identity may subscribe to several sources.
 //!
 //! NOTE: Identical Code Folding may break this assumption. If tests/subscriptions
 //!       don't work at higher levels of optimization then try ensuring uniqueness
@@ -13,33 +22,10 @@
 /// Function pointer type for subscription callbacks.
 pub const Callback = *const fn (context: ?*anyopaque, args: ?*const anyopaque, publisher: *anyopaque) void;
 
-/// Payload delivered to on-change callbacks with the ERD index and data pointer.
-pub const OnChangeArgs = struct {
-    system_data_idx: u16,
-    data: *const anyopaque,
-};
-
 context: ?*anyopaque,
 callback: ?Callback,
 
 const Self = @This();
-
-/// Dispatch on-change callbacks to a contiguous subscription slot range.
-/// Iterates `slots` in index order and invokes every non-null callback.
-/// All callbacks see the same `OnChangeArgs` pointer (built once before
-/// the loop); the args live only for the duration of `publish`, so
-/// callbacks must not retain it. Empty slots are skipped.
-/// Shared across all DataComponent instantiations to avoid monomorphization.
-pub noinline fn publish(slots: []Self, system_data_idx: u16, data: *const anyopaque, publisher: *anyopaque) void {
-    const args: OnChangeArgs = .{
-        .system_data_idx = system_data_idx,
-        .data = data,
-    };
-    for (slots) |*sub| {
-        const cb = sub.callback orelse continue;
-        cb(sub.context, @ptrCast(&args), publisher);
-    }
-}
 
 /// Add a subscription callback. Deduplicates by callback identity (a
 /// second subscribe with the same `callback` keeps the original `context`
@@ -101,31 +87,7 @@ fn cbC(_: ?*anyopaque, _: ?*const anyopaque, _: *anyopaque) void {
     cb_c_calls += 1;
 }
 
-fn resetCallCounts() void {
-    cb_a_calls = 0;
-    cb_b_calls = 0;
-    cb_c_calls = 0;
-}
-
 const empty: Self = .{ .context = null, .callback = null };
-
-const CapturedArgs = struct {
-    invocations: u32 = 0,
-    system_data_idx: u16 = 0,
-    data: ?*const anyopaque = null,
-    publisher: ?*anyopaque = null,
-    context_seen: ?*anyopaque = null,
-};
-
-fn capturingCallback(context: ?*anyopaque, args: ?*const anyopaque, publisher: *anyopaque) void {
-    const captured: *CapturedArgs = @ptrCast(@alignCast(context.?));
-    const change: *const OnChangeArgs = @ptrCast(@alignCast(args));
-    captured.invocations += 1;
-    captured.system_data_idx = change.system_data_idx;
-    captured.data = change.data;
-    captured.publisher = publisher;
-    captured.context_seen = context;
-}
 
 test "subscribe stores callback in first free slot" {
     var slots = [_]Self{empty} ** 3;
@@ -195,64 +157,6 @@ test "unsubscribe is a no-op when callback is not present" {
     try expectEqual(null, slots[1].callback);
 }
 
-test "publish invokes every populated slot, skips empty slots" {
-    cb_a_calls = 0;
-    cb_c_calls = 0;
-    var slots = [_]Self{
-        .{ .context = null, .callback = cbA },
-        empty,
-        .{ .context = null, .callback = cbC },
-    };
-    var payload: u8 = 0;
-    var publisher: u8 = 0;
-
-    publish(&slots, 0, &payload, &publisher);
-
-    try expectEqual(1, cb_a_calls);
-    try expectEqual(1, cb_c_calls);
-}
-
-test "publish passes system_data_idx, data, publisher, and context to callback" {
-    var captured: CapturedArgs = .{};
-    var slots = [_]Self{.{ .context = &captured, .callback = capturingCallback }};
-    var payload: u32 = 0xABCD;
-    var publisher: u32 = 0;
-
-    publish(&slots, 7, &payload, &publisher);
-
-    try expectEqual(1, captured.invocations);
-    try expectEqual(7, captured.system_data_idx);
-    try expectEqual(@as(*const anyopaque, &payload), captured.data);
-    try expectEqual(@as(*anyopaque, &publisher), captured.publisher);
-    try expectEqual(@as(*anyopaque, &captured), captured.context_seen);
-}
-
-test "publish tolerates a hole created by unsubscribe" {
-    resetCallCounts();
-    var slots = [_]Self{empty} ** 3;
-
-    subscribe(&slots, null, cbA);
-    subscribe(&slots, null, cbB);
-    subscribe(&slots, null, cbC);
-    unsubscribe(&slots, cbB);
-
-    try expectEqual(null, slots[1].callback);
-
-    var payload: u8 = 0;
-    var publisher: u8 = 0;
-    publish(&slots, 0, &payload, &publisher);
-
-    try expectEqual(1, cb_a_calls);
-    try expectEqual(0, cb_b_calls);
-    try expectEqual(1, cb_c_calls);
-}
-
-test "publish on empty slot slice does nothing" {
-    var slots = [_]Self{};
-    var publisher: u32 = 0;
-    publish(&slots, 0, &publisher, &publisher);
-}
-
 test "subscribe then unsubscribe then subscribe reuses slot" {
     var slots = [_]Self{empty} ** 2;
 
@@ -268,17 +172,4 @@ test "unsubscribe on empty slot slice is a no-op" {
     var slots = [_]Self{};
     unsubscribe(&slots, cbA);
     // No assertion needed: must simply not panic / OOB.
-}
-
-test "publish on all-empty slot slice invokes no callbacks" {
-    resetCallCounts();
-    var slots = [_]Self{empty} ** 3;
-    var publisher: u8 = 0;
-    var payload: u8 = 0;
-
-    publish(&slots, 0, &payload, &publisher);
-
-    try expectEqual(0, cb_a_calls);
-    try expectEqual(0, cb_b_calls);
-    try expectEqual(0, cb_c_calls);
 }

--- a/erd_core/src/Subscription.zig
+++ b/erd_core/src/Subscription.zig
@@ -3,13 +3,13 @@
 //! `Subscription`s are owned by the publisher, typically in a `comptime` sized
 //! array or slice.
 //!
-//! Each publisher owns its own args type and its own dispatch helper (see
-//! e.g. `system_data.publishOnChange` and the wire-publisher equivalent),
-//! both of which call subscribers through `Subscription.Callback`. The args
-//! pointer delivered to each subscriber is opaque from `Subscription`'s
-//! perspective: subscribers cast based on the publisher they subscribed to.
-//! Args live only for the duration of dispatch; callbacks must not retain
-//! the pointer.
+//! Each publisher defines its own args type and its own dispatch helper (see
+//! e.g. `system_data.publishOnChange`), both of which call subscribers
+//! through `Subscription.Callback`. The args pointer delivered to each subscriber
+//! is opaque from `Subscription`'s perspective: subscribers cast based on the
+//! publisher they subscribed to.
+//!
+//! NOTE: Callbacks must not retain the `args` pointer
 //!
 //! The identity of a `Subscription` is solely based on its callback pointer.
 //! `Subscription`s with the same identity cannot be known to the same publisher.
@@ -22,6 +22,8 @@
 /// Function pointer type for subscription callbacks.
 pub const Callback = *const fn (context: ?*anyopaque, args: ?*const anyopaque, publisher: *anyopaque) void;
 
+/// Client provided data that is known to `callback`, typically an instance struct. Allows for
+/// a shared `callback` for different instantiations of the same object (as opposed to static access).
 context: ?*anyopaque,
 callback: ?Callback,
 

--- a/erd_core/src/codegen_harness.zig
+++ b/erd_core/src/codegen_harness.zig
@@ -321,7 +321,7 @@ export fn read_across_two_erds(sd: *SmallSD) u32 {
 // ===========================================================================
 
 fn accumulate_callback(_: ?*anyopaque, _args: ?*const anyopaque, publisher: *anyopaque) void {
-    const args: *const SmallSD.OnChangeArgs = @ptrCast(@alignCast(_args.?));
+    const args: *const erd_core.system_data.OnChangeArgs = @ptrCast(@alignCast(_args.?));
     const sd: *SmallSD = @ptrCast(@alignCast(publisher));
     const written_val: *const bool = @ptrCast(args.data);
     if (written_val.*) {

--- a/erd_core/src/common/timer_stats.zig
+++ b/erd_core/src/common/timer_stats.zig
@@ -9,10 +9,12 @@
 //! `average_latency` = 0
 //! `maximum_latency` = 1
 
+const erd_core = @import("erd_core");
 const std = @import("std");
-const timer = @import("erd_core").timer;
+const timer = erd_core.timer;
 const Timer = timer.Timer;
 const TimerModule = timer.TimerModule;
+const OnChangeArgs = erd_core.system_data.OnChangeArgs;
 
 /// Throughput and latency measurement results for the timer module.
 pub const StatMeasurement = struct {
@@ -63,7 +65,7 @@ pub fn TimerModuleStats(SystemDataType: type) type {
         }
 
         fn onEnableChange(ctx: ?*anyopaque, _args: ?*const anyopaque, publisher: *anyopaque) void {
-            const args: *const SystemDataType.OnChangeArgs = @ptrCast(@alignCast(_args.?));
+            const args: *const OnChangeArgs = @ptrCast(@alignCast(_args.?));
             const system_data: *SystemDataType = @ptrCast(@alignCast(publisher));
             const self: *Self = @ptrCast(@alignCast(ctx));
             const is_enabled: *const bool = @ptrCast(args.data);
@@ -111,13 +113,12 @@ pub fn TimerModuleStats(SystemDataType: type) type {
             // value so the stats timers reflect ERD state at init time.
             var is_enabled: bool = undefined;
             system_data.runtimeRead(enable_erd_idx, &is_enabled);
-            const init_data: SystemDataType.OnChangeArgs = .{ .data = &is_enabled, .system_data_idx = enable_erd_idx };
+            const init_data: OnChangeArgs = .{ .data = &is_enabled, .system_data_idx = enable_erd_idx };
             onEnableChange(self, &init_data, system_data);
         }
     };
 }
 
-const erd_core = @import("erd_core");
 const Erd = erd_core.Erd;
 const SystemDataTestDouble = erd_core.testing.SystemDataTestDouble;
 

--- a/erd_core/src/converted_data_component.zig
+++ b/erd_core/src/converted_data_component.zig
@@ -11,6 +11,7 @@
 const erd_core = @import("erd_core");
 const erd_mapping = erd_core.erd_mapping;
 const std = @import("std");
+const system_data = @import("system_data.zig");
 const Erd = erd_core.Erd;
 const Subscription = erd_core.Subscription;
 const DataComponentSubscription = erd_core.data_component.subscription_mixin.DataComponentSubscription;
@@ -109,7 +110,7 @@ pub fn ConvertedDataComponent(comptime erds: []const Erd, comptime erd_mappings:
                     fnPtr(&val, publisher);
                     if (erd.subs > 0) {
                         const offset = Subs.sub_offsets[erd_data_component_idx];
-                        Subscription.publish(
+                        system_data.publishOnChange(
                             self.subs.slots[offset..][0..erd.subs],
                             erd.system_data_idx,
                             @ptrCast(&val),

--- a/erd_core/src/ram_data_component.zig
+++ b/erd_core/src/ram_data_component.zig
@@ -172,11 +172,8 @@ pub fn RamDataComponent(comptime erds: []const Erd) type {
         }
 
         // noinline so the dispatch logic is shared across all call sites.
-        // Resolves per-type lookup tables, then tail-jumps into the shared
-        // OnChangeArgs dispatcher. Args fields are passed individually so the
-        // call site is a pure register-shuffle + jmp (struct-by-value would
-        // force a hidden indirect under the Zig ABI).
-        // TODO: Add the option to binary search and avoid a large chunk of this cost
+        // TODO: Add the option to binary search to save space in `subs_from_idx`
+        //   for ERDs with no subscribers
         noinline fn publish(self: *Self, data_component_idx: u16, data: *const anyopaque, publisher: *anyopaque) void {
             const offset = Subs.sub_offsets[data_component_idx];
             const count = subs_from_idx[data_component_idx];

--- a/erd_core/src/ram_data_component.zig
+++ b/erd_core/src/ram_data_component.zig
@@ -7,8 +7,8 @@
 
 const erd_core = @import("erd_core");
 const std = @import("std");
+const system_data = @import("system_data.zig");
 const Erd = erd_core.Erd;
-const Subscription = erd_core.Subscription;
 const DataComponentSubscription = erd_core.data_component.subscription_mixin.DataComponentSubscription;
 
 /// Construct a RAM-backed data component with packed byte-array storage.
@@ -172,12 +172,15 @@ pub fn RamDataComponent(comptime erds: []const Erd) type {
         }
 
         // noinline so the dispatch logic is shared across all call sites.
-        // Resolves per-type lookup tables then delegates to the shared Subscription.publish.
+        // Resolves per-type lookup tables, then tail-jumps into the shared
+        // OnChangeArgs dispatcher. Args fields are passed individually so the
+        // call site is a pure register-shuffle + jmp (struct-by-value would
+        // force a hidden indirect under the Zig ABI).
         // TODO: Add the option to binary search and avoid a large chunk of this cost
         noinline fn publish(self: *Self, data_component_idx: u16, data: *const anyopaque, publisher: *anyopaque) void {
             const offset = Subs.sub_offsets[data_component_idx];
             const count = subs_from_idx[data_component_idx];
-            Subscription.publish(
+            system_data.publishOnChange(
                 self.subs.slots[offset..][0..count],
                 system_data_idx_from_idx[data_component_idx],
                 data,

--- a/erd_core/src/root.zig
+++ b/erd_core/src/root.zig
@@ -7,7 +7,8 @@ pub const Erd = @import("Erd.zig");
 pub const erd_mapping = @import("erd_mapping.zig");
 pub const erd_table = @import("erd_table.zig");
 pub const Subscription = @import("Subscription.zig");
-pub const SystemData = @import("system_data.zig").SystemData;
+pub const system_data = @import("system_data.zig");
+pub const SystemData = system_data.SystemData;
 
 pub const data_component = struct {
     pub const Ram = @import("ram_data_component.zig").RamDataComponent;

--- a/erd_core/src/system_data.zig
+++ b/erd_core/src/system_data.zig
@@ -19,6 +19,34 @@ const std = @import("std");
 const Erd = erd_core.Erd;
 const Subscription = erd_core.Subscription;
 
+/// Args delivered to subscribers of data-component ERDs. Each publisher owns
+/// its own args type; this is SystemData's. Lives at file scope (not inside
+/// the SystemData generic) so data components and other modules can import
+/// the type without instantiating SystemData.
+pub const OnChangeArgs = struct {
+    /// system_data_idx of the ERD whose value changed.
+    system_data_idx: u16,
+    /// Pointer to the ERD's new value, as raw bytes.
+    data: *const anyopaque,
+};
+
+/// Shared noinline dispatcher for SystemData-shaped publishes. Takes the
+/// `OnChangeArgs` *fields* individually -- Zig's struct-by-value ABI tends
+/// to insert a hidden indirect pointer for `OnChangeArgs`, which prevents
+/// callers (RAM/Converted data components) from tail-jumping. Passing the
+/// fields as separate register-sized parameters keeps the call site a pure
+/// arg-shuffle + jmp.
+///
+/// The args struct is built inside this dispatcher; the pointer handed to
+/// each subscriber is valid only for the duration of the dispatch.
+pub noinline fn publishOnChange(slots: []Subscription, system_data_idx: u16, data: *const anyopaque, publisher: *anyopaque) void {
+    const args: OnChangeArgs = .{ .system_data_idx = system_data_idx, .data = data };
+    for (slots) |*sub| {
+        const cb = sub.callback orelse continue;
+        cb(sub.context, @ptrCast(&args), publisher);
+    }
+}
+
 /// Construct a typed pub-sub system data aggregator from ERD definitions and components.
 pub fn SystemData(ErdDefs: type, ErdEnum: type, comptime erd_instance: ErdDefs, Components: type) type {
     comptime {
@@ -64,7 +92,7 @@ pub fn SystemData(ErdDefs: type, ErdEnum: type, comptime erd_instance: ErdDefs, 
         const Self = @This();
 
         /// Arguments passed to on-change subscription callbacks.
-        pub const OnChangeArgs = Subscription.OnChangeArgs;
+        pub const OnChangeArgs = @import("system_data.zig").OnChangeArgs;
 
         /// A test only type used with verifyAllSubsAreSaturated
         pub const SubException = struct { erd_enum: ErdEnum, missing: comptime_int };

--- a/erd_core/src/system_data.zig
+++ b/erd_core/src/system_data.zig
@@ -91,9 +91,6 @@ pub fn SystemData(ErdDefs: type, ErdEnum: type, comptime erd_instance: ErdDefs, 
     return struct {
         const Self = @This();
 
-        /// Arguments passed to on-change subscription callbacks.
-        pub const OnChangeArgs = @import("system_data.zig").OnChangeArgs;
-
         /// A test only type used with verifyAllSubsAreSaturated
         pub const SubException = struct { erd_enum: ErdEnum, missing: comptime_int };
 

--- a/erd_core/src/tests/converted_data_component_test.zig
+++ b/erd_core/src/tests/converted_data_component_test.zig
@@ -83,7 +83,7 @@ var subscriber_received_value: u16 = 0;
 var subscriber_call_count: u32 = 0;
 
 fn testSubscriber(_: ?*anyopaque, _args: ?*const anyopaque, _: *anyopaque) void {
-    const args: *const SystemData.OnChangeArgs = @ptrCast(@alignCast(_args.?));
+    const args: *const erd_core.system_data.OnChangeArgs = @ptrCast(@alignCast(_args.?));
     const val: *const u16 = @ptrCast(@alignCast(args.data));
     subscriber_received_value = val.*;
     subscriber_call_count += 1;
@@ -155,7 +155,7 @@ test "converted ERD with no subscribers still computes on read" {
 var cascaded_value: u16 = 0;
 
 fn cascadeSubscriber(_: ?*anyopaque, _args: ?*const anyopaque, publisher: *anyopaque) void {
-    const args: *const SystemData.OnChangeArgs = @ptrCast(@alignCast(_args.?));
+    const args: *const erd_core.system_data.OnChangeArgs = @ptrCast(@alignCast(_args.?));
     const val: *const u16 = @ptrCast(@alignCast(args.data));
     const sd: *SystemData = @ptrCast(@alignCast(publisher));
 

--- a/erd_core/src/tests/system_data_test.zig
+++ b/erd_core/src/tests/system_data_test.zig
@@ -121,7 +121,7 @@ test "subscription with context" {
 }
 
 fn contextMustMatchArgs(context: ?*anyopaque, _args: ?*const anyopaque, publisher: *anyopaque) void {
-    const args: *const SystemData.OnChangeArgs = @ptrCast(@alignCast(_args.?));
+    const args: *const erd_core.system_data.OnChangeArgs = @ptrCast(@alignCast(_args.?));
     const system_data: *SystemData = @ptrCast(@alignCast(publisher));
 
     const a: *u16 = @ptrCast(@alignCast(context.?));
@@ -148,7 +148,7 @@ test "subscription with args" {
 }
 
 fn switchOnSystemDataIdx(_: ?*anyopaque, _args: ?*const anyopaque, publisher: *anyopaque) void {
-    const args: *const SystemData.OnChangeArgs = @ptrCast(@alignCast(_args.?));
+    const args: *const erd_core.system_data.OnChangeArgs = @ptrCast(@alignCast(_args.?));
     const system_data: *SystemData = @ptrCast(@alignCast(publisher));
 
     if (args.system_data_idx != SystemData.erdFromEnum(.some_bool).system_data_idx) {
@@ -235,7 +235,7 @@ test "exact subscription enforcement" {
 }
 
 fn scratchAllocating(_: ?*anyopaque, _args: ?*const anyopaque, publisher: *anyopaque) void {
-    const args: *const SystemData.OnChangeArgs = @ptrCast(@alignCast(_args.?));
+    const args: *const erd_core.system_data.OnChangeArgs = @ptrCast(@alignCast(_args.?));
     const system_data: *SystemData = @ptrCast(@alignCast(publisher));
 
     const val: *const u16 = @ptrCast(@alignCast(args.data));
@@ -281,7 +281,7 @@ var modify_publish_count: u32 = 0;
 var modify_last_value: FourField = undefined;
 
 fn captureBox(_: ?*anyopaque, _args: ?*const anyopaque, _: *anyopaque) void {
-    const args: *const ModifySD.OnChangeArgs = @ptrCast(@alignCast(_args.?));
+    const args: *const erd_core.system_data.OnChangeArgs = @ptrCast(@alignCast(_args.?));
     const val: *const FourField = @ptrCast(@alignCast(args.data));
     modify_publish_count += 1;
     modify_last_value = val.*;

--- a/esp8266/src/application.zig
+++ b/esp8266/src/application.zig
@@ -49,7 +49,7 @@ pub fn init(app: *Application) void {
 }
 
 fn onLedStateChanged(_: ?*anyopaque, args: ?*const anyopaque, _: *anyopaque) void {
-    const on_change: *const SystemData.OnChangeArgs = @ptrCast(@alignCast(args.?));
+    const on_change: *const erd_core.system_data.OnChangeArgs = @ptrCast(@alignCast(args.?));
     const led_state: *const bool = @ptrCast(@alignCast(on_change.data));
     hardware.setLed(led_state.*);
 }

--- a/esp8266/src/application.zig
+++ b/esp8266/src/application.zig
@@ -49,7 +49,7 @@ pub fn init(app: *Application) void {
 }
 
 fn onLedStateChanged(_: ?*anyopaque, args: ?*const anyopaque, _: *anyopaque) void {
-    const on_change: *const erd_core.Subscription.OnChangeArgs = @ptrCast(@alignCast(args.?));
+    const on_change: *const SystemData.OnChangeArgs = @ptrCast(@alignCast(args.?));
     const led_state: *const bool = @ptrCast(@alignCast(on_change.data));
     hardware.setLed(led_state.*);
 }


### PR DESCRIPTION
## Summary

Light refactor of `OnChangeArgs` from being `Subscription.OnChangeArgs` to `publisher.OnChangeArgs`. Now those details no longer leak out into the interface of `Subscription`. There are also some changes to where each publisher is responsible for implementing the `publish` (as opposed to calling `Subscription.publish`) in order to retain tail-call optimized publishes.