### PR TITLE
timer: noinline methods that fail to inline at 2+ call sites

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -115,6 +115,7 @@ pub fn build(b: *std.Build) void {
             .exclude = &.{
                 b.path("erd_core/src/codegen_harness.zig"),
                 b.path("erd_core/src/codegen_mono_stress.zig"),
+                b.path("erd_core/src/codegen_timer.zig"),
                 b.path("zig-out"),
                 b.path(".zig-cache"),
                 b.path("erd_core/zig-out"),

--- a/erd_core/build_codegen.zig
+++ b/erd_core/build_codegen.zig
@@ -28,6 +28,7 @@ pub fn setup(b: *std.Build, target: std.Build.ResolvedTarget, optimize: std.buil
         const harnesses = [_]Harness{
             .{ .source = "src/codegen_harness.zig", .prefix = "", .obj_tag = "harness" },
             .{ .source = "src/codegen_mono_stress.zig", .prefix = "mono/", .obj_tag = "mono" },
+            .{ .source = "src/codegen_timer.zig", .prefix = "timer/", .obj_tag = "timer" },
         };
 
         for (modes, mode_names) |mode, mode_name| {
@@ -116,6 +117,7 @@ pub fn setup(b: *std.Build, target: std.Build.ResolvedTarget, optimize: std.buil
     const emit_sources = [_]struct { source: []const u8, output: []const u8 }{
         .{ .source = "src/codegen_harness.zig", .output = "codegen_harness.s" },
         .{ .source = "src/codegen_mono_stress.zig", .output = "codegen_mono_stress.s" },
+        .{ .source = "src/codegen_timer.zig", .output = "codegen_timer.s" },
     };
     for (emit_sources) |src| {
         const mod = b.createModule(.{

--- a/erd_core/codegen/ReleaseFast/setup_timer_callback.s
+++ b/erd_core/codegen/ReleaseFast/setup_timer_callback.s
@@ -2,81 +2,37 @@
 ; Speed: Optimal | Size: Optimal (until 2 calls)
 ;
 setup_timer_callback:
-        mov	rcx, qword ptr [rsi]
-        lea	rax, [rdx + 16]
-        cmp	qword ptr [rdx + 8], 0
-        setne	r8b
-        cmp	rcx, rax
-        sete	r9b
-        or	r9b, r8b
-        je	.L0
-        test	rcx, rcx
-        je	.L1
-        mov	r8, rsi
-        cmp	rcx, rax
-        je	.L2
-.L3:
-        mov	r9, qword ptr [rcx]
-        test	r9, r9
-        je	.L1
-        mov	r8, rcx
-        mov	rcx, r9
-        cmp	r9, rax
-        jne	.L3
-        jmp	.L2
-.L1:
-        mov	rcx, qword ptr [rsi + 8]
-        test	rcx, rcx
-        je	.L0
-        cmp	rcx, rax
-        je	.L4
-.L5:
-        mov	r9, qword ptr [rcx]
-        test	r9, r9
-        je	.L0
-        mov	r8, rcx
-        mov	rcx, r9
-        cmp	r9, rax
-        jne	.L5
-        jmp	.L2
-.L4:
-        lea	r8, [rsi + 8]
-.L2:
-        mov	rcx, qword ptr [rax]
-        mov	qword ptr [r8], rcx
+        mov	rax, rdi
+        mov	rdi, rsi
+        mov	rsi, rdx
+        mov	rdx, rax
+        jmp	timer.TimerModule.startPeriodic
+
+; --- called functions ---
+
+timer.TimerModule.startPeriodic:
+        push	r15
+        push	r14
+        push	rbx
+        mov	rbx, rdx
+        cmp	qword ptr [rsi + 8], 0
+        jne	.L0
+        lea	rax, [rsi + 16]
+        cmp	qword ptr [rdi], rax
+        jne	.L1
 .L0:
-        mov	qword ptr [rdx + 8], offset codegen_harness.timer_callback_read_write
-        mov	dword ptr [rdx + 28], 100
-        or	rdi, 1
-        mov	qword ptr [rdx], rdi
-        mov	edi, dword ptr [rsi + 16]
-        lea	ecx, [rdi + 100]
-        mov	dword ptr [rdx + 24], ecx
-        mov	rcx, qword ptr [rsi]
-        test	rcx, rcx
-        je	.L6
-        mov	edx, dword ptr [rcx + 8]
-        sub	edx, edi
-        add	edx, -101
-        cmp	edx, -65636
-        jb	.L7
-.L8:
-        mov	rsi, rcx
-        mov	rcx, qword ptr [rcx]
-        test	rcx, rcx
-        je	.L6
-        mov	edx, dword ptr [rcx + 8]
-        sub	edx, edi
-        add	edx, 65535
-        cmp	edx, 65636
-        jb	.L8
-.L7:
-        mov	qword ptr [rax], rcx
-        mov	qword ptr [rsi], rax
-        ret
-.L6:
-        xor	ecx, ecx
-        mov	qword ptr [rax], rcx
-        mov	qword ptr [rsi], rax
-        ret
+        mov	r14, rdi
+        mov	r15, rsi
+        call	timer.TimerModule.removeTimer
+        mov	rdi, r14
+        mov	rsi, r15
+.L1:
+        mov	qword ptr [rsi + 8], offset codegen_harness.timer_callback_read_write
+        mov	dword ptr [rsi + 28], 100
+        or	rbx, 1
+        mov	qword ptr [rsi], rbx
+        pop	rbx
+        pop	r14
+        pop	r15
+        jmp	timer.TimerModule.insertTimer
 

--- a/erd_core/codegen/ReleaseFast_x86_64.sizes
+++ b/erd_core/codegen/ReleaseFast_x86_64.sizes
@@ -35,6 +35,7 @@
 14	dual_write
 14	read_converted_flag_inv
 14	read_converted_sum
+14	setup_timer_callback
 17	read_then_branch
 18	read_ram_then_converted
 19	read_big_struct
@@ -63,4 +64,3 @@
 109	double_write_same_value
 114	write_junk_read_write
 173	triple_write_increment
-222	setup_timer_callback

--- a/erd_core/codegen/ReleaseSmall/setup_timer_callback.s
+++ b/erd_core/codegen/ReleaseSmall/setup_timer_callback.s
@@ -2,91 +2,37 @@
 ; Speed: Near-optimal | Size: Optimal (until 2 calls)
 ;
 setup_timer_callback:
-        push	r15
-        push	r14
-        push	r12
-        push	rbx
-        push	rax
-        mov	r15, rdx
-        mov	r14, rsi
-        mov	r12, rdi
-        lea	rbx, [rdx + 16]
-        cmp	qword ptr [rdx + 8], 0
-        je	.L0
-.L1:
-        mov	rdi, r14
-        mov	rsi, rbx
-        call	.Ltimer.TimerModule.tryRemove
-        test	al, 1
-        jne	.L2
-        lea	rdi, [r14 + 8]
-        mov	rsi, rbx
-        call	.Ltimer.TimerModule.tryRemove
-        jmp	.L2
-.L0:
-        cmp	qword ptr [r14], rbx
-        je	.L1
-.L2:
-        mov	qword ptr [r15 + 8], offset .Lcodegen_harness.timer_callback_read_write
-        mov	dword ptr [r15 + 28], 100
-        or	r12, 1
-        mov	qword ptr [r15], r12
-        mov	ecx, dword ptr [r14 + 16]
-        lea	eax, [rcx + 100]
-        mov	dword ptr [r15 + 24], eax
-        mov	rax, qword ptr [r14]
-        test	rax, rax
-        je	.L3
-        mov	edx, dword ptr [rax + 8]
-        sub	edx, ecx
-        add	edx, -101
-        cmp	edx, -65636
-        jb	.L4
-.L5:
-        mov	r14, rax
-        mov	rax, qword ptr [rax]
-        test	rax, rax
-        je	.L3
-        mov	edx, dword ptr [rax + 8]
-        sub	edx, ecx
-        add	edx, 65535
-        cmp	edx, 65636
-        jb	.L5
-        jmp	.L4
-.L3:
-        xor	eax, eax
-.L4:
-        mov	qword ptr [rbx], rax
-        mov	qword ptr [r14], rbx
-        add	rsp, 8
-        pop	rbx
-        pop	r12
-        pop	r14
-        pop	r15
-        ret
+        mov	rax, rdi
+        mov	rdi, rsi
+        mov	rsi, rdx
+        mov	rdx, rax
+        jmp	.Ltimer.TimerModule.startPeriodic
 
 ; --- called functions ---
 
-.Ltimer.TimerModule.tryRemove:
-        mov	rax, qword ptr [rdi]
-        test	rax, rax
-        je	.L6
-        cmp	rax, rsi
-        je	.L7
-.L8:
-        mov	rcx, qword ptr [rax]
-        test	rcx, rcx
-        je	.L6
-        mov	rdi, rax
-        mov	rax, rcx
-        cmp	rcx, rsi
-        jne	.L8
-.L7:
-        mov	rax, qword ptr [rsi]
-        mov	qword ptr [rdi], rax
-        mov	al, 1
-        ret
-.L6:
-        xor	eax, eax
-        ret
+.Ltimer.TimerModule.startPeriodic:
+        push	r15
+        push	r14
+        push	rbx
+        mov	rbx, rdx
+        cmp	qword ptr [rsi + 8], 0
+        jne	.L0
+        lea	rax, [rsi + 16]
+        cmp	qword ptr [rdi], rax
+        jne	.L1
+.L0:
+        mov	r14, rdi
+        mov	r15, rsi
+        call	.Ltimer.TimerModule.removeTimer
+        mov	rdi, r14
+        mov	rsi, r15
+.L1:
+        mov	qword ptr [rsi + 8], offset .Lcodegen_harness.timer_callback_read_write
+        mov	dword ptr [rsi + 28], 100
+        or	rbx, 1
+        mov	qword ptr [rsi], rbx
+        pop	rbx
+        pop	r14
+        pop	r15
+        jmp	.Ltimer.TimerModule.insertTimer
 

--- a/erd_core/codegen/ReleaseSmall_x86_64.sizes
+++ b/erd_core/codegen/ReleaseSmall_x86_64.sizes
@@ -40,6 +40,7 @@
 12	cross_erd_compute
 13	read_converted_flag_inv
 14	read_converted_sum
+14	setup_timer_callback
 17	read_then_branch
 18	read_ram_then_converted
 20	conditional_write_chain
@@ -63,4 +64,3 @@
 75	modify_medium_single_field
 98	modify_medium_two_fields
 155	double_modify_struct
-172	setup_timer_callback

--- a/erd_core/codegen/timer/ReleaseFast/app_control_burst.s
+++ b/erd_core/codegen/timer/ReleaseFast/app_control_burst.s
@@ -1,0 +1,207 @@
+; snapshot_comments.zig
+; Speed: Near-optimal | Size: Optimal
+;
+app_control_burst:
+        push	r15
+        push	r14
+        push	rbx
+        mov	rbx, rsi
+        mov	r14, rdi
+        mov	edx, 10
+        call	timer.TimerModule.startPeriodic
+        mov	rdi, r14
+        mov	rsi, rbx
+        call	timer.TimerModule.pause
+        mov	rdi, r14
+        mov	rsi, rbx
+        call	timer.TimerModule.unpause
+        lea	r15, [rbx + 32]
+        mov	rdi, r14
+        mov	rsi, r15
+        mov	edx, 20
+        call	timer.TimerModule.startOneShot
+        mov	rdi, r14
+        mov	rsi, r15
+        call	timer.TimerModule.stop
+        lea	r15, [rbx + 64]
+        mov	rdi, r14
+        mov	rsi, r15
+        mov	edx, 30
+        call	timer.TimerModule.startPeriodic
+        add	rbx, 96
+        mov	rdi, r14
+        mov	rsi, rbx
+        mov	edx, 40
+        call	timer.TimerModule.startOneShot
+        mov	rdi, r14
+        mov	rsi, r15
+        call	timer.TimerModule.stop
+        mov	rdi, r14
+        mov	rsi, rbx
+        pop	rbx
+        pop	r14
+        pop	r15
+        jmp	timer.TimerModule.stop
+
+; --- called functions ---
+
+timer.TimerModule.startPeriodic:
+        cmp	qword ptr [rsi + 8], 0
+        jne	.L0
+        lea	rax, [rsi + 16]
+        cmp	qword ptr [rdi], rax
+        je	.L0
+        mov	qword ptr [rsi + 8], offset codegen_timer.cb0
+        mov	dword ptr [rsi + 28], edx
+        mov	qword ptr [rsi], 1
+        jmp	timer.TimerModule.insertTimer
+.L0:
+        push	rbp
+        push	r14
+        push	rbx
+        mov	rbx, rdi
+        mov	r14, rsi
+        mov	ebp, edx
+        call	timer.TimerModule.removeTimer
+        mov	rdi, rbx
+        mov	rsi, r14
+        mov	edx, ebp
+        pop	rbx
+        pop	r14
+        pop	rbp
+        mov	qword ptr [rsi + 8], offset codegen_timer.cb0
+        mov	dword ptr [rsi + 28], edx
+        mov	qword ptr [rsi], 1
+        jmp	timer.TimerModule.insertTimer
+
+timer.TimerModule.pause:
+        push	r15
+        push	r14
+        push	rbx
+        cmp	qword ptr [rsi + 8], 0
+        je	.L1
+        mov	rbx, rsi
+        mov	r14, rdi
+        lea	r15, [rsi + 16]
+        mov	rsi, r15
+        call	timer.TimerModule.tryRemove
+        test	al, 1
+        je	.L2
+        mov	eax, dword ptr [r14 + 16]
+        mov	ecx, dword ptr [rbx + 24]
+        sub	ecx, eax
+        xor	eax, eax
+        cmp	ecx, -65535
+        cmovb	eax, ecx
+        mov	dword ptr [rbx + 24], eax
+        mov	rax, qword ptr [r14 + 8]
+        mov	qword ptr [rbx + 16], rax
+        mov	qword ptr [r14 + 8], r15
+        pop	rbx
+        pop	r14
+        pop	r15
+        ret
+.L2:
+        lea	rax, [r14 + 8]
+.L3:
+        mov	rax, qword ptr [rax]
+        test	rax, rax
+        je	.L4
+        cmp	rax, r15
+        jne	.L3
+.L4:
+        test	rax, rax
+        je	.L5
+.L1:
+        pop	rbx
+        pop	r14
+        pop	r15
+        ret
+.L5:
+        mov	rdi, r14
+        mov	rsi, rbx
+        pop	rbx
+        pop	r14
+        pop	r15
+        jmp	timer.TimerModule.isRunning
+
+timer.TimerModule.unpause:
+        push	r15
+        push	r14
+        push	rbx
+        cmp	qword ptr [rsi + 8], 0
+        je	.L6
+        mov	rbx, rsi
+        mov	r14, rdi
+        add	rdi, 8
+        lea	r15, [rsi + 16]
+        mov	rsi, r15
+        call	timer.TimerModule.tryRemove
+        test	al, 1
+        je	.L7
+        mov	edx, dword ptr [rbx + 24]
+        mov	rdi, r14
+        mov	rsi, rbx
+        pop	rbx
+        pop	r14
+        pop	r15
+        jmp	timer.TimerModule.insertTimer
+.L7:
+        mov	rax, r14
+.L8:
+        mov	rax, qword ptr [rax]
+        test	rax, rax
+        je	.L9
+        cmp	rax, r15
+        jne	.L8
+.L9:
+        test	rax, rax
+        je	.L10
+.L6:
+        pop	rbx
+        pop	r14
+        pop	r15
+        ret
+.L10:
+        mov	rdi, r14
+        mov	rsi, rbx
+        pop	rbx
+        pop	r14
+        pop	r15
+        jmp	timer.TimerModule.isRunning
+
+timer.TimerModule.startOneShot:
+        cmp	qword ptr [rsi + 8], 0
+        jne	.L11
+        lea	rax, [rsi + 16]
+        cmp	qword ptr [rdi], rax
+        je	.L11
+        mov	qword ptr [rsi + 8], offset codegen_timer.cb0
+        mov	dword ptr [rsi + 28], edx
+        mov	qword ptr [rsi], 0
+        jmp	timer.TimerModule.insertTimer
+.L11:
+        push	rbp
+        push	r14
+        push	rbx
+        mov	rbx, rdi
+        mov	r14, rsi
+        mov	ebp, edx
+        call	timer.TimerModule.removeTimer
+        mov	rdi, rbx
+        mov	rsi, r14
+        mov	edx, ebp
+        pop	rbx
+        pop	r14
+        pop	rbp
+        mov	qword ptr [rsi + 8], offset codegen_timer.cb0
+        mov	dword ptr [rsi + 28], edx
+        mov	qword ptr [rsi], 0
+        jmp	timer.TimerModule.insertTimer
+
+timer.TimerModule.stop:
+        and	byte ptr [rsi], -2
+        cmp	qword ptr [rsi + 8], 0
+        jne	timer.TimerModule.removeTimer
+        ret
+

--- a/erd_core/codegen/timer/ReleaseFast/app_init.s
+++ b/erd_core/codegen/timer/ReleaseFast/app_init.s
@@ -1,0 +1,105 @@
+; snapshot_comments.zig
+; Speed: Near-optimal | Size: Optimal
+; 8 starts -> 8 calls to shared startPeriodic/startOneShot (was 1812 bytes of inlined copies in RF).
+;
+app_init:
+        push	r14
+        push	rbx
+        push	rax
+        mov	rbx, rsi
+        mov	r14, rdi
+        mov	edx, 10
+        call	timer.TimerModule.startPeriodic
+        lea	rsi, [rbx + 32]
+        mov	rdi, r14
+        mov	edx, 20
+        call	timer.TimerModule.startPeriodic
+        lea	rsi, [rbx + 64]
+        mov	rdi, r14
+        mov	edx, 30
+        call	timer.TimerModule.startPeriodic
+        lea	rsi, [rbx + 96]
+        mov	rdi, r14
+        mov	edx, 40
+        call	timer.TimerModule.startOneShot
+        lea	rsi, [rbx + 128]
+        mov	rdi, r14
+        mov	edx, 50
+        call	timer.TimerModule.startOneShot
+        lea	rsi, [rbx + 160]
+        mov	rdi, r14
+        mov	edx, 60
+        call	timer.TimerModule.startOneShot
+        lea	rsi, [rbx + 192]
+        mov	rdi, r14
+        mov	edx, 70
+        call	timer.TimerModule.startPeriodic
+        add	rbx, 224
+        mov	rdi, r14
+        mov	rsi, rbx
+        mov	edx, 80
+        add	rsp, 8
+        pop	rbx
+        pop	r14
+        jmp	timer.TimerModule.startOneShot
+
+; --- called functions ---
+
+timer.TimerModule.startPeriodic:
+        cmp	qword ptr [rsi + 8], 0
+        jne	.L0
+        lea	rax, [rsi + 16]
+        cmp	qword ptr [rdi], rax
+        je	.L0
+        mov	qword ptr [rsi + 8], offset codegen_timer.cb0
+        mov	dword ptr [rsi + 28], edx
+        mov	qword ptr [rsi], 1
+        jmp	timer.TimerModule.insertTimer
+.L0:
+        push	rbp
+        push	r14
+        push	rbx
+        mov	rbx, rdi
+        mov	r14, rsi
+        mov	ebp, edx
+        call	timer.TimerModule.removeTimer
+        mov	rdi, rbx
+        mov	rsi, r14
+        mov	edx, ebp
+        pop	rbx
+        pop	r14
+        pop	rbp
+        mov	qword ptr [rsi + 8], offset codegen_timer.cb0
+        mov	dword ptr [rsi + 28], edx
+        mov	qword ptr [rsi], 1
+        jmp	timer.TimerModule.insertTimer
+
+timer.TimerModule.startOneShot:
+        cmp	qword ptr [rsi + 8], 0
+        jne	.L1
+        lea	rax, [rsi + 16]
+        cmp	qword ptr [rdi], rax
+        je	.L1
+        mov	qword ptr [rsi + 8], offset codegen_timer.cb0
+        mov	dword ptr [rsi + 28], edx
+        mov	qword ptr [rsi], 0
+        jmp	timer.TimerModule.insertTimer
+.L1:
+        push	rbp
+        push	r14
+        push	rbx
+        mov	rbx, rdi
+        mov	r14, rsi
+        mov	ebp, edx
+        call	timer.TimerModule.removeTimer
+        mov	rdi, rbx
+        mov	rsi, r14
+        mov	edx, ebp
+        pop	rbx
+        pop	r14
+        pop	rbp
+        mov	qword ptr [rsi + 8], offset codegen_timer.cb0
+        mov	dword ptr [rsi + 28], edx
+        mov	qword ptr [rsi], 0
+        jmp	timer.TimerModule.insertTimer
+

--- a/erd_core/codegen/timer/ReleaseFast/app_pause_all.s
+++ b/erd_core/codegen/timer/ReleaseFast/app_pause_all.s
@@ -1,0 +1,89 @@
+; snapshot_comments.zig
+; Speed: Near-optimal | Size: Optimal
+;
+app_pause_all:
+        push	r14
+        push	rbx
+        push	rax
+        mov	rbx, rsi
+        mov	r14, rdi
+        call	timer.TimerModule.pause
+        lea	rsi, [rbx + 32]
+        mov	rdi, r14
+        call	timer.TimerModule.pause
+        lea	rsi, [rbx + 64]
+        mov	rdi, r14
+        call	timer.TimerModule.pause
+        lea	rsi, [rbx + 96]
+        mov	rdi, r14
+        call	timer.TimerModule.pause
+        lea	rsi, [rbx + 128]
+        mov	rdi, r14
+        call	timer.TimerModule.pause
+        lea	rsi, [rbx + 160]
+        mov	rdi, r14
+        call	timer.TimerModule.pause
+        lea	rsi, [rbx + 192]
+        mov	rdi, r14
+        call	timer.TimerModule.pause
+        add	rbx, 224
+        mov	rdi, r14
+        mov	rsi, rbx
+        add	rsp, 8
+        pop	rbx
+        pop	r14
+        jmp	timer.TimerModule.pause
+
+; --- called functions ---
+
+timer.TimerModule.pause:
+        push	r15
+        push	r14
+        push	rbx
+        cmp	qword ptr [rsi + 8], 0
+        je	.L0
+        mov	rbx, rsi
+        mov	r14, rdi
+        lea	r15, [rsi + 16]
+        mov	rsi, r15
+        call	timer.TimerModule.tryRemove
+        test	al, 1
+        je	.L1
+        mov	eax, dword ptr [r14 + 16]
+        mov	ecx, dword ptr [rbx + 24]
+        sub	ecx, eax
+        xor	eax, eax
+        cmp	ecx, -65535
+        cmovb	eax, ecx
+        mov	dword ptr [rbx + 24], eax
+        mov	rax, qword ptr [r14 + 8]
+        mov	qword ptr [rbx + 16], rax
+        mov	qword ptr [r14 + 8], r15
+        pop	rbx
+        pop	r14
+        pop	r15
+        ret
+.L1:
+        lea	rax, [r14 + 8]
+.L2:
+        mov	rax, qword ptr [rax]
+        test	rax, rax
+        je	.L3
+        cmp	rax, r15
+        jne	.L2
+.L3:
+        test	rax, rax
+        je	.L4
+.L0:
+        pop	rbx
+        pop	r14
+        pop	r15
+        ret
+.L4:
+        mov	rdi, r14
+        mov	rsi, rbx
+        pop	rbx
+        pop	r14
+        pop	r15
+        jmp	timer.TimerModule.isRunning
+

--- a/erd_core/codegen/timer/ReleaseFast/app_query_remaining.s
+++ b/erd_core/codegen/timer/ReleaseFast/app_query_remaining.s
@@ -1,0 +1,76 @@
+; snapshot_comments.zig
+; Speed: Near-optimal | Size: Optimal
+;
+app_query_remaining:
+        push	r15
+        push	r14
+        push	rbx
+        mov	rbx, rdx
+        mov	r14, rsi
+        mov	r15, rdi
+        call	timer.TimerModule.remainingTicks
+        mov	dword ptr [rbx], eax
+        lea	rsi, [r14 + 32]
+        mov	rdi, r15
+        call	timer.TimerModule.remainingTicks
+        mov	dword ptr [rbx + 4], eax
+        lea	rsi, [r14 + 64]
+        mov	rdi, r15
+        call	timer.TimerModule.remainingTicks
+        mov	dword ptr [rbx + 8], eax
+        lea	rsi, [r14 + 96]
+        mov	rdi, r15
+        call	timer.TimerModule.remainingTicks
+        mov	dword ptr [rbx + 12], eax
+        lea	rsi, [r14 + 128]
+        mov	rdi, r15
+        call	timer.TimerModule.remainingTicks
+        mov	dword ptr [rbx + 16], eax
+        lea	rsi, [r14 + 160]
+        mov	rdi, r15
+        call	timer.TimerModule.remainingTicks
+        mov	dword ptr [rbx + 20], eax
+        lea	rsi, [r14 + 192]
+        mov	rdi, r15
+        call	timer.TimerModule.remainingTicks
+        mov	dword ptr [rbx + 24], eax
+        add	r14, 224
+        mov	rdi, r15
+        mov	rsi, r14
+        call	timer.TimerModule.remainingTicks
+        mov	dword ptr [rbx + 28], eax
+        pop	rbx
+        pop	r14
+        pop	r15
+        ret
+
+; --- called functions ---
+
+timer.TimerModule.remainingTicks:
+        cmp	qword ptr [rsi + 8], 0
+        je	.L0
+        lea	rax, [rdi + 8]
+        lea	rcx, [rsi + 16]
+.L1:
+        mov	rax, qword ptr [rax]
+        test	rax, rax
+        je	.L2
+        cmp	rax, rcx
+        jne	.L1
+.L2:
+        test	rax, rax
+        je	.L3
+        mov	eax, dword ptr [rsi + 24]
+        ret
+.L0:
+        xor	eax, eax
+        ret
+.L3:
+        mov	eax, dword ptr [rdi + 16]
+        mov	ecx, dword ptr [rsi + 24]
+        sub	ecx, eax
+        xor	eax, eax
+        cmp	ecx, -65535
+        cmovb	eax, ecx
+        ret
+

--- a/erd_core/codegen/timer/ReleaseFast/app_query_running.s
+++ b/erd_core/codegen/timer/ReleaseFast/app_query_running.s
@@ -1,0 +1,80 @@
+; snapshot_comments.zig
+; Speed: Near-optimal | Size: Optimal
+;
+app_query_running:
+        push	r15
+        push	r14
+        push	rbx
+        mov	rbx, rdx
+        mov	r14, rsi
+        mov	r15, rdi
+        call	timer.TimerModule.isRunning
+        and	al, 1
+        mov	byte ptr [rbx], al
+        lea	rsi, [r14 + 32]
+        mov	rdi, r15
+        call	timer.TimerModule.isRunning
+        and	al, 1
+        mov	byte ptr [rbx + 1], al
+        lea	rsi, [r14 + 64]
+        mov	rdi, r15
+        call	timer.TimerModule.isRunning
+        and	al, 1
+        mov	byte ptr [rbx + 2], al
+        lea	rsi, [r14 + 96]
+        mov	rdi, r15
+        call	timer.TimerModule.isRunning
+        and	al, 1
+        mov	byte ptr [rbx + 3], al
+        lea	rsi, [r14 + 128]
+        mov	rdi, r15
+        call	timer.TimerModule.isRunning
+        and	al, 1
+        mov	byte ptr [rbx + 4], al
+        lea	rsi, [r14 + 160]
+        mov	rdi, r15
+        call	timer.TimerModule.isRunning
+        and	al, 1
+        mov	byte ptr [rbx + 5], al
+        lea	rsi, [r14 + 192]
+        mov	rdi, r15
+        call	timer.TimerModule.isRunning
+        and	al, 1
+        mov	byte ptr [rbx + 6], al
+        add	r14, 224
+        mov	rdi, r15
+        mov	rsi, r14
+        call	timer.TimerModule.isRunning
+        and	al, 1
+        mov	byte ptr [rbx + 7], al
+        pop	rbx
+        pop	r14
+        pop	r15
+        ret
+
+; --- called functions ---
+
+timer.TimerModule.isRunning:
+        add	rsi, 16
+        mov	rcx, rdi
+.L0:
+        mov	rcx, qword ptr [rcx]
+        test	rcx, rcx
+        je	.L1
+        cmp	rcx, rsi
+        jne	.L0
+.L1:
+        mov	al, 1
+        test	rcx, rcx
+        jne	.L2
+        add	rdi, 8
+.L3:
+        mov	rdi, qword ptr [rdi]
+        test	rdi, rdi
+        setne	al
+        je	.L2
+        cmp	rdi, rsi
+        jne	.L3
+.L2:
+        ret
+

--- a/erd_core/codegen/timer/ReleaseFast/app_stop_all.s
+++ b/erd_core/codegen/timer/ReleaseFast/app_stop_all.s
@@ -1,0 +1,44 @@
+; snapshot_comments.zig
+; Speed: Near-optimal | Size: Optimal
+;
+app_stop_all:
+        push	r14
+        push	rbx
+        push	rax
+        mov	rbx, rsi
+        mov	r14, rdi
+        call	timer.TimerModule.stop
+        lea	rsi, [rbx + 32]
+        mov	rdi, r14
+        call	timer.TimerModule.stop
+        lea	rsi, [rbx + 64]
+        mov	rdi, r14
+        call	timer.TimerModule.stop
+        lea	rsi, [rbx + 96]
+        mov	rdi, r14
+        call	timer.TimerModule.stop
+        lea	rsi, [rbx + 128]
+        mov	rdi, r14
+        call	timer.TimerModule.stop
+        lea	rsi, [rbx + 160]
+        mov	rdi, r14
+        call	timer.TimerModule.stop
+        lea	rsi, [rbx + 192]
+        mov	rdi, r14
+        call	timer.TimerModule.stop
+        add	rbx, 224
+        mov	rdi, r14
+        mov	rsi, rbx
+        add	rsp, 8
+        pop	rbx
+        pop	r14
+        jmp	timer.TimerModule.stop
+
+; --- called functions ---
+
+timer.TimerModule.stop:
+        and	byte ptr [rsi], -2
+        cmp	qword ptr [rsi + 8], 0
+        jne	timer.TimerModule.removeTimer
+        ret
+

--- a/erd_core/codegen/timer/ReleaseFast/app_unpause_all.s
+++ b/erd_core/codegen/timer/ReleaseFast/app_unpause_all.s
@@ -1,0 +1,84 @@
+; snapshot_comments.zig
+; Speed: Near-optimal | Size: Optimal
+; 8 unpause calls to shared bodies (was 2225 bytes of inlined tryRemove/insertTimer in RF).
+;
+app_unpause_all:
+        push	r14
+        push	rbx
+        push	rax
+        mov	rbx, rsi
+        mov	r14, rdi
+        call	timer.TimerModule.unpause
+        lea	rsi, [rbx + 32]
+        mov	rdi, r14
+        call	timer.TimerModule.unpause
+        lea	rsi, [rbx + 64]
+        mov	rdi, r14
+        call	timer.TimerModule.unpause
+        lea	rsi, [rbx + 96]
+        mov	rdi, r14
+        call	timer.TimerModule.unpause
+        lea	rsi, [rbx + 128]
+        mov	rdi, r14
+        call	timer.TimerModule.unpause
+        lea	rsi, [rbx + 160]
+        mov	rdi, r14
+        call	timer.TimerModule.unpause
+        lea	rsi, [rbx + 192]
+        mov	rdi, r14
+        call	timer.TimerModule.unpause
+        add	rbx, 224
+        mov	rdi, r14
+        mov	rsi, rbx
+        add	rsp, 8
+        pop	rbx
+        pop	r14
+        jmp	timer.TimerModule.unpause
+
+; --- called functions ---
+
+timer.TimerModule.unpause:
+        push	r15
+        push	r14
+        push	rbx
+        cmp	qword ptr [rsi + 8], 0
+        je	.L0
+        mov	rbx, rsi
+        mov	r14, rdi
+        add	rdi, 8
+        lea	r15, [rsi + 16]
+        mov	rsi, r15
+        call	timer.TimerModule.tryRemove
+        test	al, 1
+        je	.L1
+        mov	edx, dword ptr [rbx + 24]
+        mov	rdi, r14
+        mov	rsi, rbx
+        pop	rbx
+        pop	r14
+        pop	r15
+        jmp	timer.TimerModule.insertTimer
+.L1:
+        mov	rax, r14
+.L2:
+        mov	rax, qword ptr [rax]
+        test	rax, rax
+        je	.L3
+        cmp	rax, r15
+        jne	.L2
+.L3:
+        test	rax, rax
+        je	.L4
+.L0:
+        pop	rbx
+        pop	r14
+        pop	r15
+        ret
+.L4:
+        mov	rdi, r14
+        mov	rsi, rbx
+        pop	rbx
+        pop	r14
+        pop	r15
+        jmp	timer.TimerModule.isRunning
+

--- a/erd_core/codegen/timer/ReleaseFast/run_until_idle.s
+++ b/erd_core/codegen/timer/ReleaseFast/run_until_idle.s
@@ -1,0 +1,76 @@
+; snapshot_comments.zig
+; Speed: Optimal | Size: Optimal
+; Main-loop pattern: calls the shared, noinline run() until it returns false.
+;
+run_until_idle:
+        push	rbx
+        mov	rbx, rdi
+.L0:
+        mov	rdi, rbx
+        call	timer.TimerModule.run
+        test	al, 1
+        jne	.L0
+        pop	rbx
+        ret
+
+; --- called functions ---
+
+timer.TimerModule.run:
+        push	rbp
+        push	r15
+        push	r14
+        push	r12
+        push	rbx
+        mov	ecx, dword ptr [rdi + 16]
+        mov	rax, qword ptr [rdi]
+        test	rax, rax
+        je	.L1
+        sub	ecx, dword ptr [rax + 8]
+        cmp	ecx, 65535
+        ja	.L1
+        mov	rbx, rdi
+        lea	r14, [rax - 16]
+        mov	r12, qword ptr [r14]
+        mov	rdi, r12
+        test	r12b, 1
+        jne	.L2
+        mov	rcx, qword ptr [rax]
+        mov	qword ptr [rbx], rcx
+        mov	rdi, qword ptr [rax - 16]
+.L2:
+        mov	r15, qword ptr [r14 + 8]
+        mov	qword ptr [r14 + 8], 0
+        and	rdi, -2
+        mov	rsi, rbx
+        mov	rdx, r14
+        call	r15
+        mov	bpl, 1
+        cmp	qword ptr [r14 + 8], 0
+        jne	.L3
+        test	r12b, 1
+        je	.L4
+        mov	rax, qword ptr [rbx]
+        test	rax, rax
+        je	.L4
+        mov	rax, qword ptr [rax]
+        mov	qword ptr [rbx], rax
+.L4:
+        test	byte ptr [r14], 1
+        je	.L3
+        mov	edx, dword ptr [r14 + 28]
+        mov	rdi, rbx
+        mov	rsi, r14
+        call	timer.TimerModule.insertTimer
+        mov	qword ptr [r14 + 8], r15
+        jmp	.L3
+.L1:
+        xor	ebp, ebp
+.L3:
+        mov	eax, ebp
+        pop	rbx
+        pop	r12
+        pop	r14
+        pop	r15
+        pop	rbp
+        ret
+

--- a/erd_core/codegen/timer/ReleaseFast/timer_elapsed.s
+++ b/erd_core/codegen/timer/ReleaseFast/timer_elapsed.s
@@ -1,0 +1,48 @@
+; snapshot_comments.zig
+; Speed: Optimal | Size: Optimal
+;
+timer_elapsed:
+        cmp	qword ptr [rsi + 8], 0
+        je	.L0
+        push	rbx
+        mov	ebx, dword ptr [rsi + 28]
+        call	timer.TimerModule.remainingTicks
+        mov	ecx, eax
+        mov	eax, ebx
+        sub	eax, ecx
+        pop	rbx
+        ret
+.L0:
+        xor	eax, eax
+        ret
+
+; --- called functions ---
+
+timer.TimerModule.remainingTicks:
+        cmp	qword ptr [rsi + 8], 0
+        je	.L1
+        lea	rax, [rdi + 8]
+        lea	rcx, [rsi + 16]
+.L2:
+        mov	rax, qword ptr [rax]
+        test	rax, rax
+        je	.L3
+        cmp	rax, rcx
+        jne	.L2
+.L3:
+        test	rax, rax
+        je	.L4
+        mov	eax, dword ptr [rsi + 24]
+        ret
+.L1:
+        xor	eax, eax
+        ret
+.L4:
+        mov	eax, dword ptr [rdi + 16]
+        mov	ecx, dword ptr [rsi + 24]
+        sub	ecx, eax
+        xor	eax, eax
+        cmp	ecx, -65535
+        cmovb	eax, ecx
+        ret
+

--- a/erd_core/codegen/timer/ReleaseFast/timer_increment.s
+++ b/erd_core/codegen/timer/ReleaseFast/timer_increment.s
@@ -1,0 +1,7 @@
+; snapshot_comments.zig
+; Speed: Optimal | Size: Optimal
+;
+timer_increment:
+        add	dword ptr [rdi + 16], esi
+        ret
+

--- a/erd_core/codegen/timer/ReleaseFast/timer_is_active.s
+++ b/erd_core/codegen/timer/ReleaseFast/timer_is_active.s
@@ -1,0 +1,16 @@
+; snapshot_comments.zig
+; Speed: Optimal | Size: Optimal
+;
+timer_is_active:
+        add	rsi, 16
+.L0:
+        mov	rdi, qword ptr [rdi]
+        test	rdi, rdi
+        je	.L1
+        cmp	rdi, rsi
+        jne	.L0
+.L1:
+        test	rdi, rdi
+        setne	al
+        ret
+

--- a/erd_core/codegen/timer/ReleaseFast/timer_is_paused.s
+++ b/erd_core/codegen/timer/ReleaseFast/timer_is_paused.s
@@ -1,0 +1,17 @@
+; snapshot_comments.zig
+; Speed: Optimal | Size: Optimal
+;
+timer_is_paused:
+        add	rdi, 8
+        add	rsi, 16
+.L0:
+        mov	rdi, qword ptr [rdi]
+        test	rdi, rdi
+        je	.L1
+        cmp	rdi, rsi
+        jne	.L0
+.L1:
+        test	rdi, rdi
+        setne	al
+        ret
+

--- a/erd_core/codegen/timer/ReleaseFast/timer_is_running.s
+++ b/erd_core/codegen/timer/ReleaseFast/timer_is_running.s
@@ -1,0 +1,32 @@
+; snapshot_comments.zig
+; Speed: Optimal | Size: Optimal
+;
+timer_is_running:
+        jmp	timer.TimerModule.isRunning
+
+; --- called functions ---
+
+timer.TimerModule.isRunning:
+        add	rsi, 16
+        mov	rcx, rdi
+.L0:
+        mov	rcx, qword ptr [rcx]
+        test	rcx, rcx
+        je	.L1
+        cmp	rcx, rsi
+        jne	.L0
+.L1:
+        mov	al, 1
+        test	rcx, rcx
+        jne	.L2
+        add	rdi, 8
+.L3:
+        mov	rdi, qword ptr [rdi]
+        test	rdi, rdi
+        setne	al
+        je	.L2
+        cmp	rdi, rsi
+        jne	.L3
+.L2:
+        ret
+

--- a/erd_core/codegen/timer/ReleaseFast/timer_pause.s
+++ b/erd_core/codegen/timer/ReleaseFast/timer_pause.s
@@ -1,0 +1,59 @@
+; snapshot_comments.zig
+; Speed: Optimal | Size: Optimal
+;
+timer_pause:
+        jmp	timer.TimerModule.pause
+
+; --- called functions ---
+
+timer.TimerModule.pause:
+        push	r15
+        push	r14
+        push	rbx
+        cmp	qword ptr [rsi + 8], 0
+        je	.L0
+        mov	rbx, rsi
+        mov	r14, rdi
+        lea	r15, [rsi + 16]
+        mov	rsi, r15
+        call	timer.TimerModule.tryRemove
+        test	al, 1
+        je	.L1
+        mov	eax, dword ptr [r14 + 16]
+        mov	ecx, dword ptr [rbx + 24]
+        sub	ecx, eax
+        xor	eax, eax
+        cmp	ecx, -65535
+        cmovb	eax, ecx
+        mov	dword ptr [rbx + 24], eax
+        mov	rax, qword ptr [r14 + 8]
+        mov	qword ptr [rbx + 16], rax
+        mov	qword ptr [r14 + 8], r15
+        pop	rbx
+        pop	r14
+        pop	r15
+        ret
+.L1:
+        lea	rax, [r14 + 8]
+.L2:
+        mov	rax, qword ptr [rax]
+        test	rax, rax
+        je	.L3
+        cmp	rax, r15
+        jne	.L2
+.L3:
+        test	rax, rax
+        je	.L4
+.L0:
+        pop	rbx
+        pop	r14
+        pop	r15
+        ret
+.L4:
+        mov	rdi, r14
+        mov	rsi, rbx
+        pop	rbx
+        pop	r14
+        pop	r15
+        jmp	timer.TimerModule.isRunning
+

--- a/erd_core/codegen/timer/ReleaseFast/timer_remaining.s
+++ b/erd_core/codegen/timer/ReleaseFast/timer_remaining.s
@@ -1,0 +1,36 @@
+; snapshot_comments.zig
+; Speed: Optimal | Size: Optimal
+;
+timer_remaining:
+        jmp	timer.TimerModule.remainingTicks
+
+; --- called functions ---
+
+timer.TimerModule.remainingTicks:
+        cmp	qword ptr [rsi + 8], 0
+        je	.L0
+        lea	rax, [rdi + 8]
+        lea	rcx, [rsi + 16]
+.L1:
+        mov	rax, qword ptr [rax]
+        test	rax, rax
+        je	.L2
+        cmp	rax, rcx
+        jne	.L1
+.L2:
+        test	rax, rax
+        je	.L3
+        mov	eax, dword ptr [rsi + 24]
+        ret
+.L0:
+        xor	eax, eax
+        ret
+.L3:
+        mov	eax, dword ptr [rdi + 16]
+        mov	ecx, dword ptr [rsi + 24]
+        sub	ecx, eax
+        xor	eax, eax
+        cmp	ecx, -65535
+        cmovb	eax, ecx
+        ret
+

--- a/erd_core/codegen/timer/ReleaseFast/timer_run.s
+++ b/erd_core/codegen/timer/ReleaseFast/timer_run.s
@@ -1,0 +1,67 @@
+; snapshot_comments.zig
+; Speed: Optimal | Size: Optimal
+;
+timer_run:
+        jmp	timer.TimerModule.run
+
+; --- called functions ---
+
+timer.TimerModule.run:
+        push	rbp
+        push	r15
+        push	r14
+        push	r12
+        push	rbx
+        mov	ecx, dword ptr [rdi + 16]
+        mov	rax, qword ptr [rdi]
+        test	rax, rax
+        je	.L0
+        sub	ecx, dword ptr [rax + 8]
+        cmp	ecx, 65535
+        ja	.L0
+        mov	rbx, rdi
+        lea	r14, [rax - 16]
+        mov	r12, qword ptr [r14]
+        mov	rdi, r12
+        test	r12b, 1
+        jne	.L1
+        mov	rcx, qword ptr [rax]
+        mov	qword ptr [rbx], rcx
+        mov	rdi, qword ptr [rax - 16]
+.L1:
+        mov	r15, qword ptr [r14 + 8]
+        mov	qword ptr [r14 + 8], 0
+        and	rdi, -2
+        mov	rsi, rbx
+        mov	rdx, r14
+        call	r15
+        mov	bpl, 1
+        cmp	qword ptr [r14 + 8], 0
+        jne	.L2
+        test	r12b, 1
+        je	.L3
+        mov	rax, qword ptr [rbx]
+        test	rax, rax
+        je	.L3
+        mov	rax, qword ptr [rax]
+        mov	qword ptr [rbx], rax
+.L3:
+        test	byte ptr [r14], 1
+        je	.L2
+        mov	edx, dword ptr [r14 + 28]
+        mov	rdi, rbx
+        mov	rsi, r14
+        call	timer.TimerModule.insertTimer
+        mov	qword ptr [r14 + 8], r15
+        jmp	.L2
+.L0:
+        xor	ebp, ebp
+.L2:
+        mov	eax, ebp
+        pop	rbx
+        pop	r12
+        pop	r14
+        pop	r15
+        pop	rbp
+        ret
+

--- a/erd_core/codegen/timer/ReleaseFast/timer_start_oneshot.s
+++ b/erd_core/codegen/timer/ReleaseFast/timer_start_oneshot.s
@@ -1,0 +1,38 @@
+; snapshot_comments.zig
+; Speed: Optimal | Size: Optimal
+;
+timer_start_oneshot:
+        mov	edx, 100
+        jmp	timer.TimerModule.startOneShot
+
+; --- called functions ---
+
+timer.TimerModule.startOneShot:
+        cmp	qword ptr [rsi + 8], 0
+        jne	.L0
+        lea	rax, [rsi + 16]
+        cmp	qword ptr [rdi], rax
+        je	.L0
+        mov	qword ptr [rsi + 8], offset codegen_timer.cb0
+        mov	dword ptr [rsi + 28], edx
+        mov	qword ptr [rsi], 0
+        jmp	timer.TimerModule.insertTimer
+.L0:
+        push	rbp
+        push	r14
+        push	rbx
+        mov	rbx, rdi
+        mov	r14, rsi
+        mov	ebp, edx
+        call	timer.TimerModule.removeTimer
+        mov	rdi, rbx
+        mov	rsi, r14
+        mov	edx, ebp
+        pop	rbx
+        pop	r14
+        pop	rbp
+        mov	qword ptr [rsi + 8], offset codegen_timer.cb0
+        mov	dword ptr [rsi + 28], edx
+        mov	qword ptr [rsi], 0
+        jmp	timer.TimerModule.insertTimer
+

--- a/erd_core/codegen/timer/ReleaseFast/timer_start_periodic.s
+++ b/erd_core/codegen/timer/ReleaseFast/timer_start_periodic.s
@@ -1,0 +1,39 @@
+; snapshot_comments.zig
+; Speed: Optimal | Size: Optimal
+; Tail call into shared, noinline startPeriodic (was 196 bytes inlined in RF).
+;
+timer_start_periodic:
+        mov	edx, 100
+        jmp	timer.TimerModule.startPeriodic
+
+; --- called functions ---
+
+timer.TimerModule.startPeriodic:
+        cmp	qword ptr [rsi + 8], 0
+        jne	.L0
+        lea	rax, [rsi + 16]
+        cmp	qword ptr [rdi], rax
+        je	.L0
+        mov	qword ptr [rsi + 8], offset codegen_timer.cb0
+        mov	dword ptr [rsi + 28], edx
+        mov	qword ptr [rsi], 1
+        jmp	timer.TimerModule.insertTimer
+.L0:
+        push	rbp
+        push	r14
+        push	rbx
+        mov	rbx, rdi
+        mov	r14, rsi
+        mov	ebp, edx
+        call	timer.TimerModule.removeTimer
+        mov	rdi, rbx
+        mov	rsi, r14
+        mov	edx, ebp
+        pop	rbx
+        pop	r14
+        pop	rbp
+        mov	qword ptr [rsi + 8], offset codegen_timer.cb0
+        mov	dword ptr [rsi + 28], edx
+        mov	qword ptr [rsi], 1
+        jmp	timer.TimerModule.insertTimer
+

--- a/erd_core/codegen/timer/ReleaseFast/timer_stop.s
+++ b/erd_core/codegen/timer/ReleaseFast/timer_stop.s
@@ -1,0 +1,14 @@
+; snapshot_comments.zig
+; Speed: Optimal | Size: Optimal
+;
+timer_stop:
+        jmp	timer.TimerModule.stop
+
+; --- called functions ---
+
+timer.TimerModule.stop:
+        and	byte ptr [rsi], -2
+        cmp	qword ptr [rsi + 8], 0
+        jne	timer.TimerModule.removeTimer
+        ret
+

--- a/erd_core/codegen/timer/ReleaseFast/timer_ticks_since.s
+++ b/erd_core/codegen/timer/ReleaseFast/timer_ticks_since.s
@@ -1,0 +1,27 @@
+; snapshot_comments.zig
+; Speed: Optimal | Size: Optimal
+;
+timer_ticks_since:
+        push	rax
+        lea	rax, [rdi + 8]
+        lea	rcx, [rsi + 16]
+.L0:
+        mov	rax, qword ptr [rax]
+        test	rax, rax
+        je	.L1
+        cmp	rax, rcx
+        jne	.L0
+.L1:
+        test	rax, rax
+        jne	.L2
+        mov	ecx, dword ptr [rsi + 28]
+        sub	ecx, dword ptr [rsi + 24]
+        mov	eax, dword ptr [rdi + 16]
+        add	eax, ecx
+        pop	rcx
+        ret
+.L2:
+        mov	edi, offset __anon_0
+        mov	esi, 61
+        call	debug.defaultPanic
+

--- a/erd_core/codegen/timer/ReleaseFast/timer_unpause.s
+++ b/erd_core/codegen/timer/ReleaseFast/timer_unpause.s
@@ -1,0 +1,53 @@
+; snapshot_comments.zig
+; Speed: Optimal | Size: Optimal
+;
+timer_unpause:
+        jmp	timer.TimerModule.unpause
+
+; --- called functions ---
+
+timer.TimerModule.unpause:
+        push	r15
+        push	r14
+        push	rbx
+        cmp	qword ptr [rsi + 8], 0
+        je	.L0
+        mov	rbx, rsi
+        mov	r14, rdi
+        add	rdi, 8
+        lea	r15, [rsi + 16]
+        mov	rsi, r15
+        call	timer.TimerModule.tryRemove
+        test	al, 1
+        je	.L1
+        mov	edx, dword ptr [rbx + 24]
+        mov	rdi, r14
+        mov	rsi, rbx
+        pop	rbx
+        pop	r14
+        pop	r15
+        jmp	timer.TimerModule.insertTimer
+.L1:
+        mov	rax, r14
+.L2:
+        mov	rax, qword ptr [rax]
+        test	rax, rax
+        je	.L3
+        cmp	rax, r15
+        jne	.L2
+.L3:
+        test	rax, rax
+        je	.L4
+.L0:
+        pop	rbx
+        pop	r14
+        pop	r15
+        ret
+.L4:
+        mov	rdi, r14
+        mov	rsi, rbx
+        pop	rbx
+        pop	r14
+        pop	r15
+        jmp	timer.TimerModule.isRunning
+

--- a/erd_core/codegen/timer/ReleaseFast/timer_until_next.s
+++ b/erd_core/codegen/timer/ReleaseFast/timer_until_next.s
@@ -1,0 +1,18 @@
+; snapshot_comments.zig
+; Speed: Optimal | Size: Optimal
+;
+timer_until_next:
+        mov	rax, qword ptr [rdi]
+        test	rax, rax
+        je	.L0
+        mov	ecx, dword ptr [rdi + 16]
+        mov	edx, dword ptr [rax + 8]
+        sub	edx, ecx
+        xor	eax, eax
+        cmp	edx, -65535
+        cmovb	eax, edx
+        ret
+.L0:
+        mov	eax, -1
+        ret
+

--- a/erd_core/codegen/timer/ReleaseFast_x86_64.s
+++ b/erd_core/codegen/timer/ReleaseFast_x86_64.s
@@ -1,0 +1,1198 @@
+app_control_burst:
+        push	r15
+        push	r14
+        push	rbx
+        mov	rbx, rsi
+        mov	r14, rdi
+        mov	edx, 10
+        call	timer.TimerModule.startPeriodic
+        mov	rdi, r14
+        mov	rsi, rbx
+        call	timer.TimerModule.pause
+        mov	rdi, r14
+        mov	rsi, rbx
+        call	timer.TimerModule.unpause
+        lea	r15, [rbx + 32]
+        mov	rdi, r14
+        mov	rsi, r15
+        mov	edx, 20
+        call	timer.TimerModule.startOneShot
+        mov	rdi, r14
+        mov	rsi, r15
+        call	timer.TimerModule.stop
+        lea	r15, [rbx + 64]
+        mov	rdi, r14
+        mov	rsi, r15
+        mov	edx, 30
+        call	timer.TimerModule.startPeriodic
+        add	rbx, 96
+        mov	rdi, r14
+        mov	rsi, rbx
+        mov	edx, 40
+        call	timer.TimerModule.startOneShot
+        mov	rdi, r14
+        mov	rsi, r15
+        call	timer.TimerModule.stop
+        mov	rdi, r14
+        mov	rsi, rbx
+        pop	rbx
+        pop	r14
+        pop	r15
+        jmp	timer.TimerModule.stop
+
+run_until_idle:
+        push	rbx
+        mov	rbx, rdi
+.LBB11_1:
+        mov	rdi, rbx
+        call	timer.TimerModule.run
+        test	al, 1
+        jne	.LBB11_1
+        pop	rbx
+        ret
+
+app_query_running:
+        push	r15
+        push	r14
+        push	rbx
+        mov	rbx, rdx
+        mov	r14, rsi
+        mov	r15, rdi
+        call	timer.TimerModule.isRunning
+        and	al, 1
+        mov	byte ptr [rbx], al
+        lea	rsi, [r14 + 32]
+        mov	rdi, r15
+        call	timer.TimerModule.isRunning
+        and	al, 1
+        mov	byte ptr [rbx + 1], al
+        lea	rsi, [r14 + 64]
+        mov	rdi, r15
+        call	timer.TimerModule.isRunning
+        and	al, 1
+        mov	byte ptr [rbx + 2], al
+        lea	rsi, [r14 + 96]
+        mov	rdi, r15
+        call	timer.TimerModule.isRunning
+        and	al, 1
+        mov	byte ptr [rbx + 3], al
+        lea	rsi, [r14 + 128]
+        mov	rdi, r15
+        call	timer.TimerModule.isRunning
+        and	al, 1
+        mov	byte ptr [rbx + 4], al
+        lea	rsi, [r14 + 160]
+        mov	rdi, r15
+        call	timer.TimerModule.isRunning
+        and	al, 1
+        mov	byte ptr [rbx + 5], al
+        lea	rsi, [r14 + 192]
+        mov	rdi, r15
+        call	timer.TimerModule.isRunning
+        and	al, 1
+        mov	byte ptr [rbx + 6], al
+        add	r14, 224
+        mov	rdi, r15
+        mov	rsi, r14
+        call	timer.TimerModule.isRunning
+        and	al, 1
+        mov	byte ptr [rbx + 7], al
+        pop	rbx
+        pop	r14
+        pop	r15
+        ret
+
+app_query_remaining:
+        push	r15
+        push	r14
+        push	rbx
+        mov	rbx, rdx
+        mov	r14, rsi
+        mov	r15, rdi
+        call	timer.TimerModule.remainingTicks
+        mov	dword ptr [rbx], eax
+        lea	rsi, [r14 + 32]
+        mov	rdi, r15
+        call	timer.TimerModule.remainingTicks
+        mov	dword ptr [rbx + 4], eax
+        lea	rsi, [r14 + 64]
+        mov	rdi, r15
+        call	timer.TimerModule.remainingTicks
+        mov	dword ptr [rbx + 8], eax
+        lea	rsi, [r14 + 96]
+        mov	rdi, r15
+        call	timer.TimerModule.remainingTicks
+        mov	dword ptr [rbx + 12], eax
+        lea	rsi, [r14 + 128]
+        mov	rdi, r15
+        call	timer.TimerModule.remainingTicks
+        mov	dword ptr [rbx + 16], eax
+        lea	rsi, [r14 + 160]
+        mov	rdi, r15
+        call	timer.TimerModule.remainingTicks
+        mov	dword ptr [rbx + 20], eax
+        lea	rsi, [r14 + 192]
+        mov	rdi, r15
+        call	timer.TimerModule.remainingTicks
+        mov	dword ptr [rbx + 24], eax
+        add	r14, 224
+        mov	rdi, r15
+        mov	rsi, r14
+        call	timer.TimerModule.remainingTicks
+        mov	dword ptr [rbx + 28], eax
+        pop	rbx
+        pop	r14
+        pop	r15
+        ret
+
+app_unpause_all:
+        push	r14
+        push	rbx
+        push	rax
+        mov	rbx, rsi
+        mov	r14, rdi
+        call	timer.TimerModule.unpause
+        lea	rsi, [rbx + 32]
+        mov	rdi, r14
+        call	timer.TimerModule.unpause
+        lea	rsi, [rbx + 64]
+        mov	rdi, r14
+        call	timer.TimerModule.unpause
+        lea	rsi, [rbx + 96]
+        mov	rdi, r14
+        call	timer.TimerModule.unpause
+        lea	rsi, [rbx + 128]
+        mov	rdi, r14
+        call	timer.TimerModule.unpause
+        lea	rsi, [rbx + 160]
+        mov	rdi, r14
+        call	timer.TimerModule.unpause
+        lea	rsi, [rbx + 192]
+        mov	rdi, r14
+        call	timer.TimerModule.unpause
+        add	rbx, 224
+        mov	rdi, r14
+        mov	rsi, rbx
+        add	rsp, 8
+        pop	rbx
+        pop	r14
+        jmp	timer.TimerModule.unpause
+
+app_pause_all:
+        push	r14
+        push	rbx
+        push	rax
+        mov	rbx, rsi
+        mov	r14, rdi
+        call	timer.TimerModule.pause
+        lea	rsi, [rbx + 32]
+        mov	rdi, r14
+        call	timer.TimerModule.pause
+        lea	rsi, [rbx + 64]
+        mov	rdi, r14
+        call	timer.TimerModule.pause
+        lea	rsi, [rbx + 96]
+        mov	rdi, r14
+        call	timer.TimerModule.pause
+        lea	rsi, [rbx + 128]
+        mov	rdi, r14
+        call	timer.TimerModule.pause
+        lea	rsi, [rbx + 160]
+        mov	rdi, r14
+        call	timer.TimerModule.pause
+        lea	rsi, [rbx + 192]
+        mov	rdi, r14
+        call	timer.TimerModule.pause
+        add	rbx, 224
+        mov	rdi, r14
+        mov	rsi, rbx
+        add	rsp, 8
+        pop	rbx
+        pop	r14
+        jmp	timer.TimerModule.pause
+
+app_stop_all:
+        push	r14
+        push	rbx
+        push	rax
+        mov	rbx, rsi
+        mov	r14, rdi
+        call	timer.TimerModule.stop
+        lea	rsi, [rbx + 32]
+        mov	rdi, r14
+        call	timer.TimerModule.stop
+        lea	rsi, [rbx + 64]
+        mov	rdi, r14
+        call	timer.TimerModule.stop
+        lea	rsi, [rbx + 96]
+        mov	rdi, r14
+        call	timer.TimerModule.stop
+        lea	rsi, [rbx + 128]
+        mov	rdi, r14
+        call	timer.TimerModule.stop
+        lea	rsi, [rbx + 160]
+        mov	rdi, r14
+        call	timer.TimerModule.stop
+        lea	rsi, [rbx + 192]
+        mov	rdi, r14
+        call	timer.TimerModule.stop
+        add	rbx, 224
+        mov	rdi, r14
+        mov	rsi, rbx
+        add	rsp, 8
+        pop	rbx
+        pop	r14
+        jmp	timer.TimerModule.stop
+
+app_init:
+        push	r14
+        push	rbx
+        push	rax
+        mov	rbx, rsi
+        mov	r14, rdi
+        mov	edx, 10
+        call	timer.TimerModule.startPeriodic
+        lea	rsi, [rbx + 32]
+        mov	rdi, r14
+        mov	edx, 20
+        call	timer.TimerModule.startPeriodic
+        lea	rsi, [rbx + 64]
+        mov	rdi, r14
+        mov	edx, 30
+        call	timer.TimerModule.startPeriodic
+        lea	rsi, [rbx + 96]
+        mov	rdi, r14
+        mov	edx, 40
+        call	timer.TimerModule.startOneShot
+        lea	rsi, [rbx + 128]
+        mov	rdi, r14
+        mov	edx, 50
+        call	timer.TimerModule.startOneShot
+        lea	rsi, [rbx + 160]
+        mov	rdi, r14
+        mov	edx, 60
+        call	timer.TimerModule.startOneShot
+        lea	rsi, [rbx + 192]
+        mov	rdi, r14
+        mov	edx, 70
+        call	timer.TimerModule.startPeriodic
+        add	rbx, 224
+        mov	rdi, r14
+        mov	rsi, rbx
+        mov	edx, 80
+        add	rsp, 8
+        pop	rbx
+        pop	r14
+        jmp	timer.TimerModule.startOneShot
+
+timer_increment:
+        add	dword ptr [rdi + 16], esi
+        ret
+
+timer_until_next:
+        mov	rax, qword ptr [rdi]
+        test	rax, rax
+        je	.LBB21_1
+        mov	ecx, dword ptr [rdi + 16]
+        mov	edx, dword ptr [rax + 8]
+        sub	edx, ecx
+        xor	eax, eax
+        cmp	edx, -65535
+        cmovb	eax, edx
+        ret
+.LBB21_1:
+        mov	eax, -1
+        ret
+
+timer_ticks_since:
+        push	rax
+        lea	rax, [rdi + 8]
+        lea	rcx, [rsi + 16]
+.LBB22_1:
+        mov	rax, qword ptr [rax]
+        test	rax, rax
+        je	.LBB22_3
+        cmp	rax, rcx
+        jne	.LBB22_1
+.LBB22_3:
+        test	rax, rax
+        jne	.LBB22_5
+        mov	ecx, dword ptr [rsi + 28]
+        sub	ecx, dword ptr [rsi + 24]
+        mov	eax, dword ptr [rdi + 16]
+        add	eax, ecx
+        pop	rcx
+        ret
+.LBB22_5:
+        mov	edi, offset __anon_0
+        mov	esi, 61
+        call	debug.defaultPanic
+
+timer_remaining:
+        jmp	timer.TimerModule.remainingTicks
+
+timer_elapsed:
+        cmp	qword ptr [rsi + 8], 0
+        je	.LBB296_1
+        push	rbx
+        mov	ebx, dword ptr [rsi + 28]
+        call	timer.TimerModule.remainingTicks
+        mov	ecx, eax
+        mov	eax, ebx
+        sub	eax, ecx
+        pop	rbx
+        ret
+.LBB296_1:
+        xor	eax, eax
+        ret
+
+timer_is_paused:
+        add	rdi, 8
+        add	rsi, 16
+.LBB297_1:
+        mov	rdi, qword ptr [rdi]
+        test	rdi, rdi
+        je	.LBB297_3
+        cmp	rdi, rsi
+        jne	.LBB297_1
+.LBB297_3:
+        test	rdi, rdi
+        setne	al
+        ret
+
+timer_is_active:
+        add	rsi, 16
+.LBB298_1:
+        mov	rdi, qword ptr [rdi]
+        test	rdi, rdi
+        je	.LBB298_3
+        cmp	rdi, rsi
+        jne	.LBB298_1
+.LBB298_3:
+        test	rdi, rdi
+        setne	al
+        ret
+
+timer_is_running:
+        jmp	timer.TimerModule.isRunning
+
+timer_unpause:
+        jmp	timer.TimerModule.unpause
+
+timer_pause:
+        jmp	timer.TimerModule.pause
+
+timer_stop:
+        jmp	timer.TimerModule.stop
+
+timer_start_oneshot:
+        mov	edx, 100
+        jmp	timer.TimerModule.startOneShot
+
+timer_start_periodic:
+        mov	edx, 100
+        jmp	timer.TimerModule.startPeriodic
+
+timer_run:
+        jmp	timer.TimerModule.run
+
+; --- called functions ---
+
+timer.TimerModule.startPeriodic:
+        cmp	qword ptr [rsi + 8], 0
+        jne	.LBB10_2
+        lea	rax, [rsi + 16]
+        cmp	qword ptr [rdi], rax
+        je	.LBB10_2
+        mov	qword ptr [rsi + 8], offset codegen_timer.cb0
+        mov	dword ptr [rsi + 28], edx
+        mov	qword ptr [rsi], 1
+        jmp	timer.TimerModule.insertTimer
+.LBB10_2:
+        push	rbp
+        push	r14
+        push	rbx
+        mov	rbx, rdi
+        mov	r14, rsi
+        mov	ebp, edx
+        call	timer.TimerModule.removeTimer
+        mov	rdi, rbx
+        mov	rsi, r14
+        mov	edx, ebp
+        pop	rbx
+        pop	r14
+        pop	rbp
+        mov	qword ptr [rsi + 8], offset codegen_timer.cb0
+        mov	dword ptr [rsi + 28], edx
+        mov	qword ptr [rsi], 1
+        jmp	timer.TimerModule.insertTimer
+
+timer.TimerModule.pause:
+        push	r15
+        push	r14
+        push	rbx
+        cmp	qword ptr [rsi + 8], 0
+        je	.LBB8_7
+        mov	rbx, rsi
+        mov	r14, rdi
+        lea	r15, [rsi + 16]
+        mov	rsi, r15
+        call	timer.TimerModule.tryRemove
+        test	al, 1
+        je	.LBB8_3
+        mov	eax, dword ptr [r14 + 16]
+        mov	ecx, dword ptr [rbx + 24]
+        sub	ecx, eax
+        xor	eax, eax
+        cmp	ecx, -65535
+        cmovb	eax, ecx
+        mov	dword ptr [rbx + 24], eax
+        mov	rax, qword ptr [r14 + 8]
+        mov	qword ptr [rbx + 16], rax
+        mov	qword ptr [r14 + 8], r15
+        pop	rbx
+        pop	r14
+        pop	r15
+        ret
+.LBB8_3:
+        lea	rax, [r14 + 8]
+.LBB8_4:
+        mov	rax, qword ptr [rax]
+        test	rax, rax
+        je	.LBB8_6
+        cmp	rax, r15
+        jne	.LBB8_4
+.LBB8_6:
+        test	rax, rax
+        je	.LBB8_8
+.LBB8_7:
+        pop	rbx
+        pop	r14
+        pop	r15
+        ret
+.LBB8_8:
+        mov	rdi, r14
+        mov	rsi, rbx
+        pop	rbx
+        pop	r14
+        pop	r15
+        jmp	timer.TimerModule.isRunning
+
+timer.TimerModule.unpause:
+        push	r15
+        push	r14
+        push	rbx
+        cmp	qword ptr [rsi + 8], 0
+        je	.LBB7_6
+        mov	rbx, rsi
+        mov	r14, rdi
+        add	rdi, 8
+        lea	r15, [rsi + 16]
+        mov	rsi, r15
+        call	timer.TimerModule.tryRemove
+        test	al, 1
+        je	.LBB7_2
+        mov	edx, dword ptr [rbx + 24]
+        mov	rdi, r14
+        mov	rsi, rbx
+        pop	rbx
+        pop	r14
+        pop	r15
+        jmp	timer.TimerModule.insertTimer
+.LBB7_2:
+        mov	rax, r14
+.LBB7_3:
+        mov	rax, qword ptr [rax]
+        test	rax, rax
+        je	.LBB7_5
+        cmp	rax, r15
+        jne	.LBB7_3
+.LBB7_5:
+        test	rax, rax
+        je	.LBB7_8
+.LBB7_6:
+        pop	rbx
+        pop	r14
+        pop	r15
+        ret
+.LBB7_8:
+        mov	rdi, r14
+        mov	rsi, rbx
+        pop	rbx
+        pop	r14
+        pop	r15
+        jmp	timer.TimerModule.isRunning
+
+timer.TimerModule.startOneShot:
+        cmp	qword ptr [rsi + 8], 0
+        jne	.LBB3_2
+        lea	rax, [rsi + 16]
+        cmp	qword ptr [rdi], rax
+        je	.LBB3_2
+        mov	qword ptr [rsi + 8], offset codegen_timer.cb0
+        mov	dword ptr [rsi + 28], edx
+        mov	qword ptr [rsi], 0
+        jmp	timer.TimerModule.insertTimer
+.LBB3_2:
+        push	rbp
+        push	r14
+        push	rbx
+        mov	rbx, rdi
+        mov	r14, rsi
+        mov	ebp, edx
+        call	timer.TimerModule.removeTimer
+        mov	rdi, rbx
+        mov	rsi, r14
+        mov	edx, ebp
+        pop	rbx
+        pop	r14
+        pop	rbp
+        mov	qword ptr [rsi + 8], offset codegen_timer.cb0
+        mov	dword ptr [rsi + 28], edx
+        mov	qword ptr [rsi], 0
+        jmp	timer.TimerModule.insertTimer
+
+timer.TimerModule.stop:
+        and	byte ptr [rsi], -2
+        cmp	qword ptr [rsi + 8], 0
+        jne	timer.TimerModule.removeTimer
+        ret
+
+timer.TimerModule.run:
+        push	rbp
+        push	r15
+        push	r14
+        push	r12
+        push	rbx
+        mov	ecx, dword ptr [rdi + 16]
+        mov	rax, qword ptr [rdi]
+        test	rax, rax
+        je	.LBB12_1
+        sub	ecx, dword ptr [rax + 8]
+        cmp	ecx, 65535
+        ja	.LBB12_1
+        mov	rbx, rdi
+        lea	r14, [rax - 16]
+        mov	r12, qword ptr [r14]
+        mov	rdi, r12
+        test	r12b, 1
+        jne	.LBB12_5
+        mov	rcx, qword ptr [rax]
+        mov	qword ptr [rbx], rcx
+        mov	rdi, qword ptr [rax - 16]
+.LBB12_5:
+        mov	r15, qword ptr [r14 + 8]
+        mov	qword ptr [r14 + 8], 0
+        and	rdi, -2
+        mov	rsi, rbx
+        mov	rdx, r14
+        call	r15
+        mov	bpl, 1
+        cmp	qword ptr [r14 + 8], 0
+        jne	.LBB12_2
+        test	r12b, 1
+        je	.LBB12_7
+        mov	rax, qword ptr [rbx]
+        test	rax, rax
+        je	.LBB12_7
+        mov	rax, qword ptr [rax]
+        mov	qword ptr [rbx], rax
+.LBB12_7:
+        test	byte ptr [r14], 1
+        je	.LBB12_2
+        mov	edx, dword ptr [r14 + 28]
+        mov	rdi, rbx
+        mov	rsi, r14
+        call	timer.TimerModule.insertTimer
+        mov	qword ptr [r14 + 8], r15
+        jmp	.LBB12_2
+.LBB12_1:
+        xor	ebp, ebp
+.LBB12_2:
+        mov	eax, ebp
+        pop	rbx
+        pop	r12
+        pop	r14
+        pop	r15
+        pop	rbp
+        ret
+
+timer.TimerModule.isRunning:
+        add	rsi, 16
+        mov	rcx, rdi
+.LBB9_1:
+        mov	rcx, qword ptr [rcx]
+        test	rcx, rcx
+        je	.LBB9_3
+        cmp	rcx, rsi
+        jne	.LBB9_1
+.LBB9_3:
+        mov	al, 1
+        test	rcx, rcx
+        jne	.LBB9_7
+        add	rdi, 8
+.LBB9_5:
+        mov	rdi, qword ptr [rdi]
+        test	rdi, rdi
+        setne	al
+        je	.LBB9_7
+        cmp	rdi, rsi
+        jne	.LBB9_5
+.LBB9_7:
+        ret
+
+timer.TimerModule.remainingTicks:
+        cmp	qword ptr [rsi + 8], 0
+        je	.LBB15_1
+        lea	rax, [rdi + 8]
+        lea	rcx, [rsi + 16]
+.LBB15_4:
+        mov	rax, qword ptr [rax]
+        test	rax, rax
+        je	.LBB15_6
+        cmp	rax, rcx
+        jne	.LBB15_4
+.LBB15_6:
+        test	rax, rax
+        je	.LBB15_8
+        mov	eax, dword ptr [rsi + 24]
+        ret
+.LBB15_1:
+        xor	eax, eax
+        ret
+.LBB15_8:
+        mov	eax, dword ptr [rdi + 16]
+        mov	ecx, dword ptr [rsi + 24]
+        sub	ecx, eax
+        xor	eax, eax
+        cmp	ecx, -65535
+        cmovb	eax, ecx
+        ret
+
+debug.defaultPanic:
+        push	rbp
+        push	r15
+        push	r14
+        push	r13
+        push	r12
+        push	rbx
+        sub	rsp, 200
+        mov	rax, qword ptr fs:[debug.panic_stage@TPOFF]
+        test	rax, rax
+        jne	.LBB23_1
+        mov	r14, rsi
+        mov	r15, rdi
+        mov	qword ptr fs:[debug.panic_stage@TPOFF], 1
+        lock		add	byte ptr [rip + debug.panicking], 1
+        lea	rdi, [rsp + 104]
+        call	debug.lockStderr
+        mov	r13, qword ptr [rsp + 104]
+        movzx	eax, byte ptr [rsp + 112]
+        lea	rcx, [r13 + 24]
+        mov	qword ptr [rsp + 120], rcx
+        and	al, 3
+        mov	byte ptr [rsp + 128], al
+        cmp	byte ptr fs:[Thread.LinuxThreadImpl.tls_thread_id.1@TPOFF], 1
+        mov	qword ptr [rsp + 16], rcx
+        jne	.LBB23_5
+        mov	r12d, dword ptr fs:[Thread.LinuxThreadImpl.tls_thread_id.0@TPOFF]
+        jmp	.LBB23_6
+.LBB23_5:
+        mov	eax, 186
+        #APP
+        syscall
+        #NO_APP
+        mov	r12, rax
+        mov	dword ptr fs:[Thread.LinuxThreadImpl.tls_thread_id.0@TPOFF], r12d
+        mov	byte ptr fs:[Thread.LinuxThreadImpl.tls_thread_id.1@TPOFF], 1
+.LBB23_6:
+        xor	ebp, ebp
+.LBB23_7:
+        lea	rsi, [rbp + __anon_1]
+        mov	rbx, rbp
+        xor	rbx, 7
+        mov	rdi, qword ptr [r13 + 48]
+        lea	rax, [rdi + rbx]
+        cmp	rax, qword ptr [r13 + 40]
+        ja	.LBB23_9
+        add	rdi, qword ptr [r13 + 32]
+        mov	rdx, rbx
+        call	memcpy@PLT
+        add	qword ptr [r13 + 48], rbx
+        add	rbp, rbx
+        cmp	rbp, 7
+        jb	.LBB23_7
+        jmp	.LBB23_12
+.LBB23_9:
+        mov	rcx, qword ptr [rsp + 16]
+        mov	rax, qword ptr [rcx]
+        mov	rax, qword ptr [rax]
+        mov	qword ptr [rsp], rsi
+        mov	qword ptr [rsp + 8], rbx
+        mov	rsi, rcx
+        mov	ecx, 1
+        mov	r8d, 1
+        lea	rdi, [rsp + 31]
+        mov	rdx, rsp
+        call	rax
+        cmp	word ptr [rsp + 39], 0
+        jne	.LBB23_58
+        mov	rbx, qword ptr [rsp + 31]
+        add	rbp, rbx
+        cmp	rbp, 7
+        jb	.LBB23_7
+.LBB23_12:
+        mov	edx, r12d
+        mov	eax, 65
+        cmp	r12d, 100
+        jb	.LBB23_13
+.LBB23_25:
+        imul	rcx, rdx, 1374389535
+        shr	rcx, 37
+        imul	esi, ecx, 100
+        mov	edi, edx
+        sub	edi, esi
+        movzx	esi, word ptr [rdi + rdi + __anon_2]
+        mov	word ptr [rsp + rax + 29], si
+        add	rax, -2
+        cmp	rdx, 9999
+        mov	rdx, rcx
+        ja	.LBB23_25
+        mov	qword ptr [rsp + 96], r15
+        cmp	ecx, 9
+        ja	.LBB23_14
+.LBB23_27:
+        or	cl, 48
+        mov	byte ptr [rsp + rax + 30], cl
+        add	rax, -1
+        mov	r12, rax
+        sub	r12, 65
+        je	.LBB23_22
+        jmp	.LBB23_16
+.LBB23_13:
+        mov	rcx, rdx
+        mov	qword ptr [rsp + 96], r15
+        cmp	ecx, 9
+        jbe	.LBB23_27
+.LBB23_14:
+        movzx	ecx, word ptr [rcx + rcx + __anon_2]
+        mov	word ptr [rsp + rax + 29], cx
+        add	rax, -2
+        mov	r12, rax
+        sub	r12, 65
+        jne	.LBB23_16
+.LBB23_22:
+        xor	r12d, r12d
+        mov	rbp, rsp
+        mov	r15, qword ptr [rsp + 96]
+.LBB23_23:
+        lea	rsi, [r12 + __anon_3]
+        mov	ebx, 8
+        sub	rbx, r12
+        mov	rdi, qword ptr [r13 + 48]
+        lea	rax, [rdi + rbx]
+        cmp	rax, qword ptr [r13 + 40]
+        ja	.LBB23_28
+        add	rdi, qword ptr [r13 + 32]
+        mov	rdx, rbx
+        call	memcpy@PLT
+        add	qword ptr [r13 + 48], rbx
+        add	r12, rbx
+        cmp	r12, 8
+        jb	.LBB23_23
+        jmp	.LBB23_31
+.LBB23_28:
+        mov	rcx, qword ptr [rsp + 16]
+        mov	rax, qword ptr [rcx]
+        mov	rax, qword ptr [rax]
+        mov	qword ptr [rsp], rsi
+        mov	qword ptr [rsp + 8], rbx
+        mov	rsi, rcx
+        mov	ecx, 1
+        mov	r8d, 1
+        lea	rdi, [rsp + 31]
+        mov	rdx, rbp
+        call	rax
+        cmp	word ptr [rsp + 39], 0
+        jne	.LBB23_58
+        mov	rbx, qword ptr [rsp + 31]
+        add	r12, rbx
+        cmp	r12, 8
+        jb	.LBB23_23
+.LBB23_31:
+        xor	r12d, r12d
+        mov	rbp, rsp
+.LBB23_32:
+        lea	rsi, [r15 + r12]
+        mov	rbx, r14
+        sub	rbx, r12
+        mov	rdi, qword ptr [r13 + 48]
+        lea	rax, [rdi + rbx]
+        cmp	rax, qword ptr [r13 + 40]
+        ja	.LBB23_43
+        add	rdi, qword ptr [r13 + 32]
+        mov	rdx, rbx
+        call	memcpy@PLT
+        add	qword ptr [r13 + 48], rbx
+        add	r12, rbx
+        cmp	r12, r14
+        jb	.LBB23_32
+        jmp	.LBB23_46
+.LBB23_43:
+        mov	rcx, qword ptr [rsp + 16]
+        mov	rax, qword ptr [rcx]
+        mov	rax, qword ptr [rax]
+        mov	qword ptr [rsp], rsi
+        mov	qword ptr [rsp + 8], rbx
+        mov	rsi, rcx
+        mov	ecx, 1
+        mov	r8d, 1
+        lea	rdi, [rsp + 31]
+        mov	rdx, rbp
+        call	rax
+        cmp	word ptr [rsp + 39], 0
+        jne	.LBB23_67
+        mov	rbx, qword ptr [rsp + 31]
+        add	r12, rbx
+        cmp	r12, r14
+        jb	.LBB23_32
+.LBB23_46:
+        lea	r14, [rsp + 31]
+        mov	r15, rsp
+.LBB23_47:
+        mov	rax, qword ptr [r13 + 48]
+        cmp	rax, qword ptr [r13 + 40]
+        mov	rsi, qword ptr [rsp + 16]
+        jb	.LBB23_48
+        mov	rax, qword ptr [rsi]
+        mov	rax, qword ptr [rax]
+        mov	qword ptr [rsp], offset __anon_4
+        mov	qword ptr [rsp + 8], 1
+        mov	ecx, 1
+        mov	r8d, 1
+        mov	rdi, r14
+        mov	rdx, r15
+        call	rax
+        cmp	word ptr [rsp + 39], 0
+        jne	.LBB23_67
+        cmp	qword ptr [rsp + 31], 0
+        je	.LBB23_47
+        jmp	.LBB23_51
+.LBB23_48:
+        mov	rcx, qword ptr [r13 + 32]
+        mov	byte ptr [rcx + rax], 10
+        add	qword ptr [r13 + 48], 1
+.LBB23_51:
+        mov	rax, qword ptr [rsp + 248]
+        mov	qword ptr [rsp + 152], rax
+        mov	byte ptr [rsp + 160], 1
+        mov	qword ptr [rsp + 168], 0
+        mov	byte ptr [rsp + 176], 1
+        lea	rdi, [rsp + 152]
+        lea	rsi, [rsp + 120]
+        call	debug.writeCurrentStackTrace
+        movzx	eax, word ptr [rip + Io.Threaded.global_single_threaded_instance+64]
+        test	ax, ax
+        jne	.LBB23_52
+        mov	rax, qword ptr [rip + Io.Threaded.global_single_threaded_instance+24]
+        mov	edi, offset Io.Threaded.global_single_threaded_instance+24
+        call	qword ptr [rax + 16]
+        movzx	eax, word ptr [rip + Io.Threaded.global_single_threaded_instance+64]
+.LBB23_52:
+        test	ax, ax
+        je	.LBB23_55
+        movzx	eax, ax
+        cmp	eax, 2
+        jne	.LBB23_54
+        lock		xor	qword ptr [8], 1
+.LBB23_54:
+        mov	word ptr [rip + Io.Threaded.global_single_threaded_instance+64], 0
+.LBB23_55:
+        mov	qword ptr [rip + Io.Threaded.global_single_threaded_instance+32], 1
+        xorps	xmm0, xmm0
+        movups	xmmword ptr [rip + Io.Threaded.global_single_threaded_instance+40], xmm0
+        add	qword ptr [rip + Io.Threaded.global_single_threaded_instance+800], -1
+        jne	.LBB23_40
+        mov	dword ptr [rip + Io.Threaded.global_single_threaded_instance+844], -1
+        xor	eax, eax
+        xchg	dword ptr [rip + Io.Threaded.global_single_threaded_instance+848], eax
+        cmp	eax, 2
+        je	.LBB23_57
+.LBB23_40:
+        lock		sub	byte ptr [rip + debug.panicking], 1
+        je	.LBB23_2
+        mov	dword ptr [rsp + 31], 0
+        lea	rdi, [rsp + 31]
+        mov	esi, 128
+.LBB23_42:
+        mov	eax, 202
+        xor	edx, edx
+        xor	r10d, r10d
+        #APP
+        syscall
+        #NO_APP
+        jmp	.LBB23_42
+.LBB23_16:
+        neg	r12
+        lea	rbp, [rsp + rax]
+        add	rbp, 31
+        xor	r15d, r15d
+.LBB23_17:
+        lea	rsi, [r15 + rbp]
+        mov	rbx, r12
+        sub	rbx, r15
+        mov	rdi, qword ptr [r13 + 48]
+        lea	rax, [rdi + rbx]
+        cmp	rax, qword ptr [r13 + 40]
+        ja	.LBB23_19
+        add	rdi, qword ptr [r13 + 32]
+        mov	rdx, rbx
+        call	memcpy@PLT
+        add	qword ptr [r13 + 48], rbx
+        add	r15, rbx
+        cmp	r15, r12
+        jb	.LBB23_17
+        jmp	.LBB23_22
+.LBB23_19:
+        mov	rcx, qword ptr [rsp + 16]
+        mov	rax, qword ptr [rcx]
+        mov	rax, qword ptr [rax]
+        mov	qword ptr [rsp + 136], rsi
+        mov	qword ptr [rsp + 144], rbx
+        mov	rsi, rcx
+        mov	ecx, 1
+        mov	r8d, 1
+        mov	rdi, rsp
+        lea	rdx, [rsp + 136]
+        call	rax
+        cmp	word ptr [rsp + 8], 0
+        jne	.LBB23_58
+        mov	rbx, qword ptr [rsp]
+        add	r15, rbx
+        cmp	r15, r12
+        jb	.LBB23_17
+        jmp	.LBB23_22
+.LBB23_58:
+        movzx	eax, word ptr [rip + Io.Threaded.global_single_threaded_instance+64]
+        test	ax, ax
+        jne	.LBB23_59
+        mov	rax, qword ptr [rip + Io.Threaded.global_single_threaded_instance+24]
+        mov	edi, offset Io.Threaded.global_single_threaded_instance+24
+        call	qword ptr [rax + 16]
+        movzx	eax, word ptr [rip + Io.Threaded.global_single_threaded_instance+64]
+.LBB23_59:
+        test	ax, ax
+        je	.LBB23_62
+        movzx	eax, ax
+        cmp	eax, 2
+        jne	.LBB23_61
+        lock		xor	qword ptr [8], 1
+.LBB23_61:
+        mov	word ptr [rip + Io.Threaded.global_single_threaded_instance+64], 0
+.LBB23_62:
+        mov	qword ptr [rip + Io.Threaded.global_single_threaded_instance+32], 1
+        xorps	xmm0, xmm0
+        movups	xmmword ptr [rip + Io.Threaded.global_single_threaded_instance+40], xmm0
+        add	qword ptr [rip + Io.Threaded.global_single_threaded_instance+800], -1
+        jne	.LBB23_40
+        mov	dword ptr [rip + Io.Threaded.global_single_threaded_instance+844], -1
+        xor	eax, eax
+        xchg	dword ptr [rip + Io.Threaded.global_single_threaded_instance+848], eax
+        cmp	eax, 2
+        jne	.LBB23_40
+        mov	eax, 202
+        mov	edi, offset Io.Threaded.global_single_threaded_instance+848
+        mov	esi, 129
+        mov	edx, 1
+        #APP
+        syscall
+        #NO_APP
+        jmp	.LBB23_40
+.LBB23_67:
+        movzx	eax, word ptr [rip + Io.Threaded.global_single_threaded_instance+64]
+        test	ax, ax
+        jne	.LBB23_68
+        mov	rax, qword ptr [rip + Io.Threaded.global_single_threaded_instance+24]
+        mov	edi, offset Io.Threaded.global_single_threaded_instance+24
+        call	qword ptr [rax + 16]
+        movzx	eax, word ptr [rip + Io.Threaded.global_single_threaded_instance+64]
+.LBB23_68:
+        test	ax, ax
+        je	.LBB23_71
+        movzx	eax, ax
+        cmp	eax, 2
+        jne	.LBB23_70
+        lock		xor	qword ptr [8], 1
+.LBB23_70:
+        mov	word ptr [rip + Io.Threaded.global_single_threaded_instance+64], 0
+.LBB23_71:
+        mov	qword ptr [rip + Io.Threaded.global_single_threaded_instance+32], 1
+        xorps	xmm0, xmm0
+        movups	xmmword ptr [rip + Io.Threaded.global_single_threaded_instance+40], xmm0
+        add	qword ptr [rip + Io.Threaded.global_single_threaded_instance+800], -1
+        jne	.LBB23_40
+        mov	dword ptr [rip + Io.Threaded.global_single_threaded_instance+844], -1
+        xor	eax, eax
+        xchg	dword ptr [rip + Io.Threaded.global_single_threaded_instance+848], eax
+        cmp	eax, 2
+        jne	.LBB23_40
+        mov	eax, 202
+        mov	edi, offset Io.Threaded.global_single_threaded_instance+848
+        mov	esi, 129
+        mov	edx, 1
+        #APP
+        syscall
+        #NO_APP
+        jmp	.LBB23_40
+.LBB23_57:
+        mov	eax, 202
+        mov	edi, offset Io.Threaded.global_single_threaded_instance+848
+        mov	esi, 129
+        mov	edx, 1
+        #APP
+        syscall
+        #NO_APP
+        jmp	.LBB23_40
+.LBB23_1:
+        cmp	rax, 1
+        jne	.LBB23_2
+        mov	qword ptr fs:[debug.panic_stage@TPOFF], 2
+        lea	rdi, [rsp + 184]
+        call	debug.lockStderr
+        mov	r13, qword ptr [rsp + 184]
+        lea	rbx, [r13 + 24]
+        xor	ebp, ebp
+        lea	r14, [rsp + 31]
+        mov	r15, rsp
+.LBB23_35:
+        lea	rsi, [rbp + __anon_5]
+        mov	r12d, 32
+        sub	r12, rbp
+        mov	rdi, qword ptr [r13 + 48]
+        lea	rax, [rdi + r12]
+        cmp	rax, qword ptr [r13 + 40]
+        ja	.LBB23_37
+        add	rdi, qword ptr [r13 + 32]
+        mov	rdx, r12
+        call	memcpy@PLT
+        add	qword ptr [r13 + 48], r12
+        add	rbp, r12
+        cmp	rbp, 32
+        jb	.LBB23_35
+        jmp	.LBB23_2
+.LBB23_37:
+        mov	rax, qword ptr [rbx]
+        mov	rax, qword ptr [rax]
+        mov	qword ptr [rsp], rsi
+        mov	qword ptr [rsp + 8], r12
+        mov	ecx, 1
+        mov	r8d, 1
+        mov	rdi, r14
+        mov	rsi, rbx
+        mov	rdx, r15
+        call	rax
+        cmp	word ptr [rsp + 39], 0
+        jne	.LBB23_2
+        mov	r12, qword ptr [rsp + 31]
+        add	rbp, r12
+        cmp	rbp, 32
+        jb	.LBB23_35
+.LBB23_2:
+        call	process.abort
+        .text
+
+timer.TimerModule.insertTimer:
+        mov	eax, dword ptr [rdi + 16]
+        lea	ecx, [rax + rdx]
+        mov	dword ptr [rsi + 24], ecx
+        mov	rcx, qword ptr [rdi]
+        test	rcx, rcx
+        je	.LBB5_1
+        mov	r8d, dword ptr [rcx + 8]
+        sub	r8d, eax
+        cmp	r8d, -65535
+        setb	r9b
+        cmp	r8d, edx
+        seta	r8b
+        test	r9b, r8b
+        je	.LBB5_6
+        mov	r8, rcx
+.LBB5_2:
+        mov	qword ptr [rsi + 16], r8
+        add	rsi, 16
+        mov	qword ptr [rdi], rsi
+        ret
+.LBB5_6:
+        mov	r8, qword ptr [rcx]
+        test	r8, r8
+        je	.LBB5_7
+        mov	edi, dword ptr [r8 + 8]
+        sub	edi, eax
+        cmp	edi, -65535
+        setb	r9b
+        cmp	edi, edx
+        seta	r10b
+        mov	rdi, rcx
+        mov	rcx, r8
+        test	r9b, r10b
+        je	.LBB5_6
+        jmp	.LBB5_2
+.LBB5_1:
+        xor	r8d, r8d
+        mov	qword ptr [rsi + 16], r8
+        add	rsi, 16
+        mov	qword ptr [rdi], rsi
+        ret
+.LBB5_7:
+        xor	r8d, r8d
+        mov	rdi, rcx
+        mov	qword ptr [rsi + 16], r8
+        add	rsi, 16
+        mov	qword ptr [rdi], rsi
+        ret
+
+timer.TimerModule.removeTimer:
+        push	r15
+        push	r14
+        push	rbx
+        mov	rbx, rsi
+        mov	r15, rdi
+        lea	r14, [rsi + 16]
+        mov	rsi, r14
+        call	timer.TimerModule.tryRemove
+        test	al, 1
+        jne	.LBB4_2
+        add	r15, 8
+        mov	rdi, r15
+        mov	rsi, r14
+        call	timer.TimerModule.tryRemove
+.LBB4_2:
+        mov	qword ptr [rbx + 8], 0
+        pop	rbx
+        pop	r14
+        pop	r15
+        ret
+
+timer.TimerModule.tryRemove:
+        mov	rax, qword ptr [rdi]
+        test	rax, rax
+        je	.LBB6_1
+        cmp	rax, rsi
+        je	.LBB6_6
+.LBB6_4:
+        mov	rcx, qword ptr [rax]
+        test	rcx, rcx
+        je	.LBB6_1
+        mov	rdi, rax
+        mov	rax, rcx
+        cmp	rcx, rsi
+        jne	.LBB6_4
+.LBB6_6:
+        mov	rax, qword ptr [rsi]
+        mov	qword ptr [rdi], rax
+        mov	al, 1
+        ret
+.LBB6_1:
+        xor	eax, eax
+        ret
+

--- a/erd_core/codegen/timer/ReleaseFast_x86_64.sizes
+++ b/erd_core/codegen/timer/ReleaseFast_x86_64.sizes
@@ -1,0 +1,23 @@
+# size (bytes)	function
+4	timer_increment
+5	timer_is_running
+5	timer_pause
+5	timer_remaining
+5	timer_run
+5	timer_stop
+5	timer_unpause
+15	timer_start_oneshot
+15	timer_start_periodic
+27	timer_elapsed
+30	run_until_idle
+34	timer_until_next
+36	timer_is_active
+36	timer_is_paused
+62	timer_ticks_since
+121	app_pause_all
+121	app_stop_all
+121	app_unpause_all
+147	app_query_remaining
+158	app_control_burst
+163	app_query_running
+201	app_init

--- a/erd_core/codegen/timer/ReleaseSmall/app_control_burst.s
+++ b/erd_core/codegen/timer/ReleaseSmall/app_control_burst.s
@@ -1,0 +1,211 @@
+; snapshot_comments.zig
+; Speed: Near-optimal | Size: Optimal
+;
+app_control_burst:
+        push	r15
+        push	r14
+        push	rbx
+        mov	rbx, rsi
+        mov	r14, rdi
+        push	10
+        pop	rdx
+        call	.Ltimer.TimerModule.startPeriodic
+        mov	rdi, r14
+        mov	rsi, rbx
+        call	.Ltimer.TimerModule.pause
+        mov	rdi, r14
+        mov	rsi, rbx
+        call	.Ltimer.TimerModule.unpause
+        lea	r15, [rbx + 32]
+        push	20
+        pop	rdx
+        mov	rdi, r14
+        mov	rsi, r15
+        call	.Ltimer.TimerModule.startOneShot
+        mov	rdi, r14
+        mov	rsi, r15
+        call	.Ltimer.TimerModule.stop
+        lea	r15, [rbx + 64]
+        push	30
+        pop	rdx
+        mov	rdi, r14
+        mov	rsi, r15
+        call	.Ltimer.TimerModule.startPeriodic
+        add	rbx, 96
+        push	40
+        pop	rdx
+        mov	rdi, r14
+        mov	rsi, rbx
+        call	.Ltimer.TimerModule.startOneShot
+        mov	rdi, r14
+        mov	rsi, r15
+        call	.Ltimer.TimerModule.stop
+        mov	rdi, r14
+        mov	rsi, rbx
+        pop	rbx
+        pop	r14
+        pop	r15
+        jmp	.Ltimer.TimerModule.stop
+
+; --- called functions ---
+
+.Ltimer.TimerModule.startPeriodic:
+        cmp	qword ptr [rsi + 8], 0
+        jne	.L0
+        lea	rax, [rsi + 16]
+        cmp	qword ptr [rdi], rax
+        je	.L0
+        mov	qword ptr [rsi + 8], offset .Lcodegen_timer.cb0
+        mov	dword ptr [rsi + 28], edx
+        mov	qword ptr [rsi], 1
+        jmp	.Ltimer.TimerModule.insertTimer
+.L0:
+        push	rbp
+        push	r14
+        push	rbx
+        mov	rbx, rdi
+        mov	r14, rsi
+        mov	ebp, edx
+        call	.Ltimer.TimerModule.removeTimer
+        mov	rdi, rbx
+        mov	rsi, r14
+        mov	edx, ebp
+        pop	rbx
+        pop	r14
+        pop	rbp
+        mov	qword ptr [rsi + 8], offset .Lcodegen_timer.cb0
+        mov	dword ptr [rsi + 28], edx
+        mov	qword ptr [rsi], 1
+        jmp	.Ltimer.TimerModule.insertTimer
+
+.Ltimer.TimerModule.pause:
+        push	r15
+        push	r14
+        push	rbx
+        cmp	qword ptr [rsi + 8], 0
+        je	.L1
+        mov	rbx, rsi
+        mov	r14, rdi
+        lea	r15, [rsi + 16]
+        mov	rsi, r15
+        call	.Ltimer.TimerModule.tryRemove
+        test	al, 1
+        je	.L2
+        mov	eax, dword ptr [r14 + 16]
+        mov	ecx, dword ptr [rbx + 24]
+        sub	ecx, eax
+        xor	eax, eax
+        cmp	ecx, -65535
+        cmovb	eax, ecx
+        mov	dword ptr [rbx + 24], eax
+        mov	rax, qword ptr [r14 + 8]
+        mov	qword ptr [rbx + 16], rax
+        mov	qword ptr [r14 + 8], r15
+        pop	rbx
+        pop	r14
+        pop	r15
+        ret
+.L2:
+        lea	rax, [r14 + 8]
+.L3:
+        mov	rax, qword ptr [rax]
+        test	rax, rax
+        je	.L4
+        cmp	rax, r15
+        jne	.L3
+.L4:
+        test	rax, rax
+        je	.L5
+.L1:
+        pop	rbx
+        pop	r14
+        pop	r15
+        ret
+.L5:
+        mov	rdi, r14
+        mov	rsi, rbx
+        pop	rbx
+        pop	r14
+        pop	r15
+        jmp	.Ltimer.TimerModule.isRunning
+
+.Ltimer.TimerModule.unpause:
+        push	r15
+        push	r14
+        push	rbx
+        cmp	qword ptr [rsi + 8], 0
+        je	.L6
+        mov	rbx, rsi
+        mov	r14, rdi
+        add	rdi, 8
+        lea	r15, [rsi + 16]
+        mov	rsi, r15
+        call	.Ltimer.TimerModule.tryRemove
+        test	al, 1
+        je	.L7
+        mov	edx, dword ptr [rbx + 24]
+        mov	rdi, r14
+        mov	rsi, rbx
+        pop	rbx
+        pop	r14
+        pop	r15
+        jmp	.Ltimer.TimerModule.insertTimer
+.L7:
+        mov	rax, r14
+.L8:
+        mov	rax, qword ptr [rax]
+        test	rax, rax
+        je	.L9
+        cmp	rax, r15
+        jne	.L8
+.L9:
+        test	rax, rax
+        je	.L10
+.L6:
+        pop	rbx
+        pop	r14
+        pop	r15
+        ret
+.L10:
+        mov	rdi, r14
+        mov	rsi, rbx
+        pop	rbx
+        pop	r14
+        pop	r15
+        jmp	.Ltimer.TimerModule.isRunning
+
+.Ltimer.TimerModule.startOneShot:
+        cmp	qword ptr [rsi + 8], 0
+        jne	.L11
+        lea	rax, [rsi + 16]
+        cmp	qword ptr [rdi], rax
+        je	.L11
+        mov	qword ptr [rsi + 8], offset .Lcodegen_timer.cb0
+        mov	dword ptr [rsi + 28], edx
+        mov	qword ptr [rsi], 0
+        jmp	.Ltimer.TimerModule.insertTimer
+.L11:
+        push	rbp
+        push	r14
+        push	rbx
+        mov	rbx, rdi
+        mov	r14, rsi
+        mov	ebp, edx
+        call	.Ltimer.TimerModule.removeTimer
+        mov	rdi, rbx
+        mov	rsi, r14
+        mov	edx, ebp
+        pop	rbx
+        pop	r14
+        pop	rbp
+        mov	qword ptr [rsi + 8], offset .Lcodegen_timer.cb0
+        mov	dword ptr [rsi + 28], edx
+        mov	qword ptr [rsi], 0
+        jmp	.Ltimer.TimerModule.insertTimer
+
+.Ltimer.TimerModule.stop:
+        and	byte ptr [rsi], -2
+        cmp	qword ptr [rsi + 8], 0
+        jne	.Ltimer.TimerModule.removeTimer
+        ret
+

--- a/erd_core/codegen/timer/ReleaseSmall/app_init.s
+++ b/erd_core/codegen/timer/ReleaseSmall/app_init.s
@@ -1,0 +1,113 @@
+; snapshot_comments.zig
+; Speed: Near-optimal | Size: Optimal
+; 8 starts -> 8 calls to shared startPeriodic/startOneShot (was 1812 bytes of inlined copies in RF).
+;
+app_init:
+        push	r14
+        push	rbx
+        push	rax
+        mov	rbx, rsi
+        mov	r14, rdi
+        push	10
+        pop	rdx
+        call	.Ltimer.TimerModule.startPeriodic
+        lea	rsi, [rbx + 32]
+        push	20
+        pop	rdx
+        mov	rdi, r14
+        call	.Ltimer.TimerModule.startPeriodic
+        lea	rsi, [rbx + 64]
+        push	30
+        pop	rdx
+        mov	rdi, r14
+        call	.Ltimer.TimerModule.startPeriodic
+        lea	rsi, [rbx + 96]
+        push	40
+        pop	rdx
+        mov	rdi, r14
+        call	.Ltimer.TimerModule.startOneShot
+        lea	rsi, [rbx + 128]
+        push	50
+        pop	rdx
+        mov	rdi, r14
+        call	.Ltimer.TimerModule.startOneShot
+        lea	rsi, [rbx + 160]
+        push	60
+        pop	rdx
+        mov	rdi, r14
+        call	.Ltimer.TimerModule.startOneShot
+        lea	rsi, [rbx + 192]
+        push	70
+        pop	rdx
+        mov	rdi, r14
+        call	.Ltimer.TimerModule.startPeriodic
+        add	rbx, 224
+        push	80
+        pop	rdx
+        mov	rdi, r14
+        mov	rsi, rbx
+        add	rsp, 8
+        pop	rbx
+        pop	r14
+        jmp	.Ltimer.TimerModule.startOneShot
+
+; --- called functions ---
+
+.Ltimer.TimerModule.startPeriodic:
+        cmp	qword ptr [rsi + 8], 0
+        jne	.L0
+        lea	rax, [rsi + 16]
+        cmp	qword ptr [rdi], rax
+        je	.L0
+        mov	qword ptr [rsi + 8], offset .Lcodegen_timer.cb0
+        mov	dword ptr [rsi + 28], edx
+        mov	qword ptr [rsi], 1
+        jmp	.Ltimer.TimerModule.insertTimer
+.L0:
+        push	rbp
+        push	r14
+        push	rbx
+        mov	rbx, rdi
+        mov	r14, rsi
+        mov	ebp, edx
+        call	.Ltimer.TimerModule.removeTimer
+        mov	rdi, rbx
+        mov	rsi, r14
+        mov	edx, ebp
+        pop	rbx
+        pop	r14
+        pop	rbp
+        mov	qword ptr [rsi + 8], offset .Lcodegen_timer.cb0
+        mov	dword ptr [rsi + 28], edx
+        mov	qword ptr [rsi], 1
+        jmp	.Ltimer.TimerModule.insertTimer
+
+.Ltimer.TimerModule.startOneShot:
+        cmp	qword ptr [rsi + 8], 0
+        jne	.L1
+        lea	rax, [rsi + 16]
+        cmp	qword ptr [rdi], rax
+        je	.L1
+        mov	qword ptr [rsi + 8], offset .Lcodegen_timer.cb0
+        mov	dword ptr [rsi + 28], edx
+        mov	qword ptr [rsi], 0
+        jmp	.Ltimer.TimerModule.insertTimer
+.L1:
+        push	rbp
+        push	r14
+        push	rbx
+        mov	rbx, rdi
+        mov	r14, rsi
+        mov	ebp, edx
+        call	.Ltimer.TimerModule.removeTimer
+        mov	rdi, rbx
+        mov	rsi, r14
+        mov	edx, ebp
+        pop	rbx
+        pop	r14
+        pop	rbp
+        mov	qword ptr [rsi + 8], offset .Lcodegen_timer.cb0
+        mov	dword ptr [rsi + 28], edx
+        mov	qword ptr [rsi], 0
+        jmp	.Ltimer.TimerModule.insertTimer
+

--- a/erd_core/codegen/timer/ReleaseSmall/app_pause_all.s
+++ b/erd_core/codegen/timer/ReleaseSmall/app_pause_all.s
@@ -1,0 +1,89 @@
+; snapshot_comments.zig
+; Speed: Near-optimal | Size: Optimal
+;
+app_pause_all:
+        push	r14
+        push	rbx
+        push	rax
+        mov	rbx, rsi
+        mov	r14, rdi
+        call	.Ltimer.TimerModule.pause
+        lea	rsi, [rbx + 32]
+        mov	rdi, r14
+        call	.Ltimer.TimerModule.pause
+        lea	rsi, [rbx + 64]
+        mov	rdi, r14
+        call	.Ltimer.TimerModule.pause
+        lea	rsi, [rbx + 96]
+        mov	rdi, r14
+        call	.Ltimer.TimerModule.pause
+        lea	rsi, [rbx + 128]
+        mov	rdi, r14
+        call	.Ltimer.TimerModule.pause
+        lea	rsi, [rbx + 160]
+        mov	rdi, r14
+        call	.Ltimer.TimerModule.pause
+        lea	rsi, [rbx + 192]
+        mov	rdi, r14
+        call	.Ltimer.TimerModule.pause
+        add	rbx, 224
+        mov	rdi, r14
+        mov	rsi, rbx
+        add	rsp, 8
+        pop	rbx
+        pop	r14
+        jmp	.Ltimer.TimerModule.pause
+
+; --- called functions ---
+
+.Ltimer.TimerModule.pause:
+        push	r15
+        push	r14
+        push	rbx
+        cmp	qword ptr [rsi + 8], 0
+        je	.L0
+        mov	rbx, rsi
+        mov	r14, rdi
+        lea	r15, [rsi + 16]
+        mov	rsi, r15
+        call	.Ltimer.TimerModule.tryRemove
+        test	al, 1
+        je	.L1
+        mov	eax, dword ptr [r14 + 16]
+        mov	ecx, dword ptr [rbx + 24]
+        sub	ecx, eax
+        xor	eax, eax
+        cmp	ecx, -65535
+        cmovb	eax, ecx
+        mov	dword ptr [rbx + 24], eax
+        mov	rax, qword ptr [r14 + 8]
+        mov	qword ptr [rbx + 16], rax
+        mov	qword ptr [r14 + 8], r15
+        pop	rbx
+        pop	r14
+        pop	r15
+        ret
+.L1:
+        lea	rax, [r14 + 8]
+.L2:
+        mov	rax, qword ptr [rax]
+        test	rax, rax
+        je	.L3
+        cmp	rax, r15
+        jne	.L2
+.L3:
+        test	rax, rax
+        je	.L4
+.L0:
+        pop	rbx
+        pop	r14
+        pop	r15
+        ret
+.L4:
+        mov	rdi, r14
+        mov	rsi, rbx
+        pop	rbx
+        pop	r14
+        pop	r15
+        jmp	.Ltimer.TimerModule.isRunning
+

--- a/erd_core/codegen/timer/ReleaseSmall/app_query_remaining.s
+++ b/erd_core/codegen/timer/ReleaseSmall/app_query_remaining.s
@@ -1,0 +1,76 @@
+; snapshot_comments.zig
+; Speed: Near-optimal | Size: Optimal
+;
+app_query_remaining:
+        push	r15
+        push	r14
+        push	rbx
+        mov	rbx, rdx
+        mov	r14, rsi
+        mov	r15, rdi
+        call	.Ltimer.TimerModule.remainingTicks
+        mov	dword ptr [rbx], eax
+        lea	rsi, [r14 + 32]
+        mov	rdi, r15
+        call	.Ltimer.TimerModule.remainingTicks
+        mov	dword ptr [rbx + 4], eax
+        lea	rsi, [r14 + 64]
+        mov	rdi, r15
+        call	.Ltimer.TimerModule.remainingTicks
+        mov	dword ptr [rbx + 8], eax
+        lea	rsi, [r14 + 96]
+        mov	rdi, r15
+        call	.Ltimer.TimerModule.remainingTicks
+        mov	dword ptr [rbx + 12], eax
+        lea	rsi, [r14 + 128]
+        mov	rdi, r15
+        call	.Ltimer.TimerModule.remainingTicks
+        mov	dword ptr [rbx + 16], eax
+        lea	rsi, [r14 + 160]
+        mov	rdi, r15
+        call	.Ltimer.TimerModule.remainingTicks
+        mov	dword ptr [rbx + 20], eax
+        lea	rsi, [r14 + 192]
+        mov	rdi, r15
+        call	.Ltimer.TimerModule.remainingTicks
+        mov	dword ptr [rbx + 24], eax
+        add	r14, 224
+        mov	rdi, r15
+        mov	rsi, r14
+        call	.Ltimer.TimerModule.remainingTicks
+        mov	dword ptr [rbx + 28], eax
+        pop	rbx
+        pop	r14
+        pop	r15
+        ret
+
+; --- called functions ---
+
+.Ltimer.TimerModule.remainingTicks:
+        cmp	qword ptr [rsi + 8], 0
+        je	.L0
+        lea	rax, [rdi + 8]
+        lea	rcx, [rsi + 16]
+.L1:
+        mov	rax, qword ptr [rax]
+        test	rax, rax
+        je	.L2
+        cmp	rax, rcx
+        jne	.L1
+.L2:
+        test	rax, rax
+        je	.L3
+        mov	eax, dword ptr [rsi + 24]
+        ret
+.L0:
+        xor	eax, eax
+        ret
+.L3:
+        mov	eax, dword ptr [rdi + 16]
+        mov	ecx, dword ptr [rsi + 24]
+        sub	ecx, eax
+        xor	eax, eax
+        cmp	ecx, -65535
+        cmovb	eax, ecx
+        ret
+

--- a/erd_core/codegen/timer/ReleaseSmall/app_query_running.s
+++ b/erd_core/codegen/timer/ReleaseSmall/app_query_running.s
@@ -1,0 +1,80 @@
+; snapshot_comments.zig
+; Speed: Near-optimal | Size: Optimal
+;
+app_query_running:
+        push	r15
+        push	r14
+        push	rbx
+        mov	rbx, rdx
+        mov	r14, rsi
+        mov	r15, rdi
+        call	.Ltimer.TimerModule.isRunning
+        and	al, 1
+        mov	byte ptr [rbx], al
+        lea	rsi, [r14 + 32]
+        mov	rdi, r15
+        call	.Ltimer.TimerModule.isRunning
+        and	al, 1
+        mov	byte ptr [rbx + 1], al
+        lea	rsi, [r14 + 64]
+        mov	rdi, r15
+        call	.Ltimer.TimerModule.isRunning
+        and	al, 1
+        mov	byte ptr [rbx + 2], al
+        lea	rsi, [r14 + 96]
+        mov	rdi, r15
+        call	.Ltimer.TimerModule.isRunning
+        and	al, 1
+        mov	byte ptr [rbx + 3], al
+        lea	rsi, [r14 + 128]
+        mov	rdi, r15
+        call	.Ltimer.TimerModule.isRunning
+        and	al, 1
+        mov	byte ptr [rbx + 4], al
+        lea	rsi, [r14 + 160]
+        mov	rdi, r15
+        call	.Ltimer.TimerModule.isRunning
+        and	al, 1
+        mov	byte ptr [rbx + 5], al
+        lea	rsi, [r14 + 192]
+        mov	rdi, r15
+        call	.Ltimer.TimerModule.isRunning
+        and	al, 1
+        mov	byte ptr [rbx + 6], al
+        add	r14, 224
+        mov	rdi, r15
+        mov	rsi, r14
+        call	.Ltimer.TimerModule.isRunning
+        and	al, 1
+        mov	byte ptr [rbx + 7], al
+        pop	rbx
+        pop	r14
+        pop	r15
+        ret
+
+; --- called functions ---
+
+.Ltimer.TimerModule.isRunning:
+        add	rsi, 16
+        mov	rcx, rdi
+.L0:
+        mov	rcx, qword ptr [rcx]
+        test	rcx, rcx
+        je	.L1
+        cmp	rcx, rsi
+        jne	.L0
+.L1:
+        mov	al, 1
+        test	rcx, rcx
+        jne	.L2
+        add	rdi, 8
+.L3:
+        mov	rdi, qword ptr [rdi]
+        test	rdi, rdi
+        setne	al
+        je	.L2
+        cmp	rdi, rsi
+        jne	.L3
+.L2:
+        ret
+

--- a/erd_core/codegen/timer/ReleaseSmall/app_stop_all.s
+++ b/erd_core/codegen/timer/ReleaseSmall/app_stop_all.s
@@ -1,0 +1,44 @@
+; snapshot_comments.zig
+; Speed: Near-optimal | Size: Optimal
+;
+app_stop_all:
+        push	r14
+        push	rbx
+        push	rax
+        mov	rbx, rsi
+        mov	r14, rdi
+        call	.Ltimer.TimerModule.stop
+        lea	rsi, [rbx + 32]
+        mov	rdi, r14
+        call	.Ltimer.TimerModule.stop
+        lea	rsi, [rbx + 64]
+        mov	rdi, r14
+        call	.Ltimer.TimerModule.stop
+        lea	rsi, [rbx + 96]
+        mov	rdi, r14
+        call	.Ltimer.TimerModule.stop
+        lea	rsi, [rbx + 128]
+        mov	rdi, r14
+        call	.Ltimer.TimerModule.stop
+        lea	rsi, [rbx + 160]
+        mov	rdi, r14
+        call	.Ltimer.TimerModule.stop
+        lea	rsi, [rbx + 192]
+        mov	rdi, r14
+        call	.Ltimer.TimerModule.stop
+        add	rbx, 224
+        mov	rdi, r14
+        mov	rsi, rbx
+        add	rsp, 8
+        pop	rbx
+        pop	r14
+        jmp	.Ltimer.TimerModule.stop
+
+; --- called functions ---
+
+.Ltimer.TimerModule.stop:
+        and	byte ptr [rsi], -2
+        cmp	qword ptr [rsi + 8], 0
+        jne	.Ltimer.TimerModule.removeTimer
+        ret
+

--- a/erd_core/codegen/timer/ReleaseSmall/app_unpause_all.s
+++ b/erd_core/codegen/timer/ReleaseSmall/app_unpause_all.s
@@ -1,0 +1,84 @@
+; snapshot_comments.zig
+; Speed: Near-optimal | Size: Optimal
+; 8 unpause calls to shared bodies (was 2225 bytes of inlined tryRemove/insertTimer in RF).
+;
+app_unpause_all:
+        push	r14
+        push	rbx
+        push	rax
+        mov	rbx, rsi
+        mov	r14, rdi
+        call	.Ltimer.TimerModule.unpause
+        lea	rsi, [rbx + 32]
+        mov	rdi, r14
+        call	.Ltimer.TimerModule.unpause
+        lea	rsi, [rbx + 64]
+        mov	rdi, r14
+        call	.Ltimer.TimerModule.unpause
+        lea	rsi, [rbx + 96]
+        mov	rdi, r14
+        call	.Ltimer.TimerModule.unpause
+        lea	rsi, [rbx + 128]
+        mov	rdi, r14
+        call	.Ltimer.TimerModule.unpause
+        lea	rsi, [rbx + 160]
+        mov	rdi, r14
+        call	.Ltimer.TimerModule.unpause
+        lea	rsi, [rbx + 192]
+        mov	rdi, r14
+        call	.Ltimer.TimerModule.unpause
+        add	rbx, 224
+        mov	rdi, r14
+        mov	rsi, rbx
+        add	rsp, 8
+        pop	rbx
+        pop	r14
+        jmp	.Ltimer.TimerModule.unpause
+
+; --- called functions ---
+
+.Ltimer.TimerModule.unpause:
+        push	r15
+        push	r14
+        push	rbx
+        cmp	qword ptr [rsi + 8], 0
+        je	.L0
+        mov	rbx, rsi
+        mov	r14, rdi
+        add	rdi, 8
+        lea	r15, [rsi + 16]
+        mov	rsi, r15
+        call	.Ltimer.TimerModule.tryRemove
+        test	al, 1
+        je	.L1
+        mov	edx, dword ptr [rbx + 24]
+        mov	rdi, r14
+        mov	rsi, rbx
+        pop	rbx
+        pop	r14
+        pop	r15
+        jmp	.Ltimer.TimerModule.insertTimer
+.L1:
+        mov	rax, r14
+.L2:
+        mov	rax, qword ptr [rax]
+        test	rax, rax
+        je	.L3
+        cmp	rax, r15
+        jne	.L2
+.L3:
+        test	rax, rax
+        je	.L4
+.L0:
+        pop	rbx
+        pop	r14
+        pop	r15
+        ret
+.L4:
+        mov	rdi, r14
+        mov	rsi, rbx
+        pop	rbx
+        pop	r14
+        pop	r15
+        jmp	.Ltimer.TimerModule.isRunning
+

--- a/erd_core/codegen/timer/ReleaseSmall/run_until_idle.s
+++ b/erd_core/codegen/timer/ReleaseSmall/run_until_idle.s
@@ -1,0 +1,76 @@
+; snapshot_comments.zig
+; Speed: Optimal | Size: Optimal
+; Main-loop pattern: calls the shared, noinline run() until it returns false.
+;
+run_until_idle:
+        push	rbx
+        mov	rbx, rdi
+.L0:
+        mov	rdi, rbx
+        call	.Ltimer.TimerModule.run
+        test	al, 1
+        jne	.L0
+        pop	rbx
+        ret
+
+; --- called functions ---
+
+.Ltimer.TimerModule.run:
+        push	rbp
+        push	r15
+        push	r14
+        push	r12
+        push	rbx
+        mov	ecx, dword ptr [rdi + 16]
+        mov	rax, qword ptr [rdi]
+        test	rax, rax
+        je	.L1
+        sub	ecx, dword ptr [rax + 8]
+        cmp	ecx, 65535
+        ja	.L1
+        mov	rbx, rdi
+        lea	r14, [rax - 16]
+        mov	r12, qword ptr [r14]
+        mov	rdi, r12
+        test	r12b, 1
+        jne	.L2
+        mov	rcx, qword ptr [rax]
+        mov	qword ptr [rbx], rcx
+        mov	rdi, qword ptr [rax - 16]
+.L2:
+        mov	r15, qword ptr [r14 + 8]
+        mov	qword ptr [r14 + 8], 0
+        and	rdi, -2
+        mov	rsi, rbx
+        mov	rdx, r14
+        call	r15
+        mov	bpl, 1
+        cmp	qword ptr [r14 + 8], 0
+        jne	.L3
+        test	r12b, 1
+        je	.L4
+        mov	rax, qword ptr [rbx]
+        test	rax, rax
+        je	.L4
+        mov	rax, qword ptr [rax]
+        mov	qword ptr [rbx], rax
+.L4:
+        test	byte ptr [r14], 1
+        je	.L3
+        mov	edx, dword ptr [r14 + 28]
+        mov	rdi, rbx
+        mov	rsi, r14
+        call	.Ltimer.TimerModule.insertTimer
+        mov	qword ptr [r14 + 8], r15
+        jmp	.L3
+.L1:
+        xor	ebp, ebp
+.L3:
+        mov	eax, ebp
+        pop	rbx
+        pop	r12
+        pop	r14
+        pop	r15
+        pop	rbp
+        ret
+

--- a/erd_core/codegen/timer/ReleaseSmall/timer_elapsed.s
+++ b/erd_core/codegen/timer/ReleaseSmall/timer_elapsed.s
@@ -1,0 +1,48 @@
+; snapshot_comments.zig
+; Speed: Optimal | Size: Optimal
+;
+timer_elapsed:
+        push	rbx
+        cmp	qword ptr [rsi + 8], 0
+        je	.L0
+        mov	ebx, dword ptr [rsi + 28]
+        call	.Ltimer.TimerModule.remainingTicks
+        sub	ebx, eax
+        jmp	.L1
+.L0:
+        xor	ebx, ebx
+.L1:
+        mov	eax, ebx
+        pop	rbx
+        ret
+
+; --- called functions ---
+
+.Ltimer.TimerModule.remainingTicks:
+        cmp	qword ptr [rsi + 8], 0
+        je	.L2
+        lea	rax, [rdi + 8]
+        lea	rcx, [rsi + 16]
+.L3:
+        mov	rax, qword ptr [rax]
+        test	rax, rax
+        je	.L4
+        cmp	rax, rcx
+        jne	.L3
+.L4:
+        test	rax, rax
+        je	.L5
+        mov	eax, dword ptr [rsi + 24]
+        ret
+.L2:
+        xor	eax, eax
+        ret
+.L5:
+        mov	eax, dword ptr [rdi + 16]
+        mov	ecx, dword ptr [rsi + 24]
+        sub	ecx, eax
+        xor	eax, eax
+        cmp	ecx, -65535
+        cmovb	eax, ecx
+        ret
+

--- a/erd_core/codegen/timer/ReleaseSmall/timer_increment.s
+++ b/erd_core/codegen/timer/ReleaseSmall/timer_increment.s
@@ -1,0 +1,7 @@
+; snapshot_comments.zig
+; Speed: Optimal | Size: Optimal
+;
+timer_increment:
+        add	dword ptr [rdi + 16], esi
+        ret
+

--- a/erd_core/codegen/timer/ReleaseSmall/timer_is_active.s
+++ b/erd_core/codegen/timer/ReleaseSmall/timer_is_active.s
@@ -1,0 +1,16 @@
+; snapshot_comments.zig
+; Speed: Optimal | Size: Optimal
+;
+timer_is_active:
+        add	rsi, 16
+.L0:
+        mov	rdi, qword ptr [rdi]
+        test	rdi, rdi
+        je	.L1
+        cmp	rdi, rsi
+        jne	.L0
+.L1:
+        test	rdi, rdi
+        setne	al
+        ret
+

--- a/erd_core/codegen/timer/ReleaseSmall/timer_is_paused.s
+++ b/erd_core/codegen/timer/ReleaseSmall/timer_is_paused.s
@@ -1,0 +1,17 @@
+; snapshot_comments.zig
+; Speed: Optimal | Size: Optimal
+;
+timer_is_paused:
+        add	rdi, 8
+        add	rsi, 16
+.L0:
+        mov	rdi, qword ptr [rdi]
+        test	rdi, rdi
+        je	.L1
+        cmp	rdi, rsi
+        jne	.L0
+.L1:
+        test	rdi, rdi
+        setne	al
+        ret
+

--- a/erd_core/codegen/timer/ReleaseSmall/timer_is_running.s
+++ b/erd_core/codegen/timer/ReleaseSmall/timer_is_running.s
@@ -1,0 +1,32 @@
+; snapshot_comments.zig
+; Speed: Optimal | Size: Optimal
+;
+timer_is_running:
+        jmp	.Ltimer.TimerModule.isRunning
+
+; --- called functions ---
+
+.Ltimer.TimerModule.isRunning:
+        add	rsi, 16
+        mov	rcx, rdi
+.L0:
+        mov	rcx, qword ptr [rcx]
+        test	rcx, rcx
+        je	.L1
+        cmp	rcx, rsi
+        jne	.L0
+.L1:
+        mov	al, 1
+        test	rcx, rcx
+        jne	.L2
+        add	rdi, 8
+.L3:
+        mov	rdi, qword ptr [rdi]
+        test	rdi, rdi
+        setne	al
+        je	.L2
+        cmp	rdi, rsi
+        jne	.L3
+.L2:
+        ret
+

--- a/erd_core/codegen/timer/ReleaseSmall/timer_pause.s
+++ b/erd_core/codegen/timer/ReleaseSmall/timer_pause.s
@@ -1,0 +1,59 @@
+; snapshot_comments.zig
+; Speed: Optimal | Size: Optimal
+;
+timer_pause:
+        jmp	.Ltimer.TimerModule.pause
+
+; --- called functions ---
+
+.Ltimer.TimerModule.pause:
+        push	r15
+        push	r14
+        push	rbx
+        cmp	qword ptr [rsi + 8], 0
+        je	.L0
+        mov	rbx, rsi
+        mov	r14, rdi
+        lea	r15, [rsi + 16]
+        mov	rsi, r15
+        call	.Ltimer.TimerModule.tryRemove
+        test	al, 1
+        je	.L1
+        mov	eax, dword ptr [r14 + 16]
+        mov	ecx, dword ptr [rbx + 24]
+        sub	ecx, eax
+        xor	eax, eax
+        cmp	ecx, -65535
+        cmovb	eax, ecx
+        mov	dword ptr [rbx + 24], eax
+        mov	rax, qword ptr [r14 + 8]
+        mov	qword ptr [rbx + 16], rax
+        mov	qword ptr [r14 + 8], r15
+        pop	rbx
+        pop	r14
+        pop	r15
+        ret
+.L1:
+        lea	rax, [r14 + 8]
+.L2:
+        mov	rax, qword ptr [rax]
+        test	rax, rax
+        je	.L3
+        cmp	rax, r15
+        jne	.L2
+.L3:
+        test	rax, rax
+        je	.L4
+.L0:
+        pop	rbx
+        pop	r14
+        pop	r15
+        ret
+.L4:
+        mov	rdi, r14
+        mov	rsi, rbx
+        pop	rbx
+        pop	r14
+        pop	r15
+        jmp	.Ltimer.TimerModule.isRunning
+

--- a/erd_core/codegen/timer/ReleaseSmall/timer_remaining.s
+++ b/erd_core/codegen/timer/ReleaseSmall/timer_remaining.s
@@ -1,0 +1,36 @@
+; snapshot_comments.zig
+; Speed: Optimal | Size: Optimal
+;
+timer_remaining:
+        jmp	.Ltimer.TimerModule.remainingTicks
+
+; --- called functions ---
+
+.Ltimer.TimerModule.remainingTicks:
+        cmp	qword ptr [rsi + 8], 0
+        je	.L0
+        lea	rax, [rdi + 8]
+        lea	rcx, [rsi + 16]
+.L1:
+        mov	rax, qword ptr [rax]
+        test	rax, rax
+        je	.L2
+        cmp	rax, rcx
+        jne	.L1
+.L2:
+        test	rax, rax
+        je	.L3
+        mov	eax, dword ptr [rsi + 24]
+        ret
+.L0:
+        xor	eax, eax
+        ret
+.L3:
+        mov	eax, dword ptr [rdi + 16]
+        mov	ecx, dword ptr [rsi + 24]
+        sub	ecx, eax
+        xor	eax, eax
+        cmp	ecx, -65535
+        cmovb	eax, ecx
+        ret
+

--- a/erd_core/codegen/timer/ReleaseSmall/timer_run.s
+++ b/erd_core/codegen/timer/ReleaseSmall/timer_run.s
@@ -1,0 +1,67 @@
+; snapshot_comments.zig
+; Speed: Optimal | Size: Optimal
+;
+timer_run:
+        jmp	.Ltimer.TimerModule.run
+
+; --- called functions ---
+
+.Ltimer.TimerModule.run:
+        push	rbp
+        push	r15
+        push	r14
+        push	r12
+        push	rbx
+        mov	ecx, dword ptr [rdi + 16]
+        mov	rax, qword ptr [rdi]
+        test	rax, rax
+        je	.L0
+        sub	ecx, dword ptr [rax + 8]
+        cmp	ecx, 65535
+        ja	.L0
+        mov	rbx, rdi
+        lea	r14, [rax - 16]
+        mov	r12, qword ptr [r14]
+        mov	rdi, r12
+        test	r12b, 1
+        jne	.L1
+        mov	rcx, qword ptr [rax]
+        mov	qword ptr [rbx], rcx
+        mov	rdi, qword ptr [rax - 16]
+.L1:
+        mov	r15, qword ptr [r14 + 8]
+        mov	qword ptr [r14 + 8], 0
+        and	rdi, -2
+        mov	rsi, rbx
+        mov	rdx, r14
+        call	r15
+        mov	bpl, 1
+        cmp	qword ptr [r14 + 8], 0
+        jne	.L2
+        test	r12b, 1
+        je	.L3
+        mov	rax, qword ptr [rbx]
+        test	rax, rax
+        je	.L3
+        mov	rax, qword ptr [rax]
+        mov	qword ptr [rbx], rax
+.L3:
+        test	byte ptr [r14], 1
+        je	.L2
+        mov	edx, dword ptr [r14 + 28]
+        mov	rdi, rbx
+        mov	rsi, r14
+        call	.Ltimer.TimerModule.insertTimer
+        mov	qword ptr [r14 + 8], r15
+        jmp	.L2
+.L0:
+        xor	ebp, ebp
+.L2:
+        mov	eax, ebp
+        pop	rbx
+        pop	r12
+        pop	r14
+        pop	r15
+        pop	rbp
+        ret
+

--- a/erd_core/codegen/timer/ReleaseSmall/timer_start_oneshot.s
+++ b/erd_core/codegen/timer/ReleaseSmall/timer_start_oneshot.s
@@ -1,0 +1,39 @@
+; snapshot_comments.zig
+; Speed: Optimal | Size: Optimal
+;
+timer_start_oneshot:
+        push	100
+        pop	rdx
+        jmp	.Ltimer.TimerModule.startOneShot
+
+; --- called functions ---
+
+.Ltimer.TimerModule.startOneShot:
+        cmp	qword ptr [rsi + 8], 0
+        jne	.L0
+        lea	rax, [rsi + 16]
+        cmp	qword ptr [rdi], rax
+        je	.L0
+        mov	qword ptr [rsi + 8], offset .Lcodegen_timer.cb0
+        mov	dword ptr [rsi + 28], edx
+        mov	qword ptr [rsi], 0
+        jmp	.Ltimer.TimerModule.insertTimer
+.L0:
+        push	rbp
+        push	r14
+        push	rbx
+        mov	rbx, rdi
+        mov	r14, rsi
+        mov	ebp, edx
+        call	.Ltimer.TimerModule.removeTimer
+        mov	rdi, rbx
+        mov	rsi, r14
+        mov	edx, ebp
+        pop	rbx
+        pop	r14
+        pop	rbp
+        mov	qword ptr [rsi + 8], offset .Lcodegen_timer.cb0
+        mov	dword ptr [rsi + 28], edx
+        mov	qword ptr [rsi], 0
+        jmp	.Ltimer.TimerModule.insertTimer
+

--- a/erd_core/codegen/timer/ReleaseSmall/timer_start_periodic.s
+++ b/erd_core/codegen/timer/ReleaseSmall/timer_start_periodic.s
@@ -1,0 +1,40 @@
+; snapshot_comments.zig
+; Speed: Optimal | Size: Optimal
+; Tail call into shared, noinline startPeriodic (was 196 bytes inlined in RF).
+;
+timer_start_periodic:
+        push	100
+        pop	rdx
+        jmp	.Ltimer.TimerModule.startPeriodic
+
+; --- called functions ---
+
+.Ltimer.TimerModule.startPeriodic:
+        cmp	qword ptr [rsi + 8], 0
+        jne	.L0
+        lea	rax, [rsi + 16]
+        cmp	qword ptr [rdi], rax
+        je	.L0
+        mov	qword ptr [rsi + 8], offset .Lcodegen_timer.cb0
+        mov	dword ptr [rsi + 28], edx
+        mov	qword ptr [rsi], 1
+        jmp	.Ltimer.TimerModule.insertTimer
+.L0:
+        push	rbp
+        push	r14
+        push	rbx
+        mov	rbx, rdi
+        mov	r14, rsi
+        mov	ebp, edx
+        call	.Ltimer.TimerModule.removeTimer
+        mov	rdi, rbx
+        mov	rsi, r14
+        mov	edx, ebp
+        pop	rbx
+        pop	r14
+        pop	rbp
+        mov	qword ptr [rsi + 8], offset .Lcodegen_timer.cb0
+        mov	dword ptr [rsi + 28], edx
+        mov	qword ptr [rsi], 1
+        jmp	.Ltimer.TimerModule.insertTimer
+

--- a/erd_core/codegen/timer/ReleaseSmall/timer_stop.s
+++ b/erd_core/codegen/timer/ReleaseSmall/timer_stop.s
@@ -1,0 +1,14 @@
+; snapshot_comments.zig
+; Speed: Optimal | Size: Optimal
+;
+timer_stop:
+        jmp	.Ltimer.TimerModule.stop
+
+; --- called functions ---
+
+.Ltimer.TimerModule.stop:
+        and	byte ptr [rsi], -2
+        cmp	qword ptr [rsi + 8], 0
+        jne	.Ltimer.TimerModule.removeTimer
+        ret
+

--- a/erd_core/codegen/timer/ReleaseSmall/timer_ticks_since.s
+++ b/erd_core/codegen/timer/ReleaseSmall/timer_ticks_since.s
@@ -1,0 +1,28 @@
+; snapshot_comments.zig
+; Speed: Optimal | Size: Optimal
+;
+timer_ticks_since:
+        push	rax
+        lea	rax, [rdi + 8]
+        lea	rcx, [rsi + 16]
+.L0:
+        mov	rax, qword ptr [rax]
+        test	rax, rax
+        je	.L1
+        cmp	rax, rcx
+        jne	.L0
+.L1:
+        test	rax, rax
+        jne	.L2
+        mov	ecx, dword ptr [rsi + 28]
+        sub	ecx, dword ptr [rsi + 24]
+        mov	eax, dword ptr [rdi + 16]
+        add	eax, ecx
+        pop	rcx
+        ret
+.L2:
+        push	61
+        pop	rsi
+        mov	edi, offset .L__anon_0
+        call	.Ldebug.defaultPanic
+

--- a/erd_core/codegen/timer/ReleaseSmall/timer_unpause.s
+++ b/erd_core/codegen/timer/ReleaseSmall/timer_unpause.s
@@ -1,0 +1,53 @@
+; snapshot_comments.zig
+; Speed: Optimal | Size: Optimal
+;
+timer_unpause:
+        jmp	.Ltimer.TimerModule.unpause
+
+; --- called functions ---
+
+.Ltimer.TimerModule.unpause:
+        push	r15
+        push	r14
+        push	rbx
+        cmp	qword ptr [rsi + 8], 0
+        je	.L0
+        mov	rbx, rsi
+        mov	r14, rdi
+        add	rdi, 8
+        lea	r15, [rsi + 16]
+        mov	rsi, r15
+        call	.Ltimer.TimerModule.tryRemove
+        test	al, 1
+        je	.L1
+        mov	edx, dword ptr [rbx + 24]
+        mov	rdi, r14
+        mov	rsi, rbx
+        pop	rbx
+        pop	r14
+        pop	r15
+        jmp	.Ltimer.TimerModule.insertTimer
+.L1:
+        mov	rax, r14
+.L2:
+        mov	rax, qword ptr [rax]
+        test	rax, rax
+        je	.L3
+        cmp	rax, r15
+        jne	.L2
+.L3:
+        test	rax, rax
+        je	.L4
+.L0:
+        pop	rbx
+        pop	r14
+        pop	r15
+        ret
+.L4:
+        mov	rdi, r14
+        mov	rsi, rbx
+        pop	rbx
+        pop	r14
+        pop	r15
+        jmp	.Ltimer.TimerModule.isRunning
+

--- a/erd_core/codegen/timer/ReleaseSmall/timer_until_next.s
+++ b/erd_core/codegen/timer/ReleaseSmall/timer_until_next.s
@@ -1,0 +1,19 @@
+; snapshot_comments.zig
+; Speed: Optimal | Size: Optimal
+;
+timer_until_next:
+        mov	rax, qword ptr [rdi]
+        test	rax, rax
+        je	.L0
+        mov	ecx, dword ptr [rdi + 16]
+        mov	edx, dword ptr [rax + 8]
+        sub	edx, ecx
+        xor	eax, eax
+        cmp	edx, -65535
+        cmovb	eax, edx
+        ret
+.L0:
+        push	-1
+        pop	rax
+        ret
+

--- a/erd_core/codegen/timer/ReleaseSmall_x86_64.s
+++ b/erd_core/codegen/timer/ReleaseSmall_x86_64.s
@@ -1,0 +1,921 @@
+app_control_burst:
+        push	r15
+        push	r14
+        push	rbx
+        mov	rbx, rsi
+        mov	r14, rdi
+        push	10
+        pop	rdx
+        call	.Ltimer.TimerModule.startPeriodic
+        mov	rdi, r14
+        mov	rsi, rbx
+        call	.Ltimer.TimerModule.pause
+        mov	rdi, r14
+        mov	rsi, rbx
+        call	.Ltimer.TimerModule.unpause
+        lea	r15, [rbx + 32]
+        push	20
+        pop	rdx
+        mov	rdi, r14
+        mov	rsi, r15
+        call	.Ltimer.TimerModule.startOneShot
+        mov	rdi, r14
+        mov	rsi, r15
+        call	.Ltimer.TimerModule.stop
+        lea	r15, [rbx + 64]
+        push	30
+        pop	rdx
+        mov	rdi, r14
+        mov	rsi, r15
+        call	.Ltimer.TimerModule.startPeriodic
+        add	rbx, 96
+        push	40
+        pop	rdx
+        mov	rdi, r14
+        mov	rsi, rbx
+        call	.Ltimer.TimerModule.startOneShot
+        mov	rdi, r14
+        mov	rsi, r15
+        call	.Ltimer.TimerModule.stop
+        mov	rdi, r14
+        mov	rsi, rbx
+        pop	rbx
+        pop	r14
+        pop	r15
+        jmp	.Ltimer.TimerModule.stop
+
+run_until_idle:
+        push	rbx
+        mov	rbx, rdi
+.LBB11_1:
+        mov	rdi, rbx
+        call	.Ltimer.TimerModule.run
+        test	al, 1
+        jne	.LBB11_1
+        pop	rbx
+        ret
+
+app_query_running:
+        push	r15
+        push	r14
+        push	rbx
+        mov	rbx, rdx
+        mov	r14, rsi
+        mov	r15, rdi
+        call	.Ltimer.TimerModule.isRunning
+        and	al, 1
+        mov	byte ptr [rbx], al
+        lea	rsi, [r14 + 32]
+        mov	rdi, r15
+        call	.Ltimer.TimerModule.isRunning
+        and	al, 1
+        mov	byte ptr [rbx + 1], al
+        lea	rsi, [r14 + 64]
+        mov	rdi, r15
+        call	.Ltimer.TimerModule.isRunning
+        and	al, 1
+        mov	byte ptr [rbx + 2], al
+        lea	rsi, [r14 + 96]
+        mov	rdi, r15
+        call	.Ltimer.TimerModule.isRunning
+        and	al, 1
+        mov	byte ptr [rbx + 3], al
+        lea	rsi, [r14 + 128]
+        mov	rdi, r15
+        call	.Ltimer.TimerModule.isRunning
+        and	al, 1
+        mov	byte ptr [rbx + 4], al
+        lea	rsi, [r14 + 160]
+        mov	rdi, r15
+        call	.Ltimer.TimerModule.isRunning
+        and	al, 1
+        mov	byte ptr [rbx + 5], al
+        lea	rsi, [r14 + 192]
+        mov	rdi, r15
+        call	.Ltimer.TimerModule.isRunning
+        and	al, 1
+        mov	byte ptr [rbx + 6], al
+        add	r14, 224
+        mov	rdi, r15
+        mov	rsi, r14
+        call	.Ltimer.TimerModule.isRunning
+        and	al, 1
+        mov	byte ptr [rbx + 7], al
+        pop	rbx
+        pop	r14
+        pop	r15
+        ret
+
+app_query_remaining:
+        push	r15
+        push	r14
+        push	rbx
+        mov	rbx, rdx
+        mov	r14, rsi
+        mov	r15, rdi
+        call	.Ltimer.TimerModule.remainingTicks
+        mov	dword ptr [rbx], eax
+        lea	rsi, [r14 + 32]
+        mov	rdi, r15
+        call	.Ltimer.TimerModule.remainingTicks
+        mov	dword ptr [rbx + 4], eax
+        lea	rsi, [r14 + 64]
+        mov	rdi, r15
+        call	.Ltimer.TimerModule.remainingTicks
+        mov	dword ptr [rbx + 8], eax
+        lea	rsi, [r14 + 96]
+        mov	rdi, r15
+        call	.Ltimer.TimerModule.remainingTicks
+        mov	dword ptr [rbx + 12], eax
+        lea	rsi, [r14 + 128]
+        mov	rdi, r15
+        call	.Ltimer.TimerModule.remainingTicks
+        mov	dword ptr [rbx + 16], eax
+        lea	rsi, [r14 + 160]
+        mov	rdi, r15
+        call	.Ltimer.TimerModule.remainingTicks
+        mov	dword ptr [rbx + 20], eax
+        lea	rsi, [r14 + 192]
+        mov	rdi, r15
+        call	.Ltimer.TimerModule.remainingTicks
+        mov	dword ptr [rbx + 24], eax
+        add	r14, 224
+        mov	rdi, r15
+        mov	rsi, r14
+        call	.Ltimer.TimerModule.remainingTicks
+        mov	dword ptr [rbx + 28], eax
+        pop	rbx
+        pop	r14
+        pop	r15
+        ret
+
+app_unpause_all:
+        push	r14
+        push	rbx
+        push	rax
+        mov	rbx, rsi
+        mov	r14, rdi
+        call	.Ltimer.TimerModule.unpause
+        lea	rsi, [rbx + 32]
+        mov	rdi, r14
+        call	.Ltimer.TimerModule.unpause
+        lea	rsi, [rbx + 64]
+        mov	rdi, r14
+        call	.Ltimer.TimerModule.unpause
+        lea	rsi, [rbx + 96]
+        mov	rdi, r14
+        call	.Ltimer.TimerModule.unpause
+        lea	rsi, [rbx + 128]
+        mov	rdi, r14
+        call	.Ltimer.TimerModule.unpause
+        lea	rsi, [rbx + 160]
+        mov	rdi, r14
+        call	.Ltimer.TimerModule.unpause
+        lea	rsi, [rbx + 192]
+        mov	rdi, r14
+        call	.Ltimer.TimerModule.unpause
+        add	rbx, 224
+        mov	rdi, r14
+        mov	rsi, rbx
+        add	rsp, 8
+        pop	rbx
+        pop	r14
+        jmp	.Ltimer.TimerModule.unpause
+
+app_pause_all:
+        push	r14
+        push	rbx
+        push	rax
+        mov	rbx, rsi
+        mov	r14, rdi
+        call	.Ltimer.TimerModule.pause
+        lea	rsi, [rbx + 32]
+        mov	rdi, r14
+        call	.Ltimer.TimerModule.pause
+        lea	rsi, [rbx + 64]
+        mov	rdi, r14
+        call	.Ltimer.TimerModule.pause
+        lea	rsi, [rbx + 96]
+        mov	rdi, r14
+        call	.Ltimer.TimerModule.pause
+        lea	rsi, [rbx + 128]
+        mov	rdi, r14
+        call	.Ltimer.TimerModule.pause
+        lea	rsi, [rbx + 160]
+        mov	rdi, r14
+        call	.Ltimer.TimerModule.pause
+        lea	rsi, [rbx + 192]
+        mov	rdi, r14
+        call	.Ltimer.TimerModule.pause
+        add	rbx, 224
+        mov	rdi, r14
+        mov	rsi, rbx
+        add	rsp, 8
+        pop	rbx
+        pop	r14
+        jmp	.Ltimer.TimerModule.pause
+
+app_stop_all:
+        push	r14
+        push	rbx
+        push	rax
+        mov	rbx, rsi
+        mov	r14, rdi
+        call	.Ltimer.TimerModule.stop
+        lea	rsi, [rbx + 32]
+        mov	rdi, r14
+        call	.Ltimer.TimerModule.stop
+        lea	rsi, [rbx + 64]
+        mov	rdi, r14
+        call	.Ltimer.TimerModule.stop
+        lea	rsi, [rbx + 96]
+        mov	rdi, r14
+        call	.Ltimer.TimerModule.stop
+        lea	rsi, [rbx + 128]
+        mov	rdi, r14
+        call	.Ltimer.TimerModule.stop
+        lea	rsi, [rbx + 160]
+        mov	rdi, r14
+        call	.Ltimer.TimerModule.stop
+        lea	rsi, [rbx + 192]
+        mov	rdi, r14
+        call	.Ltimer.TimerModule.stop
+        add	rbx, 224
+        mov	rdi, r14
+        mov	rsi, rbx
+        add	rsp, 8
+        pop	rbx
+        pop	r14
+        jmp	.Ltimer.TimerModule.stop
+
+app_init:
+        push	r14
+        push	rbx
+        push	rax
+        mov	rbx, rsi
+        mov	r14, rdi
+        push	10
+        pop	rdx
+        call	.Ltimer.TimerModule.startPeriodic
+        lea	rsi, [rbx + 32]
+        push	20
+        pop	rdx
+        mov	rdi, r14
+        call	.Ltimer.TimerModule.startPeriodic
+        lea	rsi, [rbx + 64]
+        push	30
+        pop	rdx
+        mov	rdi, r14
+        call	.Ltimer.TimerModule.startPeriodic
+        lea	rsi, [rbx + 96]
+        push	40
+        pop	rdx
+        mov	rdi, r14
+        call	.Ltimer.TimerModule.startOneShot
+        lea	rsi, [rbx + 128]
+        push	50
+        pop	rdx
+        mov	rdi, r14
+        call	.Ltimer.TimerModule.startOneShot
+        lea	rsi, [rbx + 160]
+        push	60
+        pop	rdx
+        mov	rdi, r14
+        call	.Ltimer.TimerModule.startOneShot
+        lea	rsi, [rbx + 192]
+        push	70
+        pop	rdx
+        mov	rdi, r14
+        call	.Ltimer.TimerModule.startPeriodic
+        add	rbx, 224
+        push	80
+        pop	rdx
+        mov	rdi, r14
+        mov	rsi, rbx
+        add	rsp, 8
+        pop	rbx
+        pop	r14
+        jmp	.Ltimer.TimerModule.startOneShot
+
+timer_increment:
+        add	dword ptr [rdi + 16], esi
+        ret
+
+timer_until_next:
+        mov	rax, qword ptr [rdi]
+        test	rax, rax
+        je	.LBB21_1
+        mov	ecx, dword ptr [rdi + 16]
+        mov	edx, dword ptr [rax + 8]
+        sub	edx, ecx
+        xor	eax, eax
+        cmp	edx, -65535
+        cmovb	eax, edx
+        ret
+.LBB21_1:
+        push	-1
+        pop	rax
+        ret
+
+timer_ticks_since:
+        push	rax
+        lea	rax, [rdi + 8]
+        lea	rcx, [rsi + 16]
+.LBB22_1:
+        mov	rax, qword ptr [rax]
+        test	rax, rax
+        je	.LBB22_3
+        cmp	rax, rcx
+        jne	.LBB22_1
+.LBB22_3:
+        test	rax, rax
+        jne	.LBB22_5
+        mov	ecx, dword ptr [rsi + 28]
+        sub	ecx, dword ptr [rsi + 24]
+        mov	eax, dword ptr [rdi + 16]
+        add	eax, ecx
+        pop	rcx
+        ret
+.LBB22_5:
+        push	61
+        pop	rsi
+        mov	edi, offset .L__anon_0
+        call	.Ldebug.defaultPanic
+
+timer_remaining:
+        jmp	.Ltimer.TimerModule.remainingTicks
+
+timer_elapsed:
+        push	rbx
+        cmp	qword ptr [rsi + 8], 0
+        je	.LBB286_1
+        mov	ebx, dword ptr [rsi + 28]
+        call	.Ltimer.TimerModule.remainingTicks
+        sub	ebx, eax
+        jmp	.LBB286_3
+.LBB286_1:
+        xor	ebx, ebx
+.LBB286_3:
+        mov	eax, ebx
+        pop	rbx
+        ret
+
+timer_is_paused:
+        add	rdi, 8
+        add	rsi, 16
+.LBB287_1:
+        mov	rdi, qword ptr [rdi]
+        test	rdi, rdi
+        je	.LBB287_3
+        cmp	rdi, rsi
+        jne	.LBB287_1
+.LBB287_3:
+        test	rdi, rdi
+        setne	al
+        ret
+
+timer_is_active:
+        add	rsi, 16
+.LBB288_1:
+        mov	rdi, qword ptr [rdi]
+        test	rdi, rdi
+        je	.LBB288_3
+        cmp	rdi, rsi
+        jne	.LBB288_1
+.LBB288_3:
+        test	rdi, rdi
+        setne	al
+        ret
+
+timer_is_running:
+        jmp	.Ltimer.TimerModule.isRunning
+
+timer_unpause:
+        jmp	.Ltimer.TimerModule.unpause
+
+timer_pause:
+        jmp	.Ltimer.TimerModule.pause
+
+timer_stop:
+        jmp	.Ltimer.TimerModule.stop
+
+timer_start_oneshot:
+        push	100
+        pop	rdx
+        jmp	.Ltimer.TimerModule.startOneShot
+
+timer_start_periodic:
+        push	100
+        pop	rdx
+        jmp	.Ltimer.TimerModule.startPeriodic
+
+timer_run:
+        jmp	.Ltimer.TimerModule.run
+
+; --- called functions ---
+
+.Ltimer.TimerModule.startPeriodic:
+        cmp	qword ptr [rsi + 8], 0
+        jne	.LBB10_2
+        lea	rax, [rsi + 16]
+        cmp	qword ptr [rdi], rax
+        je	.LBB10_2
+        mov	qword ptr [rsi + 8], offset .Lcodegen_timer.cb0
+        mov	dword ptr [rsi + 28], edx
+        mov	qword ptr [rsi], 1
+        jmp	.Ltimer.TimerModule.insertTimer
+.LBB10_2:
+        push	rbp
+        push	r14
+        push	rbx
+        mov	rbx, rdi
+        mov	r14, rsi
+        mov	ebp, edx
+        call	.Ltimer.TimerModule.removeTimer
+        mov	rdi, rbx
+        mov	rsi, r14
+        mov	edx, ebp
+        pop	rbx
+        pop	r14
+        pop	rbp
+        mov	qword ptr [rsi + 8], offset .Lcodegen_timer.cb0
+        mov	dword ptr [rsi + 28], edx
+        mov	qword ptr [rsi], 1
+        jmp	.Ltimer.TimerModule.insertTimer
+
+.Ltimer.TimerModule.pause:
+        push	r15
+        push	r14
+        push	rbx
+        cmp	qword ptr [rsi + 8], 0
+        je	.LBB8_7
+        mov	rbx, rsi
+        mov	r14, rdi
+        lea	r15, [rsi + 16]
+        mov	rsi, r15
+        call	.Ltimer.TimerModule.tryRemove
+        test	al, 1
+        je	.LBB8_3
+        mov	eax, dword ptr [r14 + 16]
+        mov	ecx, dword ptr [rbx + 24]
+        sub	ecx, eax
+        xor	eax, eax
+        cmp	ecx, -65535
+        cmovb	eax, ecx
+        mov	dword ptr [rbx + 24], eax
+        mov	rax, qword ptr [r14 + 8]
+        mov	qword ptr [rbx + 16], rax
+        mov	qword ptr [r14 + 8], r15
+        pop	rbx
+        pop	r14
+        pop	r15
+        ret
+.LBB8_3:
+        lea	rax, [r14 + 8]
+.LBB8_4:
+        mov	rax, qword ptr [rax]
+        test	rax, rax
+        je	.LBB8_6
+        cmp	rax, r15
+        jne	.LBB8_4
+.LBB8_6:
+        test	rax, rax
+        je	.LBB8_8
+.LBB8_7:
+        pop	rbx
+        pop	r14
+        pop	r15
+        ret
+.LBB8_8:
+        mov	rdi, r14
+        mov	rsi, rbx
+        pop	rbx
+        pop	r14
+        pop	r15
+        jmp	.Ltimer.TimerModule.isRunning
+
+.Ltimer.TimerModule.unpause:
+        push	r15
+        push	r14
+        push	rbx
+        cmp	qword ptr [rsi + 8], 0
+        je	.LBB7_6
+        mov	rbx, rsi
+        mov	r14, rdi
+        add	rdi, 8
+        lea	r15, [rsi + 16]
+        mov	rsi, r15
+        call	.Ltimer.TimerModule.tryRemove
+        test	al, 1
+        je	.LBB7_2
+        mov	edx, dword ptr [rbx + 24]
+        mov	rdi, r14
+        mov	rsi, rbx
+        pop	rbx
+        pop	r14
+        pop	r15
+        jmp	.Ltimer.TimerModule.insertTimer
+.LBB7_2:
+        mov	rax, r14
+.LBB7_3:
+        mov	rax, qword ptr [rax]
+        test	rax, rax
+        je	.LBB7_5
+        cmp	rax, r15
+        jne	.LBB7_3
+.LBB7_5:
+        test	rax, rax
+        je	.LBB7_8
+.LBB7_6:
+        pop	rbx
+        pop	r14
+        pop	r15
+        ret
+.LBB7_8:
+        mov	rdi, r14
+        mov	rsi, rbx
+        pop	rbx
+        pop	r14
+        pop	r15
+        jmp	.Ltimer.TimerModule.isRunning
+
+.Ltimer.TimerModule.startOneShot:
+        cmp	qword ptr [rsi + 8], 0
+        jne	.LBB3_2
+        lea	rax, [rsi + 16]
+        cmp	qword ptr [rdi], rax
+        je	.LBB3_2
+        mov	qword ptr [rsi + 8], offset .Lcodegen_timer.cb0
+        mov	dword ptr [rsi + 28], edx
+        mov	qword ptr [rsi], 0
+        jmp	.Ltimer.TimerModule.insertTimer
+.LBB3_2:
+        push	rbp
+        push	r14
+        push	rbx
+        mov	rbx, rdi
+        mov	r14, rsi
+        mov	ebp, edx
+        call	.Ltimer.TimerModule.removeTimer
+        mov	rdi, rbx
+        mov	rsi, r14
+        mov	edx, ebp
+        pop	rbx
+        pop	r14
+        pop	rbp
+        mov	qword ptr [rsi + 8], offset .Lcodegen_timer.cb0
+        mov	dword ptr [rsi + 28], edx
+        mov	qword ptr [rsi], 0
+        jmp	.Ltimer.TimerModule.insertTimer
+
+.Ltimer.TimerModule.stop:
+        and	byte ptr [rsi], -2
+        cmp	qword ptr [rsi + 8], 0
+        jne	.Ltimer.TimerModule.removeTimer
+        ret
+
+.Ltimer.TimerModule.run:
+        push	rbp
+        push	r15
+        push	r14
+        push	r12
+        push	rbx
+        mov	ecx, dword ptr [rdi + 16]
+        mov	rax, qword ptr [rdi]
+        test	rax, rax
+        je	.LBB12_1
+        sub	ecx, dword ptr [rax + 8]
+        cmp	ecx, 65535
+        ja	.LBB12_1
+        mov	rbx, rdi
+        lea	r14, [rax - 16]
+        mov	r12, qword ptr [r14]
+        mov	rdi, r12
+        test	r12b, 1
+        jne	.LBB12_5
+        mov	rcx, qword ptr [rax]
+        mov	qword ptr [rbx], rcx
+        mov	rdi, qword ptr [rax - 16]
+.LBB12_5:
+        mov	r15, qword ptr [r14 + 8]
+        mov	qword ptr [r14 + 8], 0
+        and	rdi, -2
+        mov	rsi, rbx
+        mov	rdx, r14
+        call	r15
+        mov	bpl, 1
+        cmp	qword ptr [r14 + 8], 0
+        jne	.LBB12_2
+        test	r12b, 1
+        je	.LBB12_7
+        mov	rax, qword ptr [rbx]
+        test	rax, rax
+        je	.LBB12_7
+        mov	rax, qword ptr [rax]
+        mov	qword ptr [rbx], rax
+.LBB12_7:
+        test	byte ptr [r14], 1
+        je	.LBB12_2
+        mov	edx, dword ptr [r14 + 28]
+        mov	rdi, rbx
+        mov	rsi, r14
+        call	.Ltimer.TimerModule.insertTimer
+        mov	qword ptr [r14 + 8], r15
+        jmp	.LBB12_2
+.LBB12_1:
+        xor	ebp, ebp
+.LBB12_2:
+        mov	eax, ebp
+        pop	rbx
+        pop	r12
+        pop	r14
+        pop	r15
+        pop	rbp
+        ret
+
+.Ltimer.TimerModule.isRunning:
+        add	rsi, 16
+        mov	rcx, rdi
+.LBB9_1:
+        mov	rcx, qword ptr [rcx]
+        test	rcx, rcx
+        je	.LBB9_3
+        cmp	rcx, rsi
+        jne	.LBB9_1
+.LBB9_3:
+        mov	al, 1
+        test	rcx, rcx
+        jne	.LBB9_7
+        add	rdi, 8
+.LBB9_5:
+        mov	rdi, qword ptr [rdi]
+        test	rdi, rdi
+        setne	al
+        je	.LBB9_7
+        cmp	rdi, rsi
+        jne	.LBB9_5
+.LBB9_7:
+        ret
+
+.Ltimer.TimerModule.remainingTicks:
+        cmp	qword ptr [rsi + 8], 0
+        je	.LBB15_1
+        lea	rax, [rdi + 8]
+        lea	rcx, [rsi + 16]
+.LBB15_4:
+        mov	rax, qword ptr [rax]
+        test	rax, rax
+        je	.LBB15_6
+        cmp	rax, rcx
+        jne	.LBB15_4
+.LBB15_6:
+        test	rax, rax
+        je	.LBB15_8
+        mov	eax, dword ptr [rsi + 24]
+        ret
+.LBB15_1:
+        xor	eax, eax
+        ret
+.LBB15_8:
+        mov	eax, dword ptr [rdi + 16]
+        mov	ecx, dword ptr [rsi + 24]
+        sub	ecx, eax
+        xor	eax, eax
+        cmp	ecx, -65535
+        cmovb	eax, ecx
+        ret
+
+.Ldebug.defaultPanic:
+        push	rbp
+        push	r15
+        push	r14
+        push	r12
+        push	rbx
+        sub	rsp, 128
+        mov	rax, qword ptr fs:[.Ldebug.panic_stage@TPOFF]
+        test	rax, rax
+        jne	.LBB23_16
+        mov	rbx, rsi
+        mov	r15, rdi
+        mov	qword ptr fs:[.Ldebug.panic_stage@TPOFF], 1
+        lock		inc	byte ptr [rip + .Ldebug.panicking]
+        lea	r12, [rsp + 96]
+        mov	rdi, r12
+        call	.Ldebug.lockStderr
+        mov	r14, qword ptr [r12]
+        mov	al, byte ptr [r12 + 8]
+        add	r14, 24
+        mov	qword ptr [rsp + 8], r14
+        and	al, 3
+        mov	byte ptr [rsp + 16], al
+        call	.LThread.getCurrentId
+        mov	ebp, eax
+        push	7
+        pop	rdx
+        mov	esi, offset .L__anon_1
+        mov	rdi, r14
+        call	.LIo.Writer.writeAll
+        test	ax, ax
+        jne	.LBB23_13
+        mov	ecx, ebp
+        push	63
+        pop	rdi
+        push	100
+        pop	rsi
+        mov	r8b, 10
+.LBB23_3:
+        cmp	rcx, 100
+        jb	.LBB23_5
+        mov	rax, rcx
+        xor	edx, edx
+        div	rsi
+        movzx	edx, dl
+        mov	rcx, rax
+        mov	eax, edx
+        div	r8b
+        movzx	edx, ah
+        or	dl, 48
+        movzx	edx, dl
+        shl	edx, 8
+        movzx	eax, al
+        add	eax, edx
+        add	eax, 48
+        mov	word ptr [rsp + rdi + 31], ax
+        add	rdi, -2
+        jmp	.LBB23_3
+.LBB23_5:
+        cmp	rcx, 9
+        ja	.LBB23_7
+        or	cl, 48
+        mov	byte ptr [rsp + rdi + 32], cl
+        inc	rdi
+        jmp	.LBB23_8
+.LBB23_7:
+        movzx	eax, cl
+        mov	cl, 10
+        div	cl
+        movzx	ecx, ah
+        or	cl, 48
+        movzx	ecx, cl
+        shl	ecx, 8
+        movzx	eax, al
+        add	eax, ecx
+        add	eax, 48
+        mov	word ptr [rsp + rdi + 31], ax
+.LBB23_8:
+        lea	rsi, [rsp + rdi]
+        add	rsi, 31
+        push	65
+        pop	rdx
+        sub	rdx, rdi
+        mov	rdi, r14
+        call	.LIo.Writer.writeAll
+        test	ax, ax
+        jne	.LBB23_13
+        push	8
+        pop	rdx
+        mov	esi, offset .L__anon_2
+        mov	rdi, r14
+        call	.LIo.Writer.writeAll
+        test	ax, ax
+        jne	.LBB23_13
+        mov	rdi, r14
+        mov	rsi, r15
+        mov	rdx, rbx
+        call	.LIo.Writer.writeAll
+        test	ax, ax
+        jne	.LBB23_13
+        push	1
+        pop	rdx
+        mov	esi, offset .L__anon_3
+        mov	rdi, r14
+        call	.LIo.Writer.writeAll
+        test	ax, ax
+        jne	.LBB23_13
+        lea	rdi, [rsp + 8]
+        call	.Ldebug.writeCurrentStackTrace
+.LBB23_13:
+        mov	edi, offset .LIo.Threaded.global_single_threaded_instance
+        call	.LIo.Threaded.unlockStderr
+        lock		dec	byte ptr [rip + .Ldebug.panicking]
+        je	.LBB23_18
+        lea	rbx, [rsp + 31]
+        and	dword ptr [rbx], 0
+.LBB23_15:
+        mov	edx, offset .L__anon_4
+        mov	rdi, rbx
+        xor	esi, esi
+        call	.LIo.Threaded.Thread.futexWaitUncancelable
+        jmp	.LBB23_15
+.LBB23_16:
+        cmp	rax, 1
+        jne	.LBB23_18
+        mov	qword ptr fs:[.Ldebug.panic_stage@TPOFF], 2
+        lea	rbx, [rsp + 112]
+        mov	rdi, rbx
+        call	.Ldebug.lockStderr
+        mov	rdi, qword ptr [rbx]
+        add	rdi, 24
+        push	32
+        pop	rdx
+        mov	esi, offset .L__anon_5
+        call	.LIo.Writer.writeAll
+.LBB23_18:
+        call	.Lprocess.abort
+        .text
+
+.Ltimer.TimerModule.insertTimer:
+        mov	eax, dword ptr [rdi + 16]
+        lea	ecx, [rax + rdx]
+        mov	dword ptr [rsi + 24], ecx
+        mov	rcx, qword ptr [rdi]
+        test	rcx, rcx
+        je	.LBB5_1
+        mov	r8d, dword ptr [rcx + 8]
+        sub	r8d, eax
+        cmp	r8d, -65535
+        setb	r9b
+        cmp	r8d, edx
+        seta	r8b
+        test	r9b, r8b
+        je	.LBB5_6
+        mov	r8, rcx
+.LBB5_2:
+        mov	qword ptr [rsi + 16], r8
+        add	rsi, 16
+        mov	qword ptr [rdi], rsi
+        ret
+.LBB5_6:
+        mov	r8, qword ptr [rcx]
+        test	r8, r8
+        je	.LBB5_7
+        mov	edi, dword ptr [r8 + 8]
+        sub	edi, eax
+        cmp	edi, -65535
+        setb	r9b
+        cmp	edi, edx
+        seta	r10b
+        mov	rdi, rcx
+        mov	rcx, r8
+        test	r9b, r10b
+        je	.LBB5_6
+        jmp	.LBB5_2
+.LBB5_1:
+        xor	r8d, r8d
+        mov	qword ptr [rsi + 16], r8
+        add	rsi, 16
+        mov	qword ptr [rdi], rsi
+        ret
+.LBB5_7:
+        xor	r8d, r8d
+        mov	rdi, rcx
+        mov	qword ptr [rsi + 16], r8
+        add	rsi, 16
+        mov	qword ptr [rdi], rsi
+        ret
+
+.Ltimer.TimerModule.removeTimer:
+        push	r15
+        push	r14
+        push	rbx
+        mov	rbx, rsi
+        mov	r15, rdi
+        lea	r14, [rsi + 16]
+        mov	rsi, r14
+        call	.Ltimer.TimerModule.tryRemove
+        test	al, 1
+        jne	.LBB4_2
+        add	r15, 8
+        mov	rdi, r15
+        mov	rsi, r14
+        call	.Ltimer.TimerModule.tryRemove
+.LBB4_2:
+        mov	qword ptr [rbx + 8], 0
+        pop	rbx
+        pop	r14
+        pop	r15
+        ret
+
+.Ltimer.TimerModule.tryRemove:
+        mov	rax, qword ptr [rdi]
+        test	rax, rax
+        je	.LBB6_1
+        cmp	rax, rsi
+        je	.LBB6_6
+.LBB6_4:
+        mov	rcx, qword ptr [rax]
+        test	rcx, rcx
+        je	.LBB6_1
+        mov	rdi, rax
+        mov	rax, rcx
+        cmp	rcx, rsi
+        jne	.LBB6_4
+.LBB6_6:
+        mov	rax, qword ptr [rsi]
+        mov	qword ptr [rdi], rax
+        mov	al, 1
+        ret
+.LBB6_1:
+        xor	eax, eax
+        ret
+

--- a/erd_core/codegen/timer/ReleaseSmall_x86_64.sizes
+++ b/erd_core/codegen/timer/ReleaseSmall_x86_64.sizes
@@ -1,0 +1,23 @@
+# size (bytes)	function
+4	timer_increment
+5	timer_is_running
+5	timer_pause
+5	timer_remaining
+5	timer_run
+5	timer_stop
+5	timer_unpause
+13	timer_start_oneshot
+13	timer_start_periodic
+18	run_until_idle
+24	timer_is_active
+26	timer_elapsed
+28	timer_is_paused
+32	timer_until_next
+53	timer_ticks_since
+121	app_pause_all
+121	app_stop_all
+121	app_unpause_all
+147	app_query_remaining
+150	app_control_burst
+163	app_query_running
+185	app_init

--- a/erd_core/src/codegen_timer.zig
+++ b/erd_core/src/codegen_timer.zig
@@ -1,0 +1,148 @@
+//! Timer module codegen inspection harness
+//!
+//! Exercises `erd_core.timer.TimerModule` with many call sites of every public
+//! API, plus realistic "lots of timers" aggregate functions (app_init / query
+//! / control loops). Build as an object and inspect the generated assembly to
+//! decide which internal helpers should be `noinline`: TimerModule is a single
+//! concrete type (no generic monomorphization), so an inlined helper is
+//! duplicated once per call site. Large helpers reached from several sites
+//! (insertTimer, removeTimer, tryRemove, the list scans) cost ROM each time
+//! they inline; forcing them out-of-line keeps one shared copy.
+//!
+//! Snapshotted via `zig build codegen-update`; verified via `codegen-check`.
+
+const std = @import("std");
+const erd_core = @import("erd_core");
+const timer = erd_core.timer;
+const TimerModule = timer.TimerModule;
+const Timer = timer.Timer;
+const Ticks = timer.Ticks;
+
+fn cb0(_: ?*anyopaque, _: *TimerModule, _: *Timer) void {}
+fn cb1(_: ?*anyopaque, _: *TimerModule, _: *Timer) void {}
+fn cb2(_: ?*anyopaque, _: *TimerModule, _: *Timer) void {}
+
+// ===========================================================================
+// Single-call wrappers: one clean snapshot per public API. Anything these
+// reach out-of-line shows up in the "called functions" section.
+// ===========================================================================
+
+export fn timer_run(tm: *TimerModule) bool {
+    return tm.run();
+}
+
+export fn timer_start_periodic(tm: *TimerModule, t: *Timer) void {
+    tm.startPeriodic(t, 100, null, cb0);
+}
+
+export fn timer_start_oneshot(tm: *TimerModule, t: *Timer) void {
+    tm.startOneShot(t, 100, null, cb0);
+}
+
+export fn timer_stop(tm: *TimerModule, t: *Timer) void {
+    tm.stop(t);
+}
+
+export fn timer_pause(tm: *TimerModule, t: *Timer) void {
+    tm.pause(t);
+}
+
+export fn timer_unpause(tm: *TimerModule, t: *Timer) void {
+    tm.unpause(t);
+}
+
+export fn timer_is_running(tm: *TimerModule, t: *Timer) bool {
+    return tm.isRunning(t);
+}
+
+export fn timer_is_active(tm: *TimerModule, t: *Timer) bool {
+    return tm.isActive(t);
+}
+
+export fn timer_is_paused(tm: *TimerModule, t: *Timer) bool {
+    return tm.isPaused(t);
+}
+
+export fn timer_elapsed(tm: *TimerModule, t: *Timer) Ticks {
+    return tm.elapsedTicks(t);
+}
+
+export fn timer_remaining(tm: *TimerModule, t: *Timer) Ticks {
+    return tm.remainingTicks(t);
+}
+
+export fn timer_ticks_since(tm: *TimerModule, t: *Timer) Ticks {
+    return tm.ticksSinceLastStarted(t);
+}
+
+export fn timer_until_next(tm: *TimerModule) Ticks {
+    return tm.ticksUntilNextReady();
+}
+
+export fn timer_increment(tm: *TimerModule, ticks: Ticks) void {
+    tm.incrementCurrentTime(ticks);
+}
+
+// ===========================================================================
+// Aggregate "lots of timers" call sites: this is where helpers either inline
+// repeatedly (bloat) or share one out-of-line body.
+// ===========================================================================
+
+/// Start eight timers: eight startPeriodic/startOneShot call sites, each of
+/// which reaches insertTimer and removeTimer.
+export fn app_init(tm: *TimerModule, t: *[8]Timer) void {
+    tm.startPeriodic(&t[0], 10, null, cb0);
+    tm.startPeriodic(&t[1], 20, null, cb1);
+    tm.startPeriodic(&t[2], 30, null, cb2);
+    tm.startOneShot(&t[3], 40, null, cb0);
+    tm.startOneShot(&t[4], 50, null, cb1);
+    tm.startOneShot(&t[5], 60, null, cb2);
+    tm.startPeriodic(&t[6], 70, null, cb0);
+    tm.startOneShot(&t[7], 80, null, cb1);
+}
+
+/// Stop eight timers: eight stop call sites, each reaching removeTimer.
+export fn app_stop_all(tm: *TimerModule, t: *[8]Timer) void {
+    inline for (0..8) |i| tm.stop(&t[i]);
+}
+
+/// Pause eight timers: eight pause call sites, each reaching tryRemove.
+export fn app_pause_all(tm: *TimerModule, t: *[8]Timer) void {
+    inline for (0..8) |i| tm.pause(&t[i]);
+}
+
+/// Unpause eight timers: eight unpause call sites, each reaching tryRemove and
+/// insertTimer.
+export fn app_unpause_all(tm: *TimerModule, t: *[8]Timer) void {
+    inline for (0..8) |i| tm.unpause(&t[i]);
+}
+
+/// Query remaining ticks for eight timers: eight remainingTicks call sites,
+/// each reaching isPaused and remainingTicksActiveTimer.
+export fn app_query_remaining(tm: *TimerModule, t: *[8]Timer, out: *[8]Ticks) void {
+    inline for (0..8) |i| out[i] = tm.remainingTicks(&t[i]);
+}
+
+/// Query running state for eight timers: eight isRunning call sites, each
+/// reaching the isActive and isPaused list scans.
+export fn app_query_running(tm: *TimerModule, t: *[8]Timer, out: *[8]bool) void {
+    inline for (0..8) |i| out[i] = tm.isRunning(&t[i]);
+}
+
+/// Drain the module: the run() loop a main loop would use.
+export fn run_until_idle(tm: *TimerModule) void {
+    while (tm.run()) {}
+}
+
+/// Mixed control burst: restart, pause, unpause, stop across several timers.
+export fn app_control_burst(tm: *TimerModule, t: *[4]Timer) void {
+    tm.startPeriodic(&t[0], 10, null, cb0);
+    tm.pause(&t[0]);
+    tm.unpause(&t[0]);
+    tm.startOneShot(&t[1], 20, null, cb1);
+    tm.stop(&t[1]);
+    tm.startPeriodic(&t[2], 30, null, cb2);
+    tm.startOneShot(&t[3], 40, null, cb0);
+    tm.stop(&t[2]);
+    tm.stop(&t[3]);
+}

--- a/erd_core/src/snapshot_comments.zig
+++ b/erd_core/src/snapshot_comments.zig
@@ -160,6 +160,32 @@ pub const ratings = [_]Rating{
     .{ .func = "write_u16_with_subs",                       .mode = .release_fast,  .speed = .near_optimal, .size = .{ .until = 2 }           },
     .{ .func = "write_u16_with_subs",                       .mode = .release_small, .speed = .near_optimal,},
     .{ .func = "write_u32_no_subs",                                                                         .size = .{ .until = 4 }           },
+    // ---- Timer module harness (codegen_timer.zig) ----
+    // The app_* aggregates call the now-noinline TimerModule methods once each
+    // instead of inlining a copy per call site; near_optimal speed (extra
+    // calls) buys one shared body per method (size optimal in every mode).
+    .{ .func = "app_control_burst",                                                 .speed = .near_optimal,                                   },
+    .{ .func = "app_init",                                                          .speed = .near_optimal,                                   },
+    .{ .func = "app_pause_all",                                                     .speed = .near_optimal,                                   },
+    .{ .func = "app_query_remaining",                                               .speed = .near_optimal,                                   },
+    .{ .func = "app_query_running",                                                 .speed = .near_optimal,                                   },
+    .{ .func = "app_stop_all",                                                      .speed = .near_optimal,                                   },
+    .{ .func = "app_unpause_all",                                                   .speed = .near_optimal,                                   },
+    .{ .func = "run_until_idle",                                                                                                              },
+    .{ .func = "timer_elapsed",                                                                                                               },
+    .{ .func = "timer_increment",                                                                                                             },
+    .{ .func = "timer_is_active",                                                                                                             },
+    .{ .func = "timer_is_paused",                                                                                                             },
+    .{ .func = "timer_is_running",                                                                                                            },
+    .{ .func = "timer_pause",                                                                                                                 },
+    .{ .func = "timer_remaining",                                                                                                             },
+    .{ .func = "timer_run",                                                                                                                   },
+    .{ .func = "timer_start_oneshot",                                                                                                         },
+    .{ .func = "timer_start_periodic",                                                                                                        },
+    .{ .func = "timer_stop",                                                                                                                  },
+    .{ .func = "timer_ticks_since",                                                                                                           },
+    .{ .func = "timer_unpause",                                                                                                               },
+    .{ .func = "timer_until_next",                                                                                                            },
 };
 // zig fmt: on
 
@@ -298,5 +324,29 @@ pub const comments = [_]Comment{
     .{ .func = "read_converted_both",                                           .text = "PER-ERD: two converted reads, each unique compute function." },
     .{ .func = "read_all_component_types",                                      .text = "PER-ERD: RAM + indirect (const-folded) + converted inlined." },
     .{ .func = "read_ram_then_converted",                                       .text = "PER-ERD: RAM load + converted compute inlined."     },
+
+    // ==================================================================
+    // Timer module noinline analysis
+    //
+    // TimerModule is one concrete type, so before the noinline pass every
+    // inlined method was duplicated per call site. ReleaseFast paid for a
+    // full copy of insertTimer/removeTimer/tryRemove at every start/stop/
+    // pause site, while ReleaseSmall already shared them. Marking the 11
+    // methods that ReleaseSmall left out-of-line (called from 2+ sites)
+    // `noinline` consolidates them to one copy in BOTH modes:
+    //
+    //   app_init         1812 -> 201 bytes (RF)
+    //   app_unpause_all  2225 -> 121 bytes (RF)
+    //   app_pause_all    1444 -> 121 bytes (RF)
+    //   app_control_burst 1672 -> 158 bytes (RF)
+    //
+    // The leaf helpers (safelyGetCurrentTime, remainingTicksActiveTimer,
+    // incrementCurrentTime, isActive/isPaused) stay inlinable -- they never
+    // spilled out-of-line and a call would cost more than the body.
+    // ==================================================================
+    .{ .func = "app_init",          .text = "8 starts -> 8 calls to shared startPeriodic/startOneShot (was 1812 bytes of inlined copies in RF)." },
+    .{ .func = "app_unpause_all",   .text = "8 unpause calls to shared bodies (was 2225 bytes of inlined tryRemove/insertTimer in RF)." },
+    .{ .func = "timer_start_periodic", .text = "Tail call into shared, noinline startPeriodic (was 196 bytes inlined in RF)." },
+    .{ .func = "run_until_idle",    .text = "Main-loop pattern: calls the shared, noinline run() until it returns false." },
 };
 // zig fmt: on

--- a/erd_core/src/timer.zig
+++ b/erd_core/src/timer.zig
@@ -98,9 +98,21 @@ pub const TimerModule = struct {
     active_timers: std.SinglyLinkedList = .{},
     paused_timers: std.SinglyLinkedList = .{},
 
+    // noinline policy: TimerModule is a single concrete type (no generic
+    // monomorphization), so an inlined method is duplicated once per call site.
+    // Codegen snapshots (codegen_timer.zig) show that under ReleaseSmall LLVM
+    // already leaves the functions below out-of-line and calls them from 2+
+    // sites, while under ReleaseFast it inlines them everywhere -- an app that
+    // drives many timers paid for a full copy of insertTimer/removeTimer/etc.
+    // at every start/stop/pause site (e.g. app_init was 1812 bytes). Forcing
+    // these `noinline` guarantees one shared copy in every optimization mode.
+    // The trivial leaf helpers (safelyGetCurrentTime, remainingTicksActiveTimer,
+    // incrementCurrentTime, the isActive/isPaused scans, the Timer bit-ops) are
+    // left inlinable: they never spilled out-of-line and are smaller than a call.
+
     /// Services the callbacks for a single expired timer
     /// Returns `true` if a `Timer` expired, otherwise returns `false`
-    pub fn run(self: *TimerModule) bool {
+    pub noinline fn run(self: *TimerModule) bool {
         const time_at_start_of_rtc = self.safelyGetCurrentTime();
 
         if (self.active_timers.first) |next_expiring| {
@@ -146,7 +158,7 @@ pub const TimerModule = struct {
     /// NOTE: `ctx` must be align(2) to allow an `bool` due to optimization reasons
     /// If you get an error, declare your variable as `align(2)` or use a container
     /// struct with larger alignment
-    pub fn startOneShot(self: *TimerModule, timer: *Timer, duration: Ticks, ctx: ?*align(2) anyopaque, callback: Timer.TimerCallback) void {
+    pub noinline fn startOneShot(self: *TimerModule, timer: *Timer, duration: Ticks, ctx: ?*align(2) anyopaque, callback: Timer.TimerCallback) void {
         sometimes.assert(&@src(), self.active_timers.first == &timer.node); // Re-starting a periodic as a one-shot
         if (timer.callback != null or self.active_timers.first == &timer.node) {
             self.removeTimer(timer);
@@ -165,7 +177,7 @@ pub const TimerModule = struct {
     /// NOTE: `ctx` must be align(2) to allow an `bool` due to optimization reasons
     /// If you get an error, declare your variable as `align(2)` or use a container
     /// struct with larger alignment
-    pub fn startPeriodic(self: *TimerModule, timer: *Timer, period: Ticks, ctx: ?*align(2) anyopaque, callback: Timer.TimerCallback) void {
+    pub noinline fn startPeriodic(self: *TimerModule, timer: *Timer, period: Ticks, ctx: ?*align(2) anyopaque, callback: Timer.TimerCallback) void {
         sometimes.assert(&@src(), self.active_timers.first == &timer.node); // Re-starting a periodic as a periodic
         if (timer.callback != null or self.active_timers.first == &timer.node) {
             self.removeTimer(timer);
@@ -182,7 +194,7 @@ pub const TimerModule = struct {
     }
 
     /// Stops an active or paused timer
-    pub fn stop(self: *TimerModule, timer: *Timer) void {
+    pub noinline fn stop(self: *TimerModule, timer: *Timer) void {
         timer.setIsPeriodic(false);
         if (timer.callback != null) {
             self.removeTimer(timer);
@@ -192,7 +204,7 @@ pub const TimerModule = struct {
     /// Pauses a timer
     /// If the timer is already paused or is not started then this does nothing
     /// NOTE: It is invalid to pause a timer from its own callback.
-    pub fn pause(self: *TimerModule, timer: *Timer) void {
+    pub noinline fn pause(self: *TimerModule, timer: *Timer) void {
         if (timer.callback == null) {
             return;
         }
@@ -209,7 +221,7 @@ pub const TimerModule = struct {
 
     /// Unpauses a timer
     /// If the timer is already active or is not present then this does nothing
-    pub fn unpause(self: *TimerModule, timer: *Timer) void {
+    pub noinline fn unpause(self: *TimerModule, timer: *Timer) void {
         if (timer.callback == null) {
             return;
         }
@@ -224,7 +236,7 @@ pub const TimerModule = struct {
     }
 
     /// Returns true if a timer is active or paused
-    pub fn isRunning(self: *TimerModule, timer: *Timer) bool {
+    pub noinline fn isRunning(self: *TimerModule, timer: *Timer) bool {
         return isActive(self, timer) or isPaused(self, timer);
     }
 
@@ -284,7 +296,7 @@ pub const TimerModule = struct {
     }
 
     /// Returns the remaining ticks on a timer, returns 0 if the timer is not running
-    pub fn remainingTicks(timer_module: *TimerModule, timer: *Timer) Ticks {
+    pub noinline fn remainingTicks(timer_module: *TimerModule, timer: *Timer) Ticks {
         if (timer.callback == null) {
             return 0;
         } else {
@@ -309,7 +321,7 @@ pub const TimerModule = struct {
 
     /// Inserts a timer after all other timers with equal or less remaining ticks
     /// Inserting after timers with equal remaining ticks improves fairness
-    fn insertTimer(self: *TimerModule, timer: *Timer, ticks: Ticks) void {
+    noinline fn insertTimer(self: *TimerModule, timer: *Timer, ticks: Ticks) void {
         std.debug.assert(ticks <= Timer.max_ticks);
 
         const current_time = self.safelyGetCurrentTime();
@@ -341,7 +353,7 @@ pub const TimerModule = struct {
     }
 
     /// std.SinglyLinkedList remove, but returns a bool and is valid to call when the node isn't in the list
-    fn tryRemove(list: *std.SinglyLinkedList, node: *std.SinglyLinkedList.Node) bool {
+    noinline fn tryRemove(list: *std.SinglyLinkedList, node: *std.SinglyLinkedList.Node) bool {
         if (list.first == null) {
             return false;
         } else if (list.first == node) {
@@ -361,7 +373,7 @@ pub const TimerModule = struct {
     }
 
     /// If this is called, a timer MUST be in either the active list or paused list
-    fn removeTimer(self: *TimerModule, timer: *Timer) void {
+    noinline fn removeTimer(self: *TimerModule, timer: *Timer) void {
         std.debug.assert(timer.callback != null or self.active_timers.first == &timer.node);
         const removed_from_active = tryRemove(&self.active_timers, &timer.node);
         if (!removed_from_active) {


### PR DESCRIPTION
## Summary

`TimerModule` is a single concrete type, so an inlined method is duplicated once per call site. A new call-heavy codegen harness (`codegen_timer.zig`) makes this measurable: under ReleaseSmall LLVM already leaves 11 methods out-of-line and calls them from 2+ sites, while under ReleaseFast it inlines them everywhere — an app driving several timers paid for a full copy of `insertTimer`/`removeTimer`/`tryRemove` at every start/stop/pause site.

Applying the **"noinline when 2+ calls fail to inline"** heuristic to exactly those 11 methods (`run`, `startOneShot`, `startPeriodic`, `stop`, `pause`, `unpause`, `isRunning`, `remainingTicks`, `insertTimer`, `tryRemove`, `removeTimer`) consolidates them to one shared copy in **every** optimization mode.

## ReleaseFast size impact (exported wrapper bytes)

| function | before | after |
|---|---:|---:|
| `app_init` | 1812 | 201 |
| `app_unpause_all` | 2225 | 121 |
| `app_pause_all` | 1444 | 121 |
| `app_control_burst` | 1672 | 158 |
| `setup_timer_callback` (existing harness) | 222 | 14 |

ReleaseSmall is unchanged (it already shared). The trivial leaf helpers (`safelyGetCurrentTime`, `remainingTicksActiveTimer`, `incrementCurrentTime`, the `isActive`/`isPaused` scans, the `Timer` bit-ops) stay inlinable — they never spilled out-of-line and a call would cost more than the body.

## Changes
- `erd_core/src/codegen_timer.zig` — new timer codegen harness (many call sites of every API + realistic "lots of timers" aggregates)
- `erd_core/src/timer.zig` — `noinline` on the 11 methods, with a policy comment
- `erd_core/build_codegen.zig`, `build.zig` — register the harness (snapshots in `erd_core/codegen/timer/`), lint exclude
- `erd_core/src/snapshot_comments.zig` — ratings + analysis notes
- `erd_core/codegen/**` — regenerated snapshots

## Testing
`zig build test`, `zig build test_coverage`, `zig build lint`, `zig build codegen-check` all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)